### PR TITLE
Adjust defaults for indexer

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -385,8 +385,8 @@ ETH_EVENTS_BLOCK_PROCESS_LIMIT_MAX = env.int(
     "ETH_EVENTS_BLOCK_PROCESS_LIMIT_MAX", default=0
 )  # Maximum number of blocks to process together when searching for events. 0 == no limit.
 ETH_EVENTS_QUERY_CHUNK_SIZE = env.int(
-    "ETH_EVENTS_QUERY_CHUNK_SIZE", default=5_000
-)  # Number of addresses to use as `getLogs` parameter. `0 == no limit`. By testing `5000` looks like a good default
+    "ETH_EVENTS_QUERY_CHUNK_SIZE", default=1_000
+)  # Number of addresses to use as `getLogs` parameter. `0 == no limit`. By testing `1_000` looks like a good default
 ETH_EVENTS_UPDATED_BLOCK_BEHIND = env.int(
     "ETH_EVENTS_UPDATED_BLOCK_BEHIND", default=24 * 60 * 60 // 15
 )  # Number of blocks to consider an address 'almost updated'.

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -38,14 +38,14 @@ class EthereumIndexer(ABC):
         block_process_limit_max: int = 0,
         blocks_to_reindex_again: int = 0,
         updated_blocks_behind: int = 20,
-        query_chunk_size: Optional[int] = 5000,
+        query_chunk_size: Optional[int] = 1_000,
         block_auto_process_limit: bool = True,
     ):
         """
         :param ethereum_client:
         :param confirmations: Don't index last `confirmations` blocks to prevent from reorgs
         :param block_process_limit: Number of blocks to scan at a time for relevant data. `0` == `No limit`
-        :param block_process_limit: Maximum bumber of blocks to scan at a time for relevant data. `0` == `No limit`
+        :param block_process_limit_max: Maximum bumber of blocks to scan at a time for relevant data. `0` == `No limit`
         :param blocks_to_reindex_again: Number of blocks to reindex every time the indexer runs, in case something
             was missed.
         :param updated_blocks_behind: Number of blocks scanned for an address that can be behind and
@@ -294,14 +294,14 @@ class EthereumIndexer(ABC):
                     self.__class__.__name__,
                     self.block_process_limit,
                 )
-            elif delta < 1:
+            elif delta < 2:
                 self.block_process_limit *= 2
                 logger.info(
                     "%s: block_process_limit duplicated to %d",
                     self.__class__.__name__,
                     self.block_process_limit,
                 )
-            elif delta < 3:
+            elif delta < 5:
                 self.block_process_limit += 20
                 logger.info(
                     "%s: block_process_limit increased to %d",


### PR DESCRIPTION
- Make block process limit adjustment more optimistic (increase faster)
- By default query ERC20 transfers by batches of 1,000 instead of 5,000 (some networks cannot handle 5,000, and it can always be adjusted by envar)
