### PR TITLE
Reduce number of errors when can't get metadata

### DIFF
--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -1,6 +1,7 @@
 import contextlib
 import dataclasses
 import json
+import random
 from functools import cache
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
@@ -494,10 +495,8 @@ def send_webhook_task(address: Optional[str], payload: Dict[str, Any]) -> int:
 
 @app.shared_task(
     soft_time_limit=SOFT_TIMEOUT,
-    autoretry_for=(MetadataRetrievalExceptionTimeout,),
     time_limit=LOCK_TIMEOUT,
-    retry_backoff=60,
-    retry_kwargs={"max_retries": 4},
+    max_retries=4,
 )
 def retry_get_metadata_task(
     address: ChecksumAddress, token_id: int
@@ -534,25 +533,42 @@ def retry_get_metadata_task(
 
     # Maybe other task already retrieved the metadata
     cached_metadata = collectible_with_metadata_cached["metadata"]
-    metadata = (
-        cached_metadata
-        if cached_metadata
-        else collectibles_service.get_metadata(collectible)
-    )
-    collectible_with_metadata = CollectibleWithMetadata(
-        collectible.token_name,
-        collectible.token_symbol,
-        collectible.logo_uri,
-        collectible.address,
-        collectible.id,
-        collectible.uri,
-        metadata,
-    )
-
-    redis.set(
-        redis_key,
-        json.dumps(dataclasses.asdict(collectible_with_metadata)),
-        collectibles_service.COLLECTIBLE_EXPIRATION,
-    )
-
+    try:
+        metadata = (
+            cached_metadata
+            if cached_metadata
+            else collectibles_service.get_metadata(collectible)
+        )
+        collectible_with_metadata = CollectibleWithMetadata(
+            collectible.token_name,
+            collectible.token_symbol,
+            collectible.logo_uri,
+            collectible.address,
+            collectible.id,
+            collectible.uri,
+            metadata,
+        )
+        redis.set(
+            redis_key,
+            json.dumps(dataclasses.asdict(collectible_with_metadata)),
+            collectibles_service.COLLECTIBLE_EXPIRATION,
+        )
+    except MetadataRetrievalExceptionTimeout:
+        # Random avoid to run all tasks at the same time
+        if (
+            retry_get_metadata_task.request.retries
+            < retry_get_metadata_task.max_retries
+        ):
+            retry_get_metadata_task.retry(
+                countdown=int(
+                    random.uniform(55, 65) * retry_get_metadata_task.request.retries
+                )
+            )
+        else:
+            logger.debug(
+                "Cannot get the metadata from %s after %i retries",
+                collectible.uri,
+                retry_get_metadata_task.request.retries,
+            )
+        return None
     return collectible_with_metadata

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -566,7 +566,7 @@ def retry_get_metadata_task(
             )
         else:
             logger.debug(
-                "Cannot get the metadata from %s after %i retries",
+                "Timeout when getting metadata from %s after %i retries ",
                 collectible.uri,
                 retry_get_metadata_task.request.retries,
             )


### PR DESCRIPTION
Closes #1136 

### How was it fixed? 🎯
- catch the exception
- implements a custom backoff retry 
- write a log message only when all retries were consumed
- the task finish always successfully

