### PR TITLE
Refactor erc20 indexing

### DIFF
--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -82,7 +82,7 @@ class Erc20EventsIndexer(EventsIndexer):
                 from_block=from_block_number,
                 to_block=to_block_number,
             )
-            for addresses_chunk in chunks(addresses, 5000)
+            for addresses_chunk in chunks(addresses, self.query_chunk_size)
         ]
         _ = gevent.joinall(jobs)
         transfer_events = []

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -39,7 +39,7 @@ class EthereumIndexer(ABC):
         block_process_limit_max: int = 0,
         blocks_to_reindex_again: int = 0,
         updated_blocks_behind: int = 20,
-        query_chunk_size: int = 200,
+        query_chunk_size: int = 5000,
         block_auto_process_limit: bool = True,
     ):
         """
@@ -54,7 +54,7 @@ class EthereumIndexer(ABC):
             `current block number` is 200, and last scan for an address was stopped on block 150, address
             is almost updated (200 - 100 < 150)
         :param query_chunk_size: Number of addresses to query for relevant data in the same request. By testing,
-            it seems that `200` can be a good value. If `0`, process all together
+            it seems that `5000` can be a good value. If `0`, process all together
         :param block_auto_process_limit: Auto increase or decrease the `block_process_limit`
             based on congestion algorithm
         """

--- a/safe_transaction_service/history/indexers/events_indexer.py
+++ b/safe_transaction_service/history/indexers/events_indexer.py
@@ -98,10 +98,10 @@ class EventsIndexer(EthereumIndexer):
                 for single_parameters in multiple_parameters
             ]
             _ = gevent.joinall(jobs)
-            events = []
+            log_receipts = []
             for job in jobs:
-                events.extend(job.get())
-            return events
+                log_receipts.extend(job.get())
+            return log_receipts
         else:
             return self.ethereum_client.slow_w3.eth.get_logs(parameters)
 
@@ -177,12 +177,12 @@ class EventsIndexer(EthereumIndexer):
             addresses, from_block_number, to_block_number
         )
 
-        len_events = len(log_receipts)
-        logger_fn = logger.info if len_events else logger.debug
+        len_log_receipts = len(log_receipts)
+        logger_fn = logger.info if len_log_receipts else logger.debug
         logger_fn(
             "%s: Found %d events from block-number=%d to block-number=%d for %d addresses: %s",
             self.__class__.__name__,
-            len_events,
+            len_log_receipts,
             from_block_number,
             to_block_number,
             len_addresses,

--- a/safe_transaction_service/history/indexers/events_indexer.py
+++ b/safe_transaction_service/history/indexers/events_indexer.py
@@ -80,7 +80,8 @@ class EventsIndexer(EthereumIndexer):
             "topics": [filter_topics],
         }
 
-        if not self.IGNORE_ADDRESSES_ON_LOG_FILTER:
+        if not self.IGNORE_ADDRESSES_ON_LOG_FILTER and addresses:
+            # Search logs only for the provided addresses
             parameters["address"] = addresses
 
         return self.ethereum_client.slow_w3.eth.get_logs(parameters)

--- a/safe_transaction_service/history/indexers/internal_tx_indexer.py
+++ b/safe_transaction_service/history/indexers/internal_tx_indexer.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from logging import getLogger
 from typing import Dict, Generator, Iterable, List, Optional, Sequence, Set
 
+from django.conf import settings
 from django.db import transaction
 
 from eth_typing import HexStr
@@ -26,9 +27,6 @@ class InternalTxIndexerProvider:
         if not hasattr(cls, "instance"):
             from django.conf import settings
 
-            block_process_limit: int = settings.ETH_INTERNAL_TXS_BLOCK_PROCESS_LIMIT
-            trace_txs_batch_size: int = settings.ETH_INTERNAL_TRACE_TXS_BATCH_SIZE
-            blocks_to_reindex_again = 6
             if settings.ETH_INTERNAL_NO_FILTER:
                 instance_class = InternalTxIndexerWithTraceBlock
             else:
@@ -36,9 +34,6 @@ class InternalTxIndexerProvider:
 
             cls.instance = instance_class(
                 EthereumClient(settings.ETHEREUM_TRACING_NODE_URL),
-                block_process_limit=block_process_limit,
-                blocks_to_reindex_again=blocks_to_reindex_again,
-                trace_txs_batch_size=trace_txs_batch_size,
             )
         return cls.instance
 
@@ -50,12 +45,17 @@ class InternalTxIndexerProvider:
 
 class InternalTxIndexer(EthereumIndexer):
     def __init__(self, *args, **kwargs):
-        self.tx_decoder = get_safe_tx_decoder()
-        self.number_trace_blocks = (
+        kwargs.setdefault(
+            "block_process_limit", settings.ETH_INTERNAL_TXS_BLOCK_PROCESS_LIMIT
+        )
+        kwargs.setdefault("blocks_to_reindex_again", 6)
+        super().__init__(*args, **kwargs)
+
+        self.trace_txs_batch_size: int = settings.ETH_INTERNAL_TRACE_TXS_BATCH_SIZE
+        self.number_trace_blocks: int = (
             10  # Use `trace_block` for last `number_trace_blocks` blocks indexing
         )
-        self.trace_txs_batch_size: int = kwargs.pop("trace_txs_batch_size")
-        super().__init__(*args, **kwargs)
+        self.tx_decoder = get_safe_tx_decoder()
 
     @property
     def database_field(self):


### PR DESCRIPTION
Prevent issues with nodes returning a maximum number of events, so some events are missed

- Get ERC20 events in parallel and using the address filter, instead of getting every erc20 event and checking if it is on our list of addresses.
- Refactor EventsIndexer
