### PR TITLE
Collectibles cache invalidation

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -230,6 +230,10 @@ CELERY_BROKER_TRANSPORT_OPTIONS = {}
 CELERY_ROUTES = (
     [
         (
+            "safe_transaction_service.history.tasks.retry_get_metadata_task",
+            {"queue": "tokens"},
+        ),
+        (
             "safe_transaction_service.history.tasks.send_webhook_task",
             {"queue": "webhooks"},
         ),
@@ -237,10 +241,6 @@ CELERY_ROUTES = (
         ("safe_transaction_service.contracts.tasks.*", {"queue": "contracts"}),
         ("safe_transaction_service.notifications.tasks.*", {"queue": "notifications"}),
         ("safe_transaction_service.tokens.tasks.*", {"queue": "tokens"}),
-        (
-            "safe_transaction_service.history.tasks.retry_get_metadata_task",
-            {"queue": "tokens"},
-        ),
     ],
 )
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -237,6 +237,10 @@ CELERY_ROUTES = (
         ("safe_transaction_service.contracts.tasks.*", {"queue": "contracts"}),
         ("safe_transaction_service.notifications.tasks.*", {"queue": "notifications"}),
         ("safe_transaction_service.tokens.tasks.*", {"queue": "tokens"}),
+        (
+            "safe_transaction_service.history.tasks.retry_get_metadata_task",
+            {"queue": "tokens"},
+        ),
     ],
 )
 

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -162,7 +162,7 @@ class CollectiblesService:
 
     @cachedmethod(cache=operator.attrgetter("cache_uri_metadata"))
     @cache_memoize(
-        60 * 60 * 24,
+        60 * 60 * 24 * 2,
         prefix="collectibles-_retrieve_metadata_from_uri",
         cache_exceptions=(MetadataRetrievalException,),
     )  # 1 day

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -162,7 +162,7 @@ class CollectiblesService:
         self.ens_service: EnsClient = EnsClient(self.ethereum_network.value)
 
         self.cache_uri_metadata = TTLCache[str, Optional[Dict[str, Any]]](
-            maxsize=4096, ttl=self.COLLECTIBLE_EXPRIATION
+            maxsize=4096, ttl=self.COLLECTIBLE_EXPIRATION
         )  # 1 day of caching
         self.cache_token_info: TTLCache[ChecksumAddress, Erc721InfoWithLogo] = TTLCache(
             maxsize=4096, ttl=60 * 30
@@ -431,7 +431,7 @@ class CollectiblesService:
                 )
                 retry_get_metadata_task.apply_async(
                     kwargs={"address": collectible.address, "id": collectible.id},
-                    countdown=5,
+                    countdown=30,  # 30 seconds later
                 )
 
             collectible_with_metadata = CollectibleWithMetadata(
@@ -599,7 +599,7 @@ class CollectiblesService:
             }
             pipe.mset(redis_map_to_store)
             for key in redis_map_to_store.keys():
-                pipe.expire(key, self.COLLECTIBLE_EXPRIATION)  # 1 day of caching
+                pipe.expire(key, self.COLLECTIBLE_EXPIRATION)  # 1 day of caching
             pipe.execute()
             found_uris.update(blockchain_token_uris)
 

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -599,7 +599,7 @@ class CollectiblesService:
             }
             pipe.mset(redis_map_to_store)
             for key in redis_map_to_store.keys():
-                pipe.expire(key, self.COLLECTIBLE_EXPIRATION)  # 1 day of caching
+                pipe.expire(key, self.COLLECTIBLE_EXPIRATION)
             pipe.execute()
             found_uris.update(blockchain_token_uris)
 

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -452,13 +452,11 @@ class CollectiblesService:
         redis_pipe.execute()
 
         # Creates a collectibles metadata keeping the initial order
-        collectibles_no_cached_index = 0
         for collectible_metadata_cached_index in range(len(collectibles_with_metadata)):
             if collectibles_with_metadata[collectible_metadata_cached_index] is None:
                 collectibles_with_metadata[
                     collectible_metadata_cached_index
-                ] = collectibles_with_metadata_not_cached[collectibles_no_cached_index]
-                collectibles_no_cached_index += 1
+                ] = collectibles_with_metadata_not_cached.pop(0)
 
         return collectibles_with_metadata, count
 

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -154,7 +154,7 @@ class CollectiblesService:
     COLLECTIBLE_EXPIRATION = int(
         60 * 60 * 24 * 2
     )  # Keep collectibles by 2 days in cache
-    TOKEN_EXPIRATION = int(60 * 30)
+    TOKEN_EXPIRATION = int(60 * 60)
 
     def __init__(self, ethereum_client: EthereumClient, redis: Redis):
         self.ethereum_client = ethereum_client
@@ -224,6 +224,13 @@ class CollectiblesService:
         token_id: int,
         token_metadata_uri: Optional[str],
     ) -> Collectible:
+        """
+        Build a collectible from the input parameters
+        :param token_info: information of collectible like name, symbol...
+        :param token_address:
+        :param token_id:
+        :param token_metadata_uri:
+        """
         if not token_metadata_uri:
             if token_address in CRYPTO_KITTIES_CONTRACT_ADDRESSES:
                 token_metadata_uri = f"https://api.cryptokitties.co/kitties/{token_id}"
@@ -241,6 +248,10 @@ class CollectiblesService:
         )
 
     def get_metadata(self, collectible: Collectible) -> Any:
