### PR TITLE
Remove gevent locks

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -16,6 +16,7 @@ def post_fork(server, worker):
     try:
         from psycogreen.gevent import patch_psycopg
 
+        worker.log.info("Making Psycopg2 Green")
         patch_psycopg()
         worker.log.info("Made Psycopg2 Green")
     except ImportError:

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -6,7 +6,6 @@ from typing import Any, Iterable, List, Optional, Sequence, Tuple
 from django.db.models import Min, QuerySet
 
 from celery.exceptions import SoftTimeLimitExceeded
-from web3 import Web3
 
 from gnosis.eth import EthereumClient
 
@@ -293,9 +292,6 @@ class EthereumIndexer(ABC):
             and `True` if no more blocks to scan, `False` otherwise
         """
         assert addresses, "Addresses cannot be empty!"
-        assert all(
-            Web3.isChecksumAddress(address) for address in addresses
-        ), f"An address has invalid checksum: {addresses}"
 
         current_block_number = (
             current_block_number or self.ethereum_client.current_block_number

--- a/safe_transaction_service/utils/tasks.py
+++ b/safe_transaction_service/utils/tasks.py
@@ -20,19 +20,20 @@ WORKER_STOPPED = set()  # Worker status
 
 @celeryd_init.connect
 def configure_workers(sender=None, conf=None, **kwargs):
-    def patch_psycopg():
+    def worker_patch_psycopg():
         """
         Patch postgresql to be friendly with gevent
         """
         try:
             from psycogreen.gevent import patch_psycopg
 
-            logger.info("Patching psycopg for gevent")
+            logger.info("Patching Celery psycopg for gevent")
             patch_psycopg()
+            logger.info("Patched Celery psycopg for gevent")
         except ImportError:
             pass
 
-    patch_psycopg()
+    worker_patch_psycopg()
 
 
 @worker_shutting_down.connect


### PR DESCRIPTION
- There's no need on checking for checksum addresses on the indexer, and it takes some time.
Also, being a CPU intensive task locks all the other threads
