### PR TITLE
Implement ERC20 indexing status endpoint

### DIFF
--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -599,6 +599,12 @@ class SafeMultisigTransactionResponseSerializer(SafeMultisigTxSerializerV1):
             )
 
 
+class ERC20IndexingSerializer(serializers.Serializer):
+    current_block_number = serializers.IntegerField()
+    minimum_indexed_block_number = serializers.IntegerField()
+    synced = serializers.BooleanField()
+
+
 class Erc20InfoSerializer(serializers.Serializer):
     name = serializers.CharField()
     symbol = serializers.CharField()

--- a/safe_transaction_service/history/urls.py
+++ b/safe_transaction_service/history/urls.py
@@ -20,6 +20,11 @@ urlpatterns = [
         "about/master-copies/", views.MasterCopiesView.as_view(), name="master-copies"
     ),
     path(
+        "about/erc20-indexing/",
+        views.ERC20IndexingView.as_view(),
+        name="erc20-indexing",
+    ),
+    path(
         "analytics/multisig-transactions/by-safe/",
         views.AnalyticsMultisigTxsBySafeListView.as_view(),
         name="analytics-multisig-txs-by-safe",


### PR DESCRIPTION
Add a new endpoint `api/v1/about/erc20-indexing` that returns information about the ERC20 indexing status. Response will be:

```json
{
    "current_block_number": "<str>",
    "minimum_indexed_block_number": "<int>",
    "synced": "<bool>",
}
```

- `current_block_number`: Current RPC block number.
- `minimum_indexed_block_number`: Block number for the less synced Safe (the one with the minimum indexed block number)
- `synced`: `True` if service is considered synced, `False` otherwise. Service will be considered `synced` if `minimum_indexed_block_number` is at least `ETH_REORG_BLOCKS` behind the `current_block`