### PR TITLE
Use contracts v1.3.0 for tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
     image: redis:alpine
     ports:
       - "6379:6379"
+    command:
+      - --save ""
+      - --appendonly no
 
   db:
     image: postgres:10-alpine

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ docutils==0.17.1
 drf-yasg[validation]==1.20.0
 ethereum==2.3.2
 firebase-admin==5.0.3
-gnosis-py[django]==3.4.6
+gnosis-py[django]==3.5.0
 gunicorn[gevent]==20.1.0
 hexbytes==0.2.2
 packaging>=21.0

--- a/safe_transaction_service/contracts/tx_decoder.py
+++ b/safe_transaction_service/contracts/tx_decoder.py
@@ -15,10 +15,10 @@ from web3.types import ABI
 
 from gnosis.eth.contracts import (get_erc20_contract, get_erc721_contract,
                                   get_kyber_network_proxy_contract,
-                                  get_multi_send_contract)
-from gnosis.eth.contracts import get_safe_contract as get_safe_V1_2_0_contract
-from gnosis.eth.contracts import (get_safe_V0_0_1_contract,
+                                  get_multi_send_contract,
+                                  get_safe_V0_0_1_contract,
                                   get_safe_V1_0_0_contract,
+                                  get_safe_V1_1_1_contract,
                                   get_safe_V1_3_0_contract,
                                   get_uniswap_exchange_contract)
 from gnosis.safe.multi_send import MultiSend
@@ -222,7 +222,7 @@ class SafeTxDecoder:
         safe_abis = [
             get_safe_V0_0_1_contract(self.dummy_w3).abi,
             get_safe_V1_0_0_contract(self.dummy_w3).abi,
-            get_safe_V1_2_0_contract(self.dummy_w3).abi,
+            get_safe_V1_1_1_contract(self.dummy_w3).abi,
             get_safe_V1_3_0_contract(self.dummy_w3).abi,
         ]
 

--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -12,7 +12,7 @@ from web3.types import EventData
 
 from gnosis.eth import EthereumClient
 from gnosis.eth.constants import NULL_ADDRESS
-from gnosis.eth.contracts import get_safe_contract as get_safe_V1_2_0_contract
+from gnosis.eth.contracts import get_safe_V1_1_1_contract
 
 from ..models import (EthereumTxCallType, InternalTx, InternalTxDecoded,
                       InternalTxType, SafeMasterCopy)
