### PR TITLE
Disable index_erc20_events_out_of_sync_task scheduled task

### DIFF
--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -82,12 +82,6 @@ TASKS = [
         IntervalSchedule.SECONDS,
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.history.tasks.index_erc20_events_out_of_sync_task",
-        "Index out of sync ERC20/ERC721 Events",
-        5,
-        IntervalSchedule.MINUTES,
-    ),
-    CeleryTaskConfiguration(
         "safe_transaction_service.history.tasks.reindex_last_hours_task",
         "Reindex master copies for the last hours",
         110,


### PR DESCRIPTION
- This task was created when we were indexing Safe addresses one by one and some of them missed sync while others were syncing
- As we are indexing erc20 events in big batches, I think this task is not needed anymore and can only cause conflicts with the regular indexing task, as this task is called once every 5 minutes and has no limit on how many times can be spammed. It can always be called from manage.py
