### PR TITLE
Use ipfs.io as the default IPFS gateway

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -450,7 +450,7 @@ AWS_CONFIGURED = bool(
 )
 
 ETHERSCAN_API_KEY = env("ETHERSCAN_API_KEY", default=None)
-IPFS_GATEWAY = env("IPFS_GATEWAY", default="https://cloudflare-ipfs.com/ipfs/")
+IPFS_GATEWAY = env("IPFS_GATEWAY", default="https://ipfs.io/ipfs/")
 
 SWAGGER_SETTINGS = {
     "SECURITY_DEFINITIONS": {

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -180,7 +180,7 @@ class CollectiblesService:
 
         try:
             logger.debug("Getting metadata for uri=%s", uri)
-            with requests.get(uri, timeout=10, stream=True) as response:
+            with requests.get(uri, timeout=15, stream=True) as response:
                 if not response.ok:
                     logger.debug("Cannot get metadata for uri=%s", uri)
                     raise MetadataRetrievalException(uri)

--- a/safe_transaction_service/history/tests/test_collectibles_service.py
+++ b/safe_transaction_service/history/tests/test_collectibles_service.py
@@ -399,15 +399,7 @@ class TestCollectiblesService(EthereumTestCaseMixin, TestCase):
             "image": "https://ipfs.io/ipfs/QmXKU5RBTrGaYn5M1iWQaeKuCKV34g417YDGN5Yh7Uxk4i",
         }
 
-        try:
-            self.assertEqual(
-                collectibles_service._retrieve_metadata_from_uri(ipfs_address),
-                expected_object,
-            )
-        except MetadataRetrievalException:
-            # Test a different IPFS provider
-            with self.settings(IPFS_GATEWAY="https://ipfs.io/ipfs/"):
-                self.assertEqual(
-                    collectibles_service._retrieve_metadata_from_uri(ipfs_address),
-                    expected_object,
-                )
+        self.assertEqual(
+            collectibles_service._retrieve_metadata_from_uri(ipfs_address),
+            expected_object,
+        )


### PR DESCRIPTION
- Increase timeout from 10 -> 15 seconds
- Remove ipfs.io as secondary IPFS for tests