### PR TITLE
Add price calculation of milkomeda C1 tokens

### DIFF
--- a/safe_transaction_service/tokens/clients/binance_client.py
+++ b/safe_transaction_service/tokens/clients/binance_client.py
@@ -30,6 +30,9 @@ class BinanceClient:
     def get_bnb_usd_price(self) -> float:
         return self._get_price("BNBUSDT")
 
+    def get_ada_usd_price(self) -> float:
+        return self._get_price("ADAUSDT")
+
     def get_eth_usd_price(self) -> float:
         """
         :return: current USD price for Ethereum

--- a/safe_transaction_service/tokens/services/price_service.py
+++ b/safe_transaction_service/tokens/services/price_service.py
@@ -155,6 +155,9 @@ class PriceService:
     def get_aurora_usd_price(self) -> float:
         return self.coingecko_client.get_aoa_usd_price()
 
+    def get_cardano_usd_price(self) -> float:
+        return self.binance_client.get_ada_usd_price()
+
     def get_binance_usd_price(self) -> float:
         try:
             return self.binance_client.get_bnb_usd_price()
@@ -215,6 +218,11 @@ class PriceService:
             return self.coingecko_client.get_gather_usd_price()
         elif self.ethereum_network == EthereumNetwork.AVALANCHE:
             return self.get_avalanche_usd_price()
+        elif self.ethereum_network in (
+            EthereumNetwork.MILKOMEDA_C1_TESTNET,
+            EthereumNetwork.MILKOMEDA_C1_MAINNET,
+        ):
+            return self.get_cardano_usd_price()
         elif self.ethereum_network in (
             EthereumNetwork.AURORA,
             EthereumNetwork.AURORA_BETANET,

--- a/safe_transaction_service/tokens/tests/test_price_service.py
+++ b/safe_transaction_service/tokens/tests/test_price_service.py
@@ -118,6 +118,16 @@ class TestPriceService(TestCase):
             price_service.cache_eth_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 4.4)
 
+        # Milkomeda
+        with mock.patch.object(BinanceClient, "get_ada_usd_price", return_value=5.5):
+            price_service.ethereum_network = EthereumNetwork.MILKOMEDA_C1_TESTNET
+            price_service.cache_eth_price.clear()
+            self.assertEqual(price_service.get_native_coin_usd_price(), 5.5)
+
+            price_service.ethereum_network = EthereumNetwork.MILKOMEDA_C1_MAINNET
+            price_service.cache_eth_price.clear()
+            self.assertEqual(price_service.get_native_coin_usd_price(), 5.5)
+
     @mock.patch.object(CoingeckoClient, "get_bnb_usd_price", return_value=3.0)
     @mock.patch.object(BinanceClient, "get_bnb_usd_price", return_value=5.0)
     def test_get_binance_usd_price(


### PR DESCRIPTION
### What was wrong?

Milkomeda-wrapped Cardano tokens had incorrect prices on a custom network.

### How was it fixed?

Added Cardano pricing.