### PR TITLE
Sort traces by internal_tx_id

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.3.3"
+__version__ = "4.3.4"
 __version_info__ = tuple(
     int(num) if num.isdigit() else num
     for num in __version__.replace("-", ".", 1).split(".")

--- a/safe_transaction_service/history/admin.py
+++ b/safe_transaction_service/history/admin.py
@@ -180,7 +180,7 @@ class InternalTxAdmin(BinarySearchAdmin):
     ordering = [
         "-block_number",
         "-ethereum_tx__transaction_index",
-        "-trace_address",
+        "-pk",
     ]
     raw_id_fields = ("ethereum_tx",)
     search_fields = [
@@ -226,7 +226,7 @@ class InternalTxDecodedAdmin(BinarySearchAdmin):
     ordering = [
         "-internal_tx__block_number",
         "-internal_tx__ethereum_tx__transaction_index",
-        "-internal_tx__trace_address",
+        "-internal_tx_id",
     ]
     raw_id_fields = ("internal_tx",)
     search_fields = [

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -941,7 +941,7 @@ class InternalTxDecodedQuerySet(models.QuerySet):
             "is_setup",
             "internal_tx__block_number",
             "internal_tx__ethereum_tx__transaction_index",
-            "internal_tx__trace_address",
+            "internal_tx_id",
         )
 
     def pending_for_safes(self):
@@ -1627,7 +1627,7 @@ class SafeStatusQuerySet(models.QuerySet):
             "-nonce",
             "-internal_tx__block_number",
             "-internal_tx__ethereum_tx__transaction_index",
-            "-internal_tx__trace_address",
+            "-internal_tx_id",
         )
 
     def sorted_reverse_by_mined(self):
@@ -1636,7 +1636,7 @@ class SafeStatusQuerySet(models.QuerySet):
             "nonce",
             "internal_tx__block_number",
             "internal_tx__ethereum_tx__transaction_index",
-            "internal_tx__trace_address",
+            "internal_tx_id",
         )
 
     def last_for_every_address(self) -> QuerySet:

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -581,26 +581,27 @@ class TestInternalTxDecoded(TestCase):
             InternalTxDecoded.objects.order_by_processing_queue(), []
         )
         ethereum_tx = EthereumTxFactory()
-        internal_tx_decoded_1 = InternalTxDecodedFactory(
-            internal_tx__trace_address="1", internal_tx__ethereum_tx=ethereum_tx
-        )
+        # `trace_address` is not used for ordering anymore
         internal_tx_decoded_0 = InternalTxDecodedFactory(
             internal_tx__trace_address="0", internal_tx__ethereum_tx=ethereum_tx
         )
-        internal_tx_decoded_5 = InternalTxDecodedFactory(
-            internal_tx__trace_address="5", internal_tx__ethereum_tx=ethereum_tx
+        internal_tx_decoded_1 = InternalTxDecodedFactory(
+            internal_tx__trace_address="2", internal_tx__ethereum_tx=ethereum_tx
+        )
+        internal_tx_decoded_15 = InternalTxDecodedFactory(
+            internal_tx__trace_address="15", internal_tx__ethereum_tx=ethereum_tx
         )
 
         self.assertQuerysetEqual(
             InternalTxDecoded.objects.order_by_processing_queue(),
-            [internal_tx_decoded_0, internal_tx_decoded_1, internal_tx_decoded_5],
+            [internal_tx_decoded_0, internal_tx_decoded_1, internal_tx_decoded_15],
         )
 
-        internal_tx_decoded_5.function_name = "setup"
-        internal_tx_decoded_5.save()
+        internal_tx_decoded_15.function_name = "setup"
+        internal_tx_decoded_15.save()
         self.assertQuerysetEqual(
             InternalTxDecoded.objects.order_by_processing_queue(),
-            [internal_tx_decoded_5, internal_tx_decoded_0, internal_tx_decoded_1],
+            [internal_tx_decoded_15, internal_tx_decoded_0, internal_tx_decoded_1],
         )
 
     def test_safes_pending_to_be_processed(self):


### PR DESCRIPTION
## Current problem

We are sorting traces using `blockNumber`, `transactionIndex` and `traceAddress` (for L2 Safes `traceAddress=logIndex`), but as the field is a `varchar`, sorting is not working as supposed. Example of current ordering:

| Safe Address | Trace Address | Safe Nonce |
| ------------- | ------------- | ------------- |
| 0x2de145a14e19618d4cb11201e56b6e84386f41942f6cbbf0dc4c1e6d649ead8b | 0 | 37 |
| 0x2de145a14e19618d4cb11201e56b6e84386f41942f6cbbf0dc4c1e6d649ead8b | 12 | 41 |
| 0x2de145a14e19618d4cb11201e56b6e84386f41942f6cbbf0dc4c1e6d649ead8b | 15 | 42 |
| 0x2de145a14e19618d4cb11201e56b6e84386f41942f6cbbf0dc4c1e6d649ead8b | 18 | 43 |
| 0x2de145a14e19618d4cb11201e56b6e84386f41942f6cbbf0dc4c1e6d649ead8b | 3 | 38 |
| 0x2de145a14e19618d4cb11201e56b6e84386f41942f6cbbf0dc4c1e6d649ead8b | 6 | 39 |
| 0x2de145a14e19618d4cb11201e56b6e84386f41942f6cbbf0dc4c1e6d649ead8b | 9 | 40 |
| 0xb510cf12dd8d55c4091534fcddb75a58f0dd92c373f49f48c3e4fddeecf366bc | 1 | 44 |
| 0xb510cf12dd8d55c4091534fcddb75a58f0dd92c373f49f48c3e4fddeecf366bc | 11 | 47 |
| 0xb510cf12dd8d55c4091534fcddb75a58f0dd92c373f49f48c3e4fddeecf366bc | 14 | 48 |
| 0xb510cf12dd8d55c4091534fcddb75a58f0dd92c373f49f48c3e4fddeecf366bc | 17 | 49 |
| 0xb510cf12dd8d55c4091534fcddb75a58f0dd92c373f49f48c3e4fddeecf366bc | 20 | 50 |
| 0xb510cf12dd8d55c4091534fcddb75a58f0dd92c373f49f48c3e4fddeecf366bc | 23 | 51 |
| 0xb510cf12dd8d55c4091534fcddb75a58f0dd92c373f49f48c3e4fddeecf366bc | 26 | 52 |
| 0xb510cf12dd8d55c4091534fcddb75a58f0dd92c373f49f48c3e4fddeecf366bc | 29 | 53 |
| 0xb510cf12dd8d55c4091534fcddb75a58f0dd92c373f49f48c3e4fddeecf366bc | 5 | 45 |
| 0xb510cf12dd8d55c4091534fcddb75a58f0dd92c373f49f48c3e4fddeecf366bc | 8 | 46 |

For not L2 networks, `traceAddress` can get pretty messy, being something like `0,1,10,22,0,2`

## Proposed solution
Sort by `blockNumber`, `transactionIndex` and `trace_id` (database private key). Being aware that is not guaranteed than in an incremental DB private keys are sorted in the insertion order, chances for that to happen inside the same transaction should be quite low, and at least better that the current implementation.

This solution does not require to reindex.

Closes #878