### PR TITLE
Move django-extensions from requirements-dev to requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 -r requirements-test.txt
-django-extensions
 flake8
 ipdb
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-db-geventpool==4.0.1
 django-debug-toolbar
 django-debug-toolbar-force
 django-environ==0.9.0
+django-extensions==3.2.0
 django-filter==22.1
 django-imagekit==4.1.0
 django-model-utils==4.2.0


### PR DESCRIPTION
- It has very useful commands, like shell_plus
- Closes #1028
