### PR TITLE
Add milkomeda cardano testnet

### DIFF
--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -292,6 +292,10 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
     EthereumNetwork.KLAY_CYPRESS: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 93507490, "1.3.0+L2"),
     ],
+    EthereumNetwork.MILKOMEDA_C1_TESTNET: [
+        ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 5080339, "1.3.0+L2"),
+        ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 5080357, "1.3.0"),
+    ],
 }
 
 PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
@@ -421,6 +425,9 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     ],
     EthereumNetwork.KLAY_CYPRESS: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93506870),  # v1.3.0
+    ],
+    EthereumNetwork.MILKOMEDA_C1_TESTNET: [
+        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 5080303),  # v1.3.0
     ],
 }
 


### PR DESCRIPTION
### What was wrong?

Mikomeda Cardano testnet was missing

### How was it fixed?

Added Milkomeda Cardano testnet addresses from the safe-deployments repo (https://github.com/safe-global/safe-deployments/pull/97)