+        """
+        Return metadata for a collectible
+        :param collectible
+        """
         if tld := ENS_CONTRACTS_WITH_TLD.get(
             collectible.address
         ):  # Special case for ENS

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -496,7 +496,7 @@ def send_webhook_task(address: Optional[str], payload: Dict[str, Any]) -> int:
     autoretry_for=(MetadataRetrievalExceptionTimeout,),
     time_limit=LOCK_TIMEOUT,
     retry_backoff=3,
-    retry_kwargs={"max_retries": 3},
+    retry_kwargs={"max_retries": 4},
 )
 def retry_get_metadata_task(self, address: str, id: int) -> bool:
     """

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -495,8 +495,8 @@ def send_webhook_task(address: Optional[str], payload: Dict[str, Any]) -> int:
     soft_time_limit=SOFT_TIMEOUT,
     autoretry_for=(MetadataRetrievalExceptionTimeout,),
     time_limit=LOCK_TIMEOUT,
-    retry_backoff=5,
-    retry_kwargs={"max_retries": 5},
+    retry_backoff=3,
+    retry_kwargs={"max_retries": 3},
 )
 def retry_get_metadata_task(self, address: str, id: int) -> bool:
     """

--- a/safe_transaction_service/history/tests/test_collectibles_service.py
+++ b/safe_transaction_service/history/tests/test_collectibles_service.py
@@ -246,6 +246,9 @@ class TestCollectiblesService(EthereumTestCaseMixin, TestCase):
             "image": "http://random-address.org/logo-28.png",
         }
         get_metadata_mock.return_value = metadata
+        # collectible cached by address + id
+        collectible.id = collectible.id + 1
+        get_collectibles_mock.return_value = [collectible], 0
         collectible_with_metadata = CollectibleWithMetadata(
             collectible.token_name,
             collectible.token_symbol,
@@ -261,6 +264,7 @@ class TestCollectiblesService(EthereumTestCaseMixin, TestCase):
             collectible_with_metadata.image_uri, "http://random-address.org/logo-28.png"
         )
         expected = [collectible_with_metadata]
+
         self.assertListEqual(
             collectibles_service.get_collectibles_with_metadata(safe_address),
             expected,

--- a/safe_transaction_service/history/tests/test_collectibles_service.py
+++ b/safe_transaction_service/history/tests/test_collectibles_service.py
@@ -247,7 +247,7 @@ class TestCollectiblesService(EthereumTestCaseMixin, TestCase):
         }
         get_metadata_mock.return_value = metadata
         # collectible cached by address + id
-        collectible.id = collectible.id + 1
+        collectible.id +=  1
         get_collectibles_mock.return_value = [collectible], 0
         collectible_with_metadata = CollectibleWithMetadata(
             collectible.token_name,

--- a/safe_transaction_service/history/tests/test_collectibles_service.py
+++ b/safe_transaction_service/history/tests/test_collectibles_service.py
@@ -247,7 +247,7 @@ class TestCollectiblesService(EthereumTestCaseMixin, TestCase):
         }
         get_metadata_mock.return_value = metadata
         # collectible cached by address + id
-        collectible.id +=  1
+        collectible.id += 1
         get_collectibles_mock.return_value = [collectible], 0
         collectible_with_metadata = CollectibleWithMetadata(
             collectible.token_name,

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
@@ -10,8 +11,10 @@ from eth_account import Account
 
 from gnosis.eth import EthereumClient, EthereumNetwork
 
+from ...utils.redis import get_redis
 from ..models import SafeContract, SafeLastStatus, SafeStatus
-from ..services import IndexService
+from ..services import CollectiblesService, CollectiblesServiceProvider, IndexService
+from ..services.collectibles_service import CollectibleWithMetadata
 from ..tasks import (
     check_reorgs_task,
     check_sync_status_task,
@@ -27,6 +30,7 @@ from ..tasks import (
     process_decoded_internal_txs_for_safe_task,
     process_decoded_internal_txs_task,
     reindex_last_hours_task,
+    retry_get_metadata_task,
 )
 from .factories import (
     ERC20TransferFactory,
@@ -193,3 +197,41 @@ class TestTasks(TestCase):
                         f"Safe-address={safe_address} Processing traces again after reindexing",
                         cm.output[5],
                     )
+
+    @patch.object(CollectiblesService, "get_metadata", autospec=True)
+    def test_retry_get_metadata_task(self, get_metadata_mock: MagicMock):
+        collectible_address = Account.create().address
+        collectible_id = 16
+
+        self.assertEqual(
+            retry_get_metadata_task(collectible_address, collectible_id), None
+        )
+
+        metadata = {
+            "name": "Octopus",
+            "description": "Atlantic Octopus",
+            "image": "http://random-address.org/logo-28.png",
+        }
+        get_metadata_mock.return_value = metadata
+        expected = CollectibleWithMetadata(
+            "Octopus",
+            "OCT",
+            "http://random-address.org/logo.png",
+            collectible_address,
+            collectible_id,
+            "http://random-address.org/info-28.json",
+            metadata,
+        )
+        redis = get_redis()
+        collectibles_service = CollectiblesServiceProvider()
+        redis.set(
+            collectibles_service.get_redis_metadata_key(
+                collectible_address, collectible_id
+            ),
+            json.dumps(expected.__dict__),
+            300,
+        )
+
+        self.assertEqual(
+            retry_get_metadata_task(collectible_address, collectible_id), expected
+        )


### PR DESCRIPTION
Closes #1027 
- Remove cache_memoize
- The task execution is delayed 30 seconds
- The retry_backoff is configured to 60 seconds and 4 retries as maximum , the retries is going to happen like following:
  - first try at 30 seconds
  - second try at 60 seconds
  - third try at 120 secs
  - fourth try at 240.
  - fifth try at 480 secs
