### PR TITLE
Increase webhook connection pool

### DIFF
--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -385,7 +385,7 @@ def get_webhook_http_session(
         session.headers.update({"Authorization": authorization})
     adapter = requests.adapters.HTTPAdapter(
         pool_connections=1,  # Doing all the connections to the same url
-        pool_maxsize=100,  # Number of concurrent connections
+        pool_maxsize=500,  # Number of concurrent connections
         pool_block=False,
     )
     session.mount("http://", adapter)


### PR DESCRIPTION
- Sometimes there are a lot of webhooks and tasks need to wait for the pool to be free
