### PR TITLE
Fix typo on EthereumIndexer

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.3.4"
+__version__ = "4.3.5"
 __version_info__ = tuple(
     int(num) if num.isdigit() else num
     for num in __version__.replace("-", ".", 1).split(".")

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -453,7 +453,9 @@ class EthereumIndexer(ABC):
                 )
 
                 # Not updated addresses are sorted by tx_block_number
-                minimum_block_number = not_updated_addresses_chunk[0].tx_block_number
+                minimum_block_number = getattr(
+                    not_updated_addresses_chunk[0], self.database_field
+                )
                 from_block_number = minimum_block_number + 1
                 updated = False
                 while not updated:


### PR DESCRIPTION
- Fix typo on EthereumIndexer
- Set version 4.3.5