@@ -115,7 +115,7 @@ class SafeEventsIndexer(EventsIndexer):
         """
         l2_contract = self.ethereum_client.w3.eth.contract(abi=gnosis_safe_l2_v1_3_0_abi)
         proxy_factory_contract = self.ethereum_client.w3.eth.contract(abi=proxy_factory_v1_3_0_abi)
-        old_contract = get_safe_V1_2_0_contract(self.ethereum_client.w3)
+        old_contract = get_safe_V1_1_1_contract(self.ethereum_client.w3)
         return [
             l2_contract.events.SafeMultiSigTransaction(),
             l2_contract.events.SafeModuleTransaction(),

--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -108,21 +108,21 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         payment = 0
         payment_receiver = NULL_ADDRESS
         initializer = HexBytes(
-            self.safe_contract_V1_3_0.functions.setup(
+            self.safe_contract.functions.setup(
                 owners, threshold, to, data, fallback_handler, payment_token,
                 payment, payment_receiver
             ).buildTransaction({'gas': 1, 'gasPrice': 1})['data']
         )
         initial_block_number = self.ethereum_client.current_block_number
         safe_l2_master_copy = SafeMasterCopyFactory(
-            address=self.safe_contract_V1_3_0.address,
+            address=self.safe_contract.address,
             initial_block_number=initial_block_number,
             tx_block_number=initial_block_number,
             version='1.3.0',
             l2=True
         )
         ethereum_tx_sent = self.proxy_factory.deploy_proxy_contract(
-            self.ethereum_test_account, self.safe_contract_V1_3_0.address,
+            self.ethereum_test_account, self.safe_contract.address,
             initializer=initializer
         )
         safe_address = ethereum_tx_sent.contract_address
@@ -150,7 +150,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         self.assertEqual(SafeStatus.objects.count(), 1)
         safe_status = SafeStatus.objects.get()
-        self.assertEqual(safe_status.master_copy, self.safe_contract_V1_3_0.address)
+        self.assertEqual(safe_status.master_copy, self.safe_contract.address)
         self.assertEqual(safe_status.owners, owners)
         self.assertEqual(safe_status.threshold, threshold)
         self.assertEqual(safe_status.nonce, 0)
@@ -162,7 +162,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         # Add an owner but don't update the threshold (nonce: 0) --------------------------------------------------
         owner_account_2 = Account.create()
         data = HexBytes(
-            self.safe_contract_V1_3_0.functions.addOwnerWithThreshold(
+            self.safe_contract.functions.addOwnerWithThreshold(
                 owner_account_2.address,
                 1
             ).buildTransaction({'gas': 1, 'gasPrice': 1})['data']
@@ -191,7 +191,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
 
         # Change threshold (nonce: 1) ------------------------------------------------------------------------------
         data = HexBytes(
-            self.safe_contract_V1_3_0.functions.changeThreshold(
+            self.safe_contract.functions.changeThreshold(
                 2
             ).buildTransaction({'gas': 1, 'gasPrice': 1})['data']
         )
@@ -219,7 +219,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
 
         # Remove an owner and change threshold back to 1 (nonce: 2) --------------------------------------------------
         data = HexBytes(
-            self.safe_contract_V1_3_0.functions.removeOwner(
+            self.safe_contract.functions.removeOwner(
                 SENTINEL_ADDRESS,
                 owner_account_2.address,
                 1
@@ -258,7 +258,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         # Enable module (nonce: 3) ---------------------------------------------------------------------
         module_address = Account.create().address
         data = HexBytes(
-            self.safe_contract_V1_3_0.functions.enableModule(
+            self.safe_contract.functions.enableModule(
                 module_address
             ).buildTransaction({'gas': 1, 'gasPrice': 1})['data']
         )
@@ -302,7 +302,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         # Set fallback handler (nonce: 4) --------------------------------------------------------------------------
         new_fallback_handler = Account.create().address
         data = HexBytes(
-            self.safe_contract_V1_3_0.functions.setFallbackHandler(
+            self.safe_contract.functions.setFallbackHandler(
                 new_fallback_handler
             ).buildTransaction({'gas': 1, 'gasPrice': 1})['data']
         )
@@ -332,7 +332,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
 
         # Disable Module (nonce: 5) ----------------------------------------------------------------------------------
         data = HexBytes(
-            self.safe_contract_V1_3_0.functions.disableModule(
+            self.safe_contract.functions.disableModule(
                 SENTINEL_ADDRESS,
                 module_address
             ).buildTransaction({'gas': 1, 'gasPrice': 1})['data']
@@ -401,7 +401,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         # Set guard (nonce: 7) INVALIDATES SAFE, as no more transactions can be done ---------------------------------
         guard_address = Account.create().address
         data = HexBytes(
-            self.safe_contract_V1_3_0.functions.setGuard(
+            self.safe_contract.functions.setGuard(
                 guard_address
             ).buildTransaction({'gas': 1, 'gasPrice': 1})['data']
         )
@@ -424,7 +424,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
 
         # Check master copy did not change during the execution
         self.assertEqual(SafeStatus.objects.last_for_address(safe_address).master_copy,
-                         self.safe_contract_V1_3_0.address)
+                         self.safe_contract.address)
 
         self.assertEqual(MultisigTransaction.objects.order_by('-nonce')[0].safe_tx_hash,
                          multisig_tx.safe_tx_hash.hex())

--- a/safe_transaction_service/history/tests/test_safe_service.py
+++ b/safe_transaction_service/history/tests/test_safe_service.py
@@ -76,11 +76,11 @@ class TestSafeService(SafeTestCaseMixin, TestCase):
         with self.assertRaises(CannotGetSafeInfo):
             self.safe_service.get_safe_info(safe_address)
 
-        safe_create_tx = self.deploy_test_safe()
-        safe_info = self.safe_service.get_safe_info(safe_create_tx.safe_address)
+        safe = self.deploy_test_safe()
+        safe_info = self.safe_service.get_safe_info(safe.address)
         self.assertIsInstance(safe_info, SafeInfo)
-        self.assertEqual(safe_info.address, safe_create_tx.safe_address)
-        self.assertEqual(safe_info.owners, safe_create_tx.owners)
-        self.assertEqual(safe_info.threshold, safe_create_tx.threshold)
-        self.assertEqual(safe_info.fallback_handler, NULL_ADDRESS)
+        self.assertEqual(safe_info.address, safe.address)
+        self.assertEqual(safe_info.owners, safe.retrieve_owners())
+        self.assertEqual(safe_info.threshold, safe.retrieve_threshold())
+        self.assertEqual(safe_info.fallback_handler, self.compatibility_fallback_handler.address)
         self.assertEqual(safe_info.guard, NULL_ADDRESS)

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -254,8 +254,8 @@ class TestViews(SafeTestCaseMixin, APITestCase):
 
         owner_account_1 = Account.create()
         owner_account_2 = Account.create()
-        safe_create2_tx = self.deploy_test_safe(owners=[owner_account_1.address, owner_account_2.address])
-        safe_address = safe_create2_tx.safe_address
+        safe = self.deploy_test_safe(owners=[owner_account_1.address, owner_account_2.address])
+        safe_address = safe.address
         multisig_transaction = MultisigTransactionFactory(safe=safe_address, trusted=False)
         safe_tx_hash = multisig_transaction.safe_tx_hash
         response = self.client.post(reverse('v1:history:multisig-transaction-confirmations', args=(safe_tx_hash,)),
@@ -417,8 +417,8 @@ class TestViews(SafeTestCaseMixin, APITestCase):
 
     def test_post_multisig_transactions_null_signature(self):
         safe_owner_1 = Account.create()
-        safe_create2_tx = self.deploy_test_safe(owners=[safe_owner_1.address])
-        safe_address = safe_create2_tx.safe_address
+        safe = self.deploy_test_safe(owners=[safe_owner_1.address])
+        safe_address = safe.address
         safe = Safe(safe_address, self.ethereum_client)
 
         response = self.client.get(reverse('v1:history:multisig-transactions', args=(safe_address,)), format='json')
@@ -458,9 +458,8 @@ class TestViews(SafeTestCaseMixin, APITestCase):
 
     def test_post_multisig_transactions(self):
         safe_owner_1 = Account.create()
-        safe_create2_tx = self.deploy_test_safe(owners=[safe_owner_1.address])
-        safe_address = safe_create2_tx.safe_address
-        safe = Safe(safe_address, self.ethereum_client)
+        safe = self.deploy_test_safe(owners=[safe_owner_1.address])
+        safe_address = safe.address
 
         response = self.client.get(reverse('v1:history:multisig-transactions', args=(safe_address,)), format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -527,9 +526,8 @@ class TestViews(SafeTestCaseMixin, APITestCase):
 
     def test_post_executed_transaction(self):
         safe_owner_1 = Account.create()
-        safe_create2_tx = self.deploy_test_safe(owners=[safe_owner_1.address])
-        safe_address = safe_create2_tx.safe_address
-        safe = Safe(safe_address, self.ethereum_client)
+        safe = self.deploy_test_safe(owners=[safe_owner_1.address])
+        safe_address = safe.address
 
         response = self.client.get(reverse('v1:history:multisig-transactions', args=(safe_address,)), format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -595,9 +593,8 @@ class TestViews(SafeTestCaseMixin, APITestCase):
 
     def test_post_multisig_transactions_with_origin(self):
         safe_owner_1 = Account.create()
-        safe_create2_tx = self.deploy_test_safe(owners=[safe_owner_1.address])
-        safe_address = safe_create2_tx.safe_address
-        safe = Safe(safe_address, self.ethereum_client)
+        safe = self.deploy_test_safe(owners=[safe_owner_1.address])
+        safe_address = safe.address
 
         response = self.client.get(reverse('v1:history:multisig-transactions', args=(safe_address,)), format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -636,9 +633,8 @@ class TestViews(SafeTestCaseMixin, APITestCase):
     def test_post_multisig_transactions_with_multiple_signatures(self):
         safe_owners = [Account.create() for _ in range(4)]
         safe_owner_addresses = [s.address for s in safe_owners]
-        safe_create2_tx = self.deploy_test_safe(owners=safe_owner_addresses, threshold=3)
-        safe_address = safe_create2_tx.safe_address
-        safe = Safe(safe_address, self.ethereum_client)
+        safe = self.deploy_test_safe(owners=safe_owner_addresses, threshold=3)
+        safe_address = safe.address
 
         response = self.client.get(reverse('v1:history:multisig-transactions', args=(safe_address,)), format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -687,9 +683,8 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         safe_owners = [Account.create() for _ in range(4)]
         safe_owner_addresses = [s.address for s in safe_owners]
         safe_delegate = Account.create()
-        safe_create2_tx = self.deploy_test_safe(owners=safe_owner_addresses, threshold=3)
-        safe_address = safe_create2_tx.safe_address
-        safe = Safe(safe_address, self.ethereum_client)
+        safe = self.deploy_test_safe(owners=safe_owner_addresses, threshold=3)
+        safe_address = safe.address
 
         self.assertEqual(MultisigTransaction.objects.count(), 0)
 
@@ -925,7 +920,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         endpoint = 'v1:history:safe-delegates'
 
         owner_account = Account.create()
-        safe_address = self.deploy_test_safe(owners=[owner_account.address]).safe_address
+        safe_address = self.deploy_test_safe(owners=[owner_account.address]).address
         safe_contract = SafeContractFactory(address=safe_address)
         response = self.client.delete(reverse(endpoint, args=(safe_address,)), format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)  # Data is missing
@@ -972,7 +967,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         }
 
         owner_account = Account.create()
-        safe_address = self.deploy_test_safe(owners=[owner_account.address]).safe_address
+        safe_address = self.deploy_test_safe(owners=[owner_account.address]).address
         response = self.client.post(reverse('v1:history:safe-delegates', args=(safe_address, )), format='json', data=data)
         self.assertIn(f'Safe={safe_address} does not exist', response.data['non_field_errors'][0])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -1246,7 +1241,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         owner_account = Account.create()
-        safe_address = self.deploy_test_safe(owners=[owner_account.address]).safe_address
+        safe_address = self.deploy_test_safe(owners=[owner_account.address]).address
         response = self.client.delete(reverse('v1:history:safe-delegate', args=(safe_address, delegate_address)),
                                       format='json', data=data)
         self.assertIn(f'Safe={safe_address} does not exist', response.data['non_field_errors'][0])
@@ -1676,8 +1671,8 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         response = self.client.get(reverse('v1:history:safe-info', args=(invalid_address,)))
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
-        safe_create_tx = self.deploy_test_safe()
-        safe_address = safe_create_tx.safe_address
+        safe = self.deploy_test_safe()
+        safe_address = safe.address
         response = self.client.get(reverse('v1:history:safe-info', args=(safe_address,)))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -1687,13 +1682,13 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         self.assertEqual(response.data, {
             'address': safe_address,
             'nonce': 0,
-            'threshold': safe_create_tx.threshold,
-            'owners': safe_create_tx.owners,
-            'master_copy': safe_create_tx.master_copy_address,
+            'threshold': safe.retrieve_threshold(),
+            'owners': safe.retrieve_owners(),
+            'master_copy': safe.retrieve_master_copy_address(),
             'modules': [],
-            'fallback_handler': safe_create_tx.fallback_handler,
+            'fallback_handler': safe.retrieve_fallback_handler(),
             'guard': NULL_ADDRESS,
-            'version': '1.1.1'})
+            'version': '1.3.0'})
 
         with mock.patch.object(SafeService, 'get_safe_info', side_effect=NodeConnectionException, autospec=True):
             response = self.client.get(reverse('v1:history:safe-info', args=(safe_address,)), format='json')


### PR DESCRIPTION
### What was wrong?

- V1.1.1 contracts were used for most of the tests
 
### How was it fixed?
- V1.3.0 contracts are used now

