### PR TITLE
Bump safe-eth-py from 4.7.0 to 4.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,5 @@ psycogreen==1.0.2
 psycopg2==2.9.5
 redis==4.3.4
 requests==2.28.1
-safe-eth-py[django]==4.7.0
+safe-eth-py[django]==4.7.1
 web3==5.31.1


### PR DESCRIPTION
# Release notes
https://github.com/safe-global/safe-eth-py/releases/tag/v4.7.1