### PR TITLE
Fix cronos mainnet address

### DIFF
--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -313,7 +313,7 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 3290835, "1.3.0"),
     ],
     EthereumNetwork.CRONOS_MAINNET: [
-        ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 1395140, "1.3.0+L2"),
+        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 3002268, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 3002760, "1.3.0"),
     ],
 }


### PR DESCRIPTION
### What was wrong?

The cronos mainnet address for v1.3.0 l2 was not right. 
Check out the address in safe deployments: https://github.com/safe-global/safe-deployments/pull/93/files
