### PR TITLE
Return only relevant master copies

### DIFF
--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -2835,8 +2835,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
     def test_master_copies_view(self):
         response = self.client.get(reverse("v1:history:master-copies"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        expected = []
-        self.assertEqual(response.data, expected)
+        self.assertEqual(response.data, [])
 
         deployed_block_number = 2
         last_indexed_block_number = 5
@@ -2846,7 +2845,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         )
         response = self.client.get(reverse("v1:history:master-copies"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        expected = [
+        expected_master_copy = [
             {
                 "address": safe_master_copy.address,
                 "version": safe_master_copy.version,
@@ -2856,12 +2855,12 @@ class TestViews(SafeTestCaseMixin, APITestCase):
                 "l2": False,
             }
         ]
-        self.assertCountEqual(response.data, expected)
+        self.assertCountEqual(response.data, expected_master_copy)
 
         safe_master_copy = SafeMasterCopyFactory(l2=True)
         response = self.client.get(reverse("v1:history:master-copies"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        expected += [
+        expected_l2_master_copy = [
             {
                 "address": safe_master_copy.address,
                 "version": safe_master_copy.version,
@@ -2872,7 +2871,14 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             }
         ]
 
-        self.assertCountEqual(response.data, expected)
+        self.assertCountEqual(
+            response.data, expected_master_copy + expected_l2_master_copy
+        )
+
+        with self.settings(ETH_L2_NETWORK=True):
+            response = self.client.get(reverse("v1:history:master-copies"))
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertCountEqual(response.data, expected_l2_master_copy)
 
     def test_analytics_multisig_txs_by_origin_view(self):
         response = self.client.get(

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -1006,8 +1006,10 @@ class SafeInfoView(GenericAPIView):
 
 class MasterCopiesView(ListAPIView):
     serializer_class = serializers.MasterCopyResponseSerializer
-    queryset = SafeMasterCopy.objects.all()
     pagination_class = None
+
+    def get_queryset(self):
+        return SafeMasterCopy.objects.relevant()
 
 
 class OwnersView(GenericAPIView):


### PR DESCRIPTION
- Modifies master copy endpoint
- Don't return not L2 MasterCopies on L2 networks
