### PR TITLE
Fix indexing issues due to SafeLastStatus missing

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.3.5"
+__version__ = "4.3.6"
 __version_info__ = tuple(
     int(num) if num.isdigit() else num
     for num in __version__.replace("-", ".", 1).split(".")

--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -4,7 +4,7 @@ from typing import Dict, Iterator, List, Optional, Sequence, Union
 
 from django.db import transaction
 
-from eth_typing import ChecksumAddress
+from eth_typing import ChecksumAddress, HexStr
 from eth_utils import event_abi_to_log_topic
 from hexbytes import HexBytes
 from packaging.version import Version
@@ -105,7 +105,7 @@ class SafeTxProcessor(TxProcessor):
             Version("1.3.0"),  # ChainId was included
         )
 
-    def clear_cache(self, safe_address: Optional[str] = None):
+    def clear_cache(self, safe_address: Optional[ChecksumAddress] = None) -> None:
         if safe_address:
             if safe_address in self.safe_last_status_cache:
                 del self.safe_last_status_cache[safe_address]
@@ -113,7 +113,7 @@ class SafeTxProcessor(TxProcessor):
             self.safe_last_status_cache.clear()
 
     def is_failed(
-        self, ethereum_tx: EthereumTx, safe_tx_hash: Union[str, bytes]
+        self, ethereum_tx: EthereumTx, safe_tx_hash: Union[HexStr, bytes]
     ) -> bool:
         """
         Detects failure events on a Safe Multisig Tx
@@ -170,10 +170,10 @@ class SafeTxProcessor(TxProcessor):
         try:
             safe_status = self.safe_last_status_cache.get(
                 address
-            ) or SafeLastStatus.objects.get(address=address)
+            ) or SafeLastStatus.objects.get_or_create(address)
             return safe_status
         except SafeLastStatus.DoesNotExist:
-            logger.error("SafeStatus not found for address=%s", address)
+            logger.error("SafeLastStatus not found for address=%s", address)
 
     def is_version_breaking_signatures(
         self, old_safe_version: str, new_safe_version: str

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -1547,6 +1547,21 @@ class SafeStatusBase(models.Model):
 
 
 class SafeLastStatusManager(models.Manager):
+    def get_or_create(self, address: ChecksumAddress) -> "SafeLastStatus":
+        """
+        :param address:
+        :return: `SafeLastStatus` if it exists. If not, it will try to build it from `SafeStatus` table
+        """
+        try:
+            return SafeLastStatus.objects.get(address=address)
+        except self.model.DoesNotExist:
+            safe_status = SafeStatus.objects.last_for_address(address)
+            if safe_status:
+                return SafeLastStatus.objects.update_or_create_from_safe_status(
+                    safe_status
+                )
+            raise
+
     def update_or_create_from_safe_status(
         self, safe_status: "SafeStatus"
     ) -> "SafeLastStatus":

--- a/safe_transaction_service/history/services/safe_service.py
+++ b/safe_transaction_service/history/services/safe_service.py
@@ -161,7 +161,7 @@ class SafeService:
 
     def get_safe_info_from_db(self, safe_address: ChecksumAddress) -> SafeInfo:
         try:
-            return SafeLastStatus.objects.get(address=safe_address).get_safe_info()
+            return SafeLastStatus.objects.get_or_create(safe_address).get_safe_info()
         except SafeLastStatus.DoesNotExist as exc:
             raise CannotGetSafeInfoFromDB(safe_address) from exc
 

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -729,6 +729,28 @@ class TestLastSafeStatus(TestCase):
         )
 
 
+class TestSafeLastStatus(TestCase):
+    def test_get_or_create(self):
+        address = Account.create().address
+        with self.assertRaises(SafeLastStatus.DoesNotExist):
+            SafeLastStatus.objects.get_or_create(address)
+
+        SafeStatusFactory(address=address, nonce=0)
+        SafeStatusFactory(address=address, nonce=5)
+        self.assertEqual(SafeLastStatus.objects.count(), 0)
+        # SafeLastStatus should be created from latest SafeStatus
+        self.assertEqual(SafeLastStatus.objects.get_or_create(address).nonce, 5)
+        self.assertEqual(SafeLastStatus.objects.count(), 1)
+
+        # SafeLastStatus was already created and will not be increased
+        SafeStatusFactory(address=address, nonce=7)
+        self.assertEqual(SafeLastStatus.objects.get_or_create(address).nonce, 5)
+
+        SafeLastStatus.objects.all().delete()
+        SafeLastStatusFactory(address=address, nonce=17)
+        self.assertEqual(SafeLastStatus.objects.get_or_create(address).nonce, 17)
+
+
 class TestSafeStatus(TestCase):
     def test_safe_status_is_corrupted(self):
         address = Account.create().address

--- a/safe_transaction_service/notifications/tasks.py
+++ b/safe_transaction_service/notifications/tasks.py
@@ -163,7 +163,7 @@ def send_notification_owner_task(address: str, safe_tx_hash: str) -> Tuple[int, 
     assert safe_tx_hash, "Safe tx hash was not provided"
 
     try:
-        safe_last_status = SafeLastStatus.objects.get(address=address)
+        safe_last_status = SafeLastStatus.objects.get_or_create(address)
     except SafeLastStatus.DoesNotExist:
         logger.info("Cannot find threshold information for safe=%s", address)
         return 0, 0


### PR DESCRIPTION
- When a reorg happens, `SafeLastStatus` was deleted
- If `SafeLastStatus` was missing, indexing was not able to continue
- Now when `SafeLastStatus` is not found `SafeStatus` will be used to recreate it if possible
- Set version 4.3.6 as this needs to be released asap
