### PR TITLE
Setup Safe contracts for MoonBase

### DIFF
--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -147,6 +147,14 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ('0xfb1bffC9d739B8D520DaF37dF666da4C687191EA', 4_949_507, '1.3.0+L2'),
         ('0x69f4D1788e39c87893C980c06EdF4b7f686e2938', 4_949_512, '1.3.0'),
     ],
+    EthereumNetwork.MOON_MOONRIVER: [
+        ('0x3E5c63644E683549055b9Be8653de26E0B4CD36E', 707_738, '1.3.0+L2'),
+        ('0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552', 707_741, '1.3.0'),
+    ],
+    EthereumNetwork.MOON_MOONBASE: [
+        ('0x3E5c63644E683549055b9Be8653de26E0B4CD36E', 939_244, '1.3.0+L2'),
+        ('0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552', 939_246, '1.3.0'),
+    ],
 }
 
 PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
@@ -206,6 +214,12 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     ],
     EthereumNetwork.AVALANCHE: [
         ('0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC', 4_949_487),  # v1.3.0
+    ],
+    EthereumNetwork.MOON_MOONRIVER: [
+        ('0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2', 707_721),  # v1.3.0
+    ],
+    EthereumNetwork.MOON_MOONBASE: [
+        ('0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2', 939_239),  # v1.3.0
     ],
 }
 


### PR DESCRIPTION
- Setup Safe contracts v1.3.0 for Moonbase
- Deployment block number is approximate as moonbase block explorer does not provide information
- Related to https://github.com/gnosis/safe-deployments/pull/21/files
