### PR TITLE
Fix CORS configuration

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -174,7 +174,8 @@ TEMPLATES = [
 
 
 # CORS
-CORS_ORIGIN_ALLOW_ALL = True
+# ------------------------------------------------------------------------------
+CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_HEADERS = list(default_cors_headers) + [
     "if-match",
     "if-modified-since",


### PR DESCRIPTION
- `CORS_ORIGIN_ALLOW_ALL` was renamed to `CORS_ALLOW_ALL_ORIGINS`
- More info: https://github.com/adamchainz/django-cors-headers
