### PR TITLE
Auto adjust block limit for every RPC query

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.8.0"
+__version__ = "4.8.1"
 __version_info__ = tuple(
     int(num) if num.isdigit() else num
     for num in __version__.replace("-", ".", 1).split(".")

--- a/safe_transaction_service/history/indexers/events_indexer.py
+++ b/safe_transaction_service/history/indexers/events_indexer.py
@@ -94,15 +94,18 @@ class EventsIndexer(EthereumIndexer):
                 for addresses_chunk in addresses_chunks
             ]
 
-            return [
-                event
-                for single_parameters in multiple_parameters
-                for event in self.ethereum_client.slow_w3.eth.get_logs(
-                    single_parameters
-                )
-            ]
+            log_receipts = []
+
+            for single_parameters in multiple_parameters:
+                with self.auto_adjust_block_limit(from_block_number, to_block_number):
+                    log_receipts.extend(
+                        self.ethereum_client.slow_w3.eth.get_logs(single_parameters)
+                    )
+
+            return log_receipts
         else:
-            return self.ethereum_client.slow_w3.eth.get_logs(parameters)
+            with self.auto_adjust_block_limit(from_block_number, to_block_number):
+                return self.ethereum_client.slow_w3.eth.get_logs(parameters)
 
     def _find_elements_using_topics(
         self,

--- a/safe_transaction_service/history/tests/test_internal_tx_indexer.py
+++ b/safe_transaction_service/history/tests/test_internal_tx_indexer.py
@@ -229,9 +229,6 @@ class TestInternalTxIndexer(TestCase):
         elements = internal_tx_indexer.find_relevant_elements(
             addresses, current_block_number - 50, current_block_number
         )
-        print(trace_filter_transactions | trace_block_transactions)
-        print()
-        print(elements)
         self.assertEqual(trace_filter_transactions | trace_block_transactions, elements)
         trace_filter_mock.assert_called_once_with(
             internal_tx_indexer.ethereum_client.parity,


### PR DESCRIPTION
Previously all RPC queries together were taken into account, so if there were a lot of queries even if the RPC was fast block process limit was not increased (or even decreased)
