### PR TITLE
Rename SafeLastStatus get_or_create -> get_or_generate

### DIFF
--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -170,7 +170,7 @@ class SafeTxProcessor(TxProcessor):
         try:
             safe_status = self.safe_last_status_cache.get(
                 address
-            ) or SafeLastStatus.objects.get_or_create(address)
+            ) or SafeLastStatus.objects.get_or_generate(address)
             return safe_status
         except SafeLastStatus.DoesNotExist:
             logger.error("SafeLastStatus not found for address=%s", address)

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -1547,7 +1547,7 @@ class SafeStatusBase(models.Model):
 
 
 class SafeLastStatusManager(models.Manager):
-    def get_or_create(self, address: ChecksumAddress) -> "SafeLastStatus":
+    def get_or_generate(self, address: ChecksumAddress) -> "SafeLastStatus":
         """
         :param address:
         :return: `SafeLastStatus` if it exists. If not, it will try to build it from `SafeStatus` table

--- a/safe_transaction_service/history/services/safe_service.py
+++ b/safe_transaction_service/history/services/safe_service.py
@@ -161,7 +161,7 @@ class SafeService:
 
     def get_safe_info_from_db(self, safe_address: ChecksumAddress) -> SafeInfo:
         try:
-            return SafeLastStatus.objects.get_or_create(safe_address).get_safe_info()
+            return SafeLastStatus.objects.get_or_generate(safe_address).get_safe_info()
         except SafeLastStatus.DoesNotExist as exc:
             raise CannotGetSafeInfoFromDB(safe_address) from exc
 

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -730,25 +730,25 @@ class TestLastSafeStatus(TestCase):
 
 
 class TestSafeLastStatus(TestCase):
-    def test_get_or_create(self):
+    def test_get_or_generate(self):
         address = Account.create().address
         with self.assertRaises(SafeLastStatus.DoesNotExist):
-            SafeLastStatus.objects.get_or_create(address)
+            SafeLastStatus.objects.get_or_generate(address)
 
         SafeStatusFactory(address=address, nonce=0)
         SafeStatusFactory(address=address, nonce=5)
         self.assertEqual(SafeLastStatus.objects.count(), 0)
         # SafeLastStatus should be created from latest SafeStatus
-        self.assertEqual(SafeLastStatus.objects.get_or_create(address).nonce, 5)
+        self.assertEqual(SafeLastStatus.objects.get_or_generate(address).nonce, 5)
         self.assertEqual(SafeLastStatus.objects.count(), 1)
 
         # SafeLastStatus was already created and will not be increased
         SafeStatusFactory(address=address, nonce=7)
-        self.assertEqual(SafeLastStatus.objects.get_or_create(address).nonce, 5)
+        self.assertEqual(SafeLastStatus.objects.get_or_generate(address).nonce, 5)
 
         SafeLastStatus.objects.all().delete()
         SafeLastStatusFactory(address=address, nonce=17)
-        self.assertEqual(SafeLastStatus.objects.get_or_create(address).nonce, 17)
+        self.assertEqual(SafeLastStatus.objects.get_or_generate(address).nonce, 17)
 
 
 class TestSafeStatus(TestCase):

--- a/safe_transaction_service/notifications/tasks.py
+++ b/safe_transaction_service/notifications/tasks.py
@@ -163,7 +163,7 @@ def send_notification_owner_task(address: str, safe_tx_hash: str) -> Tuple[int, 
     assert safe_tx_hash, "Safe tx hash was not provided"
 
     try:
-        safe_last_status = SafeLastStatus.objects.get_or_create(address)
+        safe_last_status = SafeLastStatus.objects.get_or_generate(address)
     except SafeLastStatus.DoesNotExist:
         logger.info("Cannot find threshold information for safe=%s", address)
         return 0, 0


### PR DESCRIPTION
- There's no need to override Django ORM method
