### PR TITLE
Add task to index ERC events for Safes out of sync

### DIFF
--- a/safe_transaction_service/history/management/commands/index_erc20.py
+++ b/safe_transaction_service/history/management/commands/index_erc20.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from ...indexers import Erc20EventsIndexerProvider, FindRelevantElementsException
+from ...tasks import index_erc20_events_out_of_sync_task
 
 
 class Command(BaseCommand):
@@ -28,47 +28,37 @@ class Command(BaseCommand):
             help="Max number of blocks to query each time",
             default=None,
         )
+        parser.add_argument(
+            "--sync",
+            help="Don't trigger an async task",
+            action="store_true",
+            default=False,
+        )
 
     def handle(self, *args, **options):
-        erc20_events_indexer = Erc20EventsIndexerProvider()
+        addresses = options["addresses"]
+        number_of_addresses = options["number_of_addresses"]
+        sync = options["sync"]
+
         if block_process_limit := options["block_process_limit"]:
             self.stdout.write(
                 self.style.SUCCESS(
                     f"Setting block-process-limit to {block_process_limit}"
                 )
             )
-            erc20_events_indexer.block_process_limit = block_process_limit
         if block_process_limit_max := options["block_process_limit_max"]:
-            erc20_events_indexer.block_process_limit_max = block_process_limit_max
             self.stdout.write(
                 self.style.SUCCESS(
                     f"Setting block-process-limit-max to {block_process_limit_max}"
                 )
             )
-
-        current_block_number = erc20_events_indexer.ethereum_client.current_block_number
-        addresses = options["addresses"] or [
-            x.address
-            for x in erc20_events_indexer.get_not_updated_addresses(
-                current_block_number
-            )[: options["number_of_addresses"]]
-        ]
-
-        if not addresses:
-            self.stdout.write(self.style.WARNING("No addresses to process"))
+        arguments = {
+            "block_process_limit": block_process_limit,
+            "block_process_limit_max": block_process_limit_max,
+            "addresses": addresses,
+            "number_of_addresses": number_of_addresses,
+        }
+        if sync:
+            index_erc20_events_out_of_sync_task(**arguments)
         else:
-            self.stdout.write(
-                self.style.SUCCESS(f"Start indexing ERC20 addresses {addresses}")
-            )
-            updated = False
-            while not updated:
-                try:
-                    _, updated = erc20_events_indexer.process_addresses(
-                        addresses, current_block_number
-                    )
-                except FindRelevantElementsException:
-                    pass
-
-            self.stdout.write(
-                self.style.SUCCESS(f"End indexing ERC20 addresses {addresses}")
-            )
+            index_erc20_events_out_of_sync_task.delay(**arguments)

--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -65,9 +65,15 @@ TASKS = [
     ),
     CeleryTaskConfiguration(
         "safe_transaction_service.history.tasks.index_erc20_events_task",
-        "Index ERC20 Events",
+        "Index ERC20/721 Events",
         14,
         IntervalSchedule.SECONDS,
+    ),
+    CeleryTaskConfiguration(
+        "safe_transaction_service.history.tasks.index_erc20_events_out_of_sync_task",
+        "Index out of sync ERC20/ERC721 Events",
+        5,
+        IntervalSchedule.MINUTES,
     ),
     CeleryTaskConfiguration(
         "safe_transaction_service.history.tasks.process_decoded_internal_txs_task",

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -9,11 +9,14 @@ from eth_account import Account
 from gnosis.eth import EthereumClient, EthereumNetwork
 
 from ..models import SafeContract, SafeStatus
+from ..tasks import index_erc20_events_out_of_sync_task
+from ..tasks import logger as task_logger
 from ..tasks import process_decoded_internal_txs_task
 from .factories import (
     EthereumEventFactory,
     InternalTxDecodedFactory,
     InternalTxFactory,
+    SafeContractFactory,
     WebHookFactory,
 )
 
@@ -60,3 +63,20 @@ class TestTasks(TestCase):
         self.assertEqual(safe_status.master_copy, master_copy)
         self.assertEqual(safe_status.owners, [owner])
         self.assertEqual(safe_status.threshold, threshold)
+
+    def test_index_erc20_events_out_of_sync_task(self):
+        with self.assertLogs(logger=task_logger) as cm:
+            index_erc20_events_out_of_sync_task.delay()
+            self.assertIn("No addresses to process", cm.output[0])
+
+        with self.assertLogs(logger=task_logger) as cm:
+            safe_contract = SafeContractFactory()
+            index_erc20_events_out_of_sync_task.delay()
+            self.assertIn(
+                f"Start indexing of erc20/721 events for out of sync addresses {[safe_contract.address]}",
+                cm.output[0],
+            )
+            self.assertIn(
+                "Indexing of erc20/721 events for out of sync addresses task processed 0 events",
+                cm.output[1],
+            )


### PR DESCRIPTION
### What was wrong?

When syncing ERC20/721 events, Safes **closest to the current block number are prioritized**, that could lead to some Safes never getting synced. A new task was created to prioritize the Safes **farthest from the current block number**
