### PR TITLE
Split Celery tasks in queues

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -236,6 +236,19 @@ CELERY_TASK_DEFAULT_PRIORITY = 5
 CELERY_TASK_QUEUE_MAX_PRIORITY = 10
 # https://docs.celeryproject.org/en/latest/userguide/configuration.html#broker-transport-options
 CELERY_BROKER_TRANSPORT_OPTIONS = {}
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_routes
+CELERY_ROUTES = (
+    [
+        (
+            "safe_transaction_service.history.tasks.send_webhook_task",
+            {"queue": "webhooks"},
+        ),
+        ("safe_transaction_service.history.tasks.*", {"queue": "indexing"}),
+        ("safe_transaction_service.contracts.tasks.*", {"queue": "contracts"}),
+        ("safe_transaction_service.notifications.tasks.*", {"queue": "notifications"}),
+        ("safe_transaction_service.tokens.tasks.*", {"queue": "tokens"}),
+    ],
+)
 
 
 # Django REST Framework

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,7 @@ services:
     ports:
       - "6379:6379"
     command:
-      - --save ""
-      - --appendonly no
+      - --appendonly yes
 
   rabbitmq:
     image: rabbitmq:alpine
@@ -50,17 +49,30 @@ services:
       - nginx-shared:/nginx
     command: docker/web/run_web.sh
 
-  worker: &worker
+  indexer-worker: &worker
     build:
       context: .
       dockerfile: docker/web/Dockerfile
     env_file:
       - .env
+    environment:
+      RUN_MIGRATIONS: 1
+      WORKER_QUEUES: "default,indexing"
     depends_on:
       - db
       - redis
       - rabbitmq
     command: docker/web/celery/worker/run.sh
+
+  contracts-tokens-worker:
+    <<: *worker
+    environment:
+      WORKER_QUEUES: "contracts,tokens"
+
+  notifications-webhooks-worker:
+    <<: *worker
+    environment:
+      WORKER_QUEUES: "notifications,webhooks"
 
   scheduler:
     <<: *worker

--- a/docker/web/celery/worker/run.sh
+++ b/docker/web/celery/worker/run.sh
@@ -9,16 +9,21 @@ else
     log_level="info"
 fi
 
-echo "==> $(date +%H:%M:%S) ==> Migrating Django models... "
-python manage.py migrate --noinput
+if [ ${RUN_MIGRATIONS:-0} = 1 ]; then
+  echo "==> $(date +%H:%M:%S) ==> Migrating Django models... "
+  python manage.py migrate --noinput
 
-echo "==> $(date +%H:%M:%S) ==> Setting up service... "
-python manage.py setup_service
+  echo "==> $(date +%H:%M:%S) ==> Setting up service... "
+  python manage.py setup_service
+fi
 
 MAX_MEMORY_PER_CHILD="${WORKER_MAX_MEMORY_PER_CHILD:-2097152}"
 MAX_TASKS_PER_CHILD="${MAX_TASKS_PER_CHILD:-1000000}"
 
 echo "==> $(date +%H:%M:%S) ==> Running Celery worker with a max_memory_per_child of ${MAX_MEMORY_PER_CHILD} <=="
-exec celery -C -A config.celery_app worker --loglevel $log_level --pool=gevent \
-     --concurrency=${CELERYD_CONCURRENCY:-1000} --max-memory-per-child=${MAX_MEMORY_PER_CHILD} \
-     --max-tasks-per-child=${MAX_TASKS_PER_CHILD}
+exec celery -C -A config.celery_app worker \
+     --loglevel $log_level --pool=gevent \
+     --concurrency=${CELERYD_CONCURRENCY:-1000} \
+     --max-memory-per-child=${MAX_MEMORY_PER_CHILD} \
+     --max-tasks-per-child=${MAX_TASKS_PER_CHILD} \
+     -Q "$WORKER_QUEUES"


### PR DESCRIPTION
Multiple queues were created:
- contracts
- indexing
- notifications
- tokens
- webhooks

Added a new variable `RUN_MIGRATIONS` to choose what worker will run the database migrations.

Closes #620
