### PR TITLE
Get SafeInfo from blockchain if nonce=0

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.3.1"
+__version__ = "4.3.2"
 __version_info__ = tuple(
     int(num) if num.isdigit() else num
     for num in __version__.replace("-", ".", 1).split(".")

--- a/safe_transaction_service/history/tests/clients/test_ens_client.py
+++ b/safe_transaction_service/history/tests/clients/test_ens_client.py
@@ -24,7 +24,6 @@ class TestEnsClient(TestCase):
         self.assertEqual(len(EnsClient.domain_hash_to_hex_str(2)), 66)
 
     def test_query_by_account(self):
-        self.maxDiff = None
         ens_client = EnsClient(EthereumNetwork.RINKEBY.value)  # Mainnet
         if not ens_client.is_available():
             self.skipTest("ENS Rinkeby Client is not available")

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -54,6 +54,7 @@ from .services import (
     TransactionServiceProvider,
 )
 from .services.collectibles_service import CollectiblesServiceProvider
+from .services.safe_service import CannotGetSafeInfo
 
 logger = logging.getLogger(__name__)
 
@@ -989,17 +990,27 @@ class SafeInfoView(GenericAPIView):
 
         try:
             safe_info = SafeLastStatus.objects.get(address=address).get_safe_info()
+            if safe_info.nonce == 0:
+                # This works for:
+                # - Not indexed Safes
+                # - Not L2 Safes on L2 networks
+                raise SafeLastStatus.DoesNotExist
             serializer = self.get_serializer(safe_info)
             return Response(status=status.HTTP_200_OK, data=serializer.data)
         except SafeLastStatus.DoesNotExist:
-            return Response(
-                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                data={
-                    "code": 50,
-                    "message": "Service is still indexing",
-                    "arguments": [address],
-                },
-            )
+            try:
+                safe_info = SafeServiceProvider().get_safe_info(address)
+                serializer = self.get_serializer(safe_info)
+                return Response(status=status.HTTP_200_OK, data=serializer.data)
+            except CannotGetSafeInfo:
+                return Response(
+                    status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    data={
+                        "code": 50,
+                        "message": "Cannot get Safe info from blockchain",
+                        "arguments": [address],
+                    },
+                )
 
 
 class MasterCopiesView(ListAPIView):


### PR DESCRIPTION
- Get SafeInfo from blockchain (instead of `SafeLastStatus` table) if `nonce=0` or not found on the DB.
- Fixes issues with Safes not indexed or not L2 Safes in L2 networks