### PR TITLE
Mention delegates in error message when creating a new tx

### DIFF
--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -445,7 +445,7 @@ class SafeMultisigTransactionListView(ListAPIView):
             201: "Created or signature updated",
             400: "Invalid data",
             422: "Invalid ethereum address/User is not an owner/Invalid safeTxHash/"
-            "Invalid signature/Nonce already executed/Sender is not an owner",
+            "Invalid signature/Nonce already executed/Sender is not an owner or delegate",
         }
     )
     def post(self, request, address, format=None):


### PR DESCRIPTION
### What was wrong?

The endpoint `POST ​/safes​/{address}​/multisig-transactions​/` in Swagger shows this error message when the response code is 422: `Invalid ethereum address/User is not an owner/Invalid safeTxHash/Invalid signature/Nonce already executed/Sender is not an owner`

`Sender is not an owner` should be replaced with `Sender is not an owner or delegate`.

### How was it fixed?

Message error was updated.
