### PR TITLE
Don't preload tx decoder

### DIFF
--- a/safe_transaction_service/history/apps.py
+++ b/safe_transaction_service/history/apps.py
@@ -1,5 +1,3 @@
-import sys
-
 from django.apps import AppConfig
 
 
@@ -9,14 +7,3 @@ class HistoryConfig(AppConfig):
 
     def ready(self):
         from . import signals  # noqa
-
-        for argument in sys.argv:
-            if "gunicorn" in argument:  # pragma: no cover
-                # Just run this on production
-                # TODO Find a better way
-                from safe_transaction_service.contracts.tx_decoder import (
-                    get_db_tx_decoder,
-                )
-
-                get_db_tx_decoder()  # Build tx decoder cache
-                break


### PR DESCRIPTION
- Previously it was needed, as loading tx decoder could take more than a minute
- With the current implementation it takes a few seconds, so only the first request will be delayed a little until it gets cached
