### PR TITLE
Don't send webhooks older than 60 minutes

### DIFF
--- a/safe_transaction_service/history/signals.py
+++ b/safe_transaction_service/history/signals.py
@@ -187,7 +187,7 @@ def is_relevant_notification(
         TokenTransfer, InternalTx, MultisigConfirmation, MultisigTransaction
     ],
     created: bool,
-    minutes: int = 30,
+    minutes: int = 60,
 ) -> bool:
     """
     For `MultisigTransaction`, webhook is valid if the instance was modified in the last `minutes` minutes.
@@ -253,10 +253,10 @@ def process_webhook(
     )
     for payload in payloads:
         if address := payload.get("address"):
-            send_webhook_task.apply_async(
-                args=(address, payload), priority=4
-            )  # Almost the lowest priority
             if is_relevant_notification(sender, instance, created):
+                send_webhook_task.apply_async(
+                    args=(address, payload), priority=4
+                )  # Almost the lowest priority
                 send_notification_task.apply_async(
                     args=(address, payload), countdown=5, priority=4
                 )

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -87,13 +87,13 @@ class TestSignals(TestCase):
                 webhook_task_mock.assert_called()
                 send_notification_task_mock.assert_called()
 
-        multisig_confirmation.created -= timedelta(minutes=45)
+        multisig_confirmation.created -= timedelta(minutes=75)
         with mock.patch.object(send_webhook_task, "apply_async") as webhook_task_mock:
             with mock.patch.object(
                 send_notification_task, "apply_async"
             ) as send_notification_task_mock:
                 process_webhook(MultisigConfirmation, multisig_confirmation, True)
-                webhook_task_mock.assert_called()
+                webhook_task_mock.assert_not_called()
                 send_notification_task_mock.assert_not_called()
 
     @factory.django.mute_signals(post_save)
@@ -109,7 +109,7 @@ class TestSignals(TestCase):
                 multisig_confirmation.__class__, multisig_confirmation, created=True
             )
         )
-        multisig_confirmation.created -= timedelta(minutes=45)
+        multisig_confirmation.created -= timedelta(minutes=75)
         self.assertFalse(
             is_relevant_notification(
                 multisig_confirmation.__class__, multisig_confirmation, created=True
@@ -120,11 +120,11 @@ class TestSignals(TestCase):
         self.assertTrue(
             is_relevant_notification(multisig_tx.__class__, multisig_tx, created=False)
         )
-        multisig_tx.created -= timedelta(minutes=45)
+        multisig_tx.created -= timedelta(minutes=75)
         self.assertTrue(
             is_relevant_notification(multisig_tx.__class__, multisig_tx, created=False)
         )
-        multisig_tx.modified -= timedelta(minutes=45)
+        multisig_tx.modified -= timedelta(minutes=75)
         self.assertFalse(
             is_relevant_notification(multisig_tx.__class__, multisig_tx, created=False)
         )


### PR DESCRIPTION
- Previously, if reindexing all the webhooks are sent again
- With this change webhooks older than 60 minutes are ignored
