### PR TITLE
Set 5000 addresses as default for calling `eth_getLogs`

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -367,7 +367,7 @@ REDIS_URL = env("REDIS_URL", default="redis://localhost:6379/0")
 ETHEREUM_NODE_URL = env("ETHEREUM_NODE_URL", default=None)
 ETHEREUM_TRACING_NODE_URL = env("ETHEREUM_TRACING_NODE_URL", default=None)
 ETH_INTERNAL_TXS_BLOCK_PROCESS_LIMIT = env.int(
-    "ETH_INTERNAL_TXS_BLOCK_PROCESS_LIMIT", default=10000
+    "ETH_INTERNAL_TXS_BLOCK_PROCESS_LIMIT", default=10_000
 )
 ETH_INTERNAL_NO_FILTER = env.bool("ETH_INTERNAL_NO_FILTER", default=False)
 ETH_INTERNAL_TRACE_TXS_BATCH_SIZE = env.int(
@@ -383,8 +383,8 @@ ETH_EVENTS_BLOCK_PROCESS_LIMIT_MAX = env.int(
     "ETH_EVENTS_BLOCK_PROCESS_LIMIT_MAX", default=0
 )  # Maximum number of blocks to process together when searching for events. 0 == no limit.
 ETH_EVENTS_QUERY_CHUNK_SIZE = env.int(
-    "ETH_EVENTS_QUERY_CHUNK_SIZE", default=0
-)  # Number of addresses 'almost updated' to update together. 0 == no limit
+    "ETH_EVENTS_QUERY_CHUNK_SIZE", default=5_000
+)  # Number of addresses to use as `getLogs` parameter. `0 == no limit`. By testing `5000` looks like a good default
 ETH_EVENTS_UPDATED_BLOCK_BEHIND = env.int(
     "ETH_EVENTS_UPDATED_BLOCK_BEHIND", default=24 * 60 * 60 // 15
 )  # Number of blocks to consider an address 'almost updated'.

--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.6.0"
+__version__ = "4.6.1"
 __version_info__ = tuple(
     int(num) if num.isdigit() else num
     for num in __version__.replace("-", ".", 1).split(".")

--- a/safe_transaction_service/history/indexers/events_indexer.py
+++ b/safe_transaction_service/history/indexers/events_indexer.py
@@ -40,7 +40,9 @@ class EventsIndexer(EthereumIndexer):
         kwargs.setdefault(
             "blocks_to_reindex_again", 10
         )  # Reindex last 10 blocks every run of the indexer
-        kwargs.setdefault("query_chunk_size", settings.ETH_EVENTS_QUERY_CHUNK_SIZE)
+        kwargs.setdefault(
+            "query_chunk_size", settings.ETH_EVENTS_QUERY_CHUNK_SIZE
+        )  # Number of elements to process together when calling `eth_getLogs`
         kwargs.setdefault(
             "updated_blocks_behind", settings.ETH_EVENTS_UPDATED_BLOCK_BEHIND
         )  # For last x blocks, consider them almost updated and process them first


### PR DESCRIPTION
- 0 (no limit) was set by mistake and had to be modified on the deployment via envvar
