### PR TITLE
Detect reindexed transactions out of order

### DIFF
--- a/safe_transaction_service/history/management/commands/check_index_problems.py
+++ b/safe_transaction_service/history/management/commands/check_index_problems.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from gnosis.eth import EthereumClient
@@ -33,6 +34,10 @@ class Command(BaseCommand):
         force_batch_call = options["force_batch_call"]
 
         queryset = SafeLastStatus.objects.all()
+        if settings.ETH_L2_NETWORK:
+            # Filter nonce=0 to exclude not initialized or non L2 Safes in a L2 network
+            queryset = queryset.exclude(nonce=0)
+
         count = queryset.count()
         batch = 1000
         index_service = IndexServiceProvider()


### PR DESCRIPTION
- Previously, if a transaction was reindexed after others were processed for a Safe, it could be processed out of order
- Also a flag was added to prevent checking non L2 Safes on L2 networks on `check_index_problems`
