### PR TITLE
Remove persistence from Redis on docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,6 @@ services:
     image: redis:alpine
     ports:
       - "6379:6379"
-    command:
-      - --save ""
-      - --appendonly no
 
   rabbitmq:
     image: rabbitmq:alpine


### PR DESCRIPTION
- This is not needed, caching `redis` does not need to be persistent and spend time recording to disk