### PR TITLE
Remove tokens blockchain retrieval on 404

### DIFF
--- a/safe_transaction_service/tokens/tasks.py
+++ b/safe_transaction_service/tokens/tasks.py
@@ -111,21 +111,3 @@ def fix_pool_tokens_task() -> Optional[int]:
         if number:
             logger.info("%d pool token names were fixed", number)
         return number
-
-
-@app.shared_task()
-@close_gevent_db_connection_decorator
-def get_token_info_from_blockchain_task(token_address: ChecksumAddress) -> bool:
-    """
-    Retrieve token information from blockchain
-
-    :param token_address:
-    :return: `True` if found, `False` otherwise
-    """
-    redis = get_redis()
-    key = f"token-task:{token_address}"
-    if result := redis.get(key):
-        return bool(int(result))
-    token_found = bool(Token.objects.create_from_blockchain(token_address))
-    redis.setex(key, 60 * 60 * 6, int(token_found))  # Cache result 6 hours
-    return token_found

--- a/safe_transaction_service/tokens/tests/test_views.py
+++ b/safe_transaction_service/tokens/tests/test_views.py
@@ -10,7 +10,7 @@ from rest_framework import status
 from rest_framework.exceptions import ErrorDetail
 from rest_framework.test import APITestCase
 
-from gnosis.eth.ethereum_client import Erc20Info, Erc20Manager, InvalidERC20Info
+from gnosis.eth.ethereum_client import Erc20Manager, InvalidERC20Info
 from gnosis.safe.tests.safe_test_case import SafeTestCaseMixin
 
 from ..clients import CannotGetPrice
@@ -75,16 +75,9 @@ class TestTokenViews(SafeTestCaseMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(Token.objects.count(), 0)
 
-        random_address = Account.create().address  # Use new address to skip caching
-        get_token_info_mock.side_effect = None
-        get_token_info_mock.return_value = Erc20Info("UXIO", "UXI", 18)
         response = self.client.get(reverse("v1:tokens:detail", args=(random_address,)))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(Token.objects.count(), 1)
-
-        response = self.client.get(reverse("v1:tokens:detail", args=(random_address,)))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(Token.objects.count(), 1)
+        self.assertEqual(Token.objects.count(), 0)
 
     def test_tokens_view(self):
         response = self.client.get(reverse("v1:tokens:list"))

--- a/safe_transaction_service/tokens/views.py
+++ b/safe_transaction_service/tokens/views.py
@@ -22,7 +22,7 @@ class TokenView(RetrieveAPIView):
     lookup_field = "address"
     queryset = Token.objects.all()
 
-    @method_decorator(cache_page(60 * 60))  # Cache 1 hour, this should never change
+    @method_decorator(cache_page(60 * 60))  # Cache 1 hour, this does not change often
     def get(self, request, *args, **kwargs):
         address = self.kwargs["address"]
         if not fast_is_checksum_address(address):

--- a/safe_transaction_service/tokens/views.py
+++ b/safe_transaction_service/tokens/views.py
@@ -1,4 +1,3 @@
-from django.http import Http404
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
@@ -16,7 +15,6 @@ from . import filters, serializers
 from .clients import CannotGetPrice
 from .models import Token
 from .services import PriceServiceProvider
-from .tasks import get_token_info_from_blockchain_task
 
 
 class TokenView(RetrieveAPIView):
@@ -37,11 +35,7 @@ class TokenView(RetrieveAPIView):
                 },
             )
 
-        try:
-            return super().get(request, *args, **kwargs)
-        except Http404 as exc:  # Try to get info about the token
-            get_token_info_from_blockchain_task.delay(address)
-            raise exc
+        return super().get(request, *args, **kwargs)
 
 
 class TokensView(ListAPIView):


### PR DESCRIPTION
- [X] You ran `./run_tests.sh`
- [X] You ran `pre-commit run -a`

### What was wrong? 👾
Since tokens are indexed through an scheduled process, there's no need to make ad-hoc costly calls to the blockchain. This PR removes that functionality, so when a unknown token is requested, the service just responds 404 and does no further tasks.

Closes #

### How was it fixed? 🎯
I removed both the task and the unit tests which covered it.
