### PR TITLE
add venidium safe contracts

### DIFF
--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -278,6 +278,10 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 12845441, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 12845443, "1.3.0"),
     ],
+    EthereumNetwork.VENIDIUM: [
+        ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 1127191, "1.3.0+L2"),
+        ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 1127192, "1.3.0"),
+    ],
     EthereumNetwork.VENIDIUM_TESTNET: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 761243, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 761244, "1.3.0"),
@@ -417,6 +421,9 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     ],
     EthereumNetwork.EURUS_TESTNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 12845425),  # v1.3.0
+    ],
+    EthereumNetwork.VENIDIUM: [
+        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 1127130),  # v1.3.0
     ],
     EthereumNetwork.VENIDIUM_TESTNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 761231),  # v1.3.0


### PR DESCRIPTION
### What was wrong?

Missing safe contract addresses for Venidium Mainnet network

### How was it fixed?

updated [setup_service.py](https://github.com/safe-global/safe-transaction-service/compare/master...Venidium-Network:safe-transaction-service:master#diff-2fe58867936fddcf0364a8394de2efbd6dc48c4a19b34787112191a67f5b1e63)

@gnosis/safe-services
