### PR TITLE
Don't require Safes to be "indexed" to be processed

### DIFF
--- a/safe_transaction_service/history/signals.py
+++ b/safe_transaction_service/history/signals.py
@@ -249,13 +249,19 @@ def process_webhook(
     created: bool,
     **kwargs,
 ) -> None:
+    logger.debug("Start building payloads for created=%s object=%s", created, instance)
     payloads = build_webhook_payload(sender, instance)
     logger.debug(
-        "Built payloads %s for created=%s object=%s", payloads, created, instance
+        "End building payloads %s for created=%s object=%s", payloads, created, instance
     )
     for payload in payloads:
         if address := payload.get("address"):
             if is_relevant_notification(sender, instance, created):
+                logger.debug(
+                    "Triggering send_webhook and send_notification tasks for created=%s object=%s",
+                    created,
+                    instance,
+                )
                 send_webhook_task.apply_async(
                     args=(address, payload), priority=1  # Almost lowest priority
                 )  # Almost the lowest priority
@@ -292,6 +298,11 @@ def add_to_historical_table(
     :param kwargs:
     :return: SafeStatus
     """
+    logger.debug(
+        "Storing created=%s object=%s on `SafeStatus` table",
+        created,
+        instance,
+    )
     safe_status = SafeStatus.from_status_instance(instance)
     safe_status.save()
     return safe_status

--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -189,7 +189,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
 
         self.assertEqual(setup_internal_tx.trace_address, "1,0")
 
-        txs_decoded_queryset = InternalTxDecoded.objects.pending_for_indexed_safes()
+        txs_decoded_queryset = InternalTxDecoded.objects.pending_for_safes()
         self.assertEqual(SafeStatus.objects.count(), 0)
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         self.assertEqual(SafeStatus.objects.count(), 1)


### PR DESCRIPTION
- This was a very old behaviour that makes database struggle and leave some unbinded traces on DB without processing

Also:
- Add more debug information for tx processing
- Refactor code and rename variables
- Use iterator for InternalTxDecoded
