### PR TITLE
Fix warnings in admin tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,6 @@
             "args": [
                 "--lf",
                 "-rxXs",
-                "--disable-warnings",
                 "${file}"
             ],
             "django": true,

--- a/safe_transaction_service/contracts/tests/test_admin.py
+++ b/safe_transaction_service/contracts/tests/test_admin.py
@@ -26,8 +26,11 @@ class TestContractAdmin(TestCase):
         cls.contract3 = ContractFactory.create(
             contract_abi=ContractAbiFactory.create(relevance=4)
         )
-        cls.contract_admin = ContractAdmin(Contract, site)
         cls.contracts = {cls.contract1, cls.contract2, cls.contract3}
+
+    def setUp(self) -> None:
+        self.contract_admin = ContractAdmin(Contract, site)
+        return super().setUp()
 
     def test_lookups(self) -> None:
         request = self.request_factory.get("/")

--- a/safe_transaction_service/tokens/tests/test_admin.py
+++ b/safe_transaction_service/tokens/tests/test_admin.py
@@ -16,13 +16,14 @@ class TestTokenAdmin(TestCase):
         cls.superuser = User.objects.create_superuser(
             "alfred", "alfred@example.com", "password"
         )
-
         cls.token1 = TokenFactory.create(logo=None)
         cls.token2 = TokenFactory.create()
         cls.token3 = TokenFactory.create()
-
-        cls.token_admin = TokenAdmin(Token, site)
         cls.tokens = {cls.token1, cls.token2, cls.token3}
+
+    def setUp(self) -> None:
+        self.token_admin = TokenAdmin(Token, site)
+        return super().setUp()
 
     def test_unfiltered_lookup(self) -> None:
         request = self.request_factory.get("/")


### PR DESCRIPTION
### What was wrong?

Some tests were producing avoidable warnings.

### How was it fixed?

I changed some initialisations in the admin tests to avoid the warnings.

@gnosis/safe-services
