### PR TITLE
add klaytn network

### DIFF
--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -286,6 +286,12 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 93204, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 93168, "1.3.0"),
     ],
+    EthereumNetwork.KLAYTN_TESTNET: [
+        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 93821635, "1.3.0"),
+    ],
+    EthereumNetwork.KLAYTN_MAINNET: [
+        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 93507490, "1.3.0"),
+    ],
 }
 
 PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
@@ -409,6 +415,12 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     ],
     EthereumNetwork.GODWOKEN_TESTNET: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93108),  # v1.3.0
+    ],
+    EthereumNetwork.KLAYTN_TESTNET: [
+        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93821613), # v1.3.0
+    ],
+     EthereumNetwork.KLAYTN_MAINNET: [
+        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93506870),  # v1.3.0
     ],
 }
 

--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -417,9 +417,9 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93108),  # v1.3.0
     ],
     EthereumNetwork.KLAY_BAOBAB: [
-        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93821613), # v1.3.0
+        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93821613),  # v1.3.0
     ],
-     EthereumNetwork.KLAY_CYPRESS: [
+    EthereumNetwork.KLAY_CYPRESS: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93506870),  # v1.3.0
     ],
 }

--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -286,11 +286,11 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 93204, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 93168, "1.3.0"),
     ],
-    EthereumNetwork.KLAYTN_TESTNET: [
-        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 93821635, "1.3.0"),
+    EthereumNetwork.KLAY_BAOBAB: [
+        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 93821635, "1.3.0+L2"),
     ],
-    EthereumNetwork.KLAYTN_MAINNET: [
-        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 93507490, "1.3.0"),
+    EthereumNetwork.KLAY_CYPRESS: [
+        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 93507490, "1.3.0+L2"),
     ],
 }
 
@@ -416,10 +416,10 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     EthereumNetwork.GODWOKEN_TESTNET: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93108),  # v1.3.0
     ],
-    EthereumNetwork.KLAYTN_TESTNET: [
+    EthereumNetwork.KLAY_BAOBAB: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93821613), # v1.3.0
     ],
-     EthereumNetwork.KLAYTN_MAINNET: [
+     EthereumNetwork.KLAY_CYPRESS: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93506870),  # v1.3.0
     ],
 }


### PR DESCRIPTION
### What was wrong?

Missing safe contract addresses for Klaytn network

### How was it fixed?

Added safe contract addresses for Klaytn Mainnet and Testnet

Ref: 
**Safe address :** 
Baobab Testnet : [0xfb1bffC9d739B8D520DaF37dF666da4C687191EA](https://baobab.scope.klaytn.com/account/0xfb1bffC9d739B8D520DaF37dF666da4C687191EA?tabId=internalTx)
Cypress Mainnet : [0xfb1bffC9d739B8D520DaF37dF666da4C687191EA](https://scope.klaytn.com/account/0xfb1bffC9d739B8D520DaF37dF666da4C687191EA?tabId=internalTx)

**Proxy Factory :** 
Baobab Testnet : [0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC](https://baobab.scope.klaytn.com/account/0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC?tabId=internalTx)
Cypress Mainnet : [0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC](https://scope.klaytn.com/account/0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC?tabId=internalTx)

https://github.com/safe-global/safe-deployments/pull/95
