### PR TITLE
Maintain order for owners when adding/removing/swapping

### DIFF
--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -222,15 +222,15 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         safe_status = SafeStatus.objects.last_for_address(
             safe_address
         )  # Processed execTransaction and addOwner
-        self.assertCountEqual(
-            safe_status.owners, [owner_account_1.address, owner_account_2.address]
+        self.assertEqual(
+            safe_status.owners, [owner_account_2.address, owner_account_1.address]
         )
         self.assertEqual(safe_status.nonce, 1)
 
         safe_status = SafeStatus.objects.sorted_by_mined()[
             1
         ]  # Just processed execTransaction
-        self.assertCountEqual(safe_status.owners, [owner_account_1.address])
+        self.assertEqual(safe_status.owners, [owner_account_1.address])
         self.assertEqual(safe_status.nonce, 1)
 
         self.assertEqual(MultisigTransaction.objects.count(), 1)

--- a/safe_transaction_service/history/tests/test_tx_processor.py
+++ b/safe_transaction_service/history/tests/test_tx_processor.py
@@ -87,7 +87,7 @@ class TestSafeTxProcessor(TestCase):
 
         self.assertEqual(SafeStatus.objects.count(), 3)
         safe_status = SafeStatus.objects.last_for_address(safe_address)
-        self.assertCountEqual(safe_status.owners, [owner, new_owner])
+        self.assertEqual(safe_status.owners, [new_owner, owner])
         self.assertEqual(safe_status.nonce, 1)
         self.assertEqual(safe_status.threshold, threshold)
 
@@ -107,7 +107,7 @@ class TestSafeTxProcessor(TestCase):
         )
         self.assertEqual(SafeStatus.objects.count(), 5)
         safe_status = SafeStatus.objects.last_for_address(safe_address)
-        self.assertCountEqual(safe_status.owners, [another_owner, new_owner])
+        self.assertEqual(safe_status.owners, [new_owner, another_owner])
         self.assertEqual(safe_status.nonce, 2)
         self.assertEqual(safe_status.threshold, threshold)
 


### PR DESCRIPTION
- Guarantee we keep owners in the database in the same order they are kept in blockchain
- Closes #814
