### PR TITLE
Limit v1 collectibles endpoint to 50

### DIFF
--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -478,14 +478,15 @@ class CollectiblesService:
         exclude_spam: bool = False,
     ) -> List[CollectibleWithMetadata]:
         """
-         Get collectibles v1 returns no paginated response
+        Get collectibles v1 returns no paginated response
+
         :param safe_address:
         :param only_trusted: If True, return balance only for trusted tokens
         :param exclude_spam: If True, exclude spam tokens
         :return: collectibles
         """
         collectibles, _ = self._get_collectibles_with_metadata(
-            safe_address, only_trusted, exclude_spam
+            safe_address, only_trusted, exclude_spam, limit=50, offset=0
         )
         return collectibles
 
@@ -508,7 +509,7 @@ class CollectiblesService:
         :return: collectibles and count
         """
         return self._get_collectibles_with_metadata(
-            safe_address, only_trusted, exclude_spam, limit, offset
+            safe_address, only_trusted, exclude_spam, limit=limit, offset=offset
         )
 
     @cachedmethod(cache=operator.attrgetter("cache_token_info"))

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -509,7 +509,7 @@ class SafeMultisigTransactionDeprecatedListView(SafeMultisigTransactionListView)
         return super().post(*args, **kwargs)
 
 
-def swagger_safe_balance_schema(serializer_class):
+def swagger_safe_balance_schema(serializer_class, deprecated: bool = False):
     _schema_token_trusted_param = openapi.Parameter(
         "trusted",
         openapi.IN_QUERY,
@@ -534,6 +534,7 @@ def swagger_safe_balance_schema(serializer_class):
             _schema_token_trusted_param,
             _schema_token_exclude_spam_param,
         ],
+        deprecated=deprecated,
     )
 
 
@@ -607,10 +608,11 @@ class SafeCollectiblesView(SafeBalanceView):
             *args, **kwargs
         )
 
-    @swagger_safe_balance_schema(serializer_class)
+    @swagger_safe_balance_schema(serializer_class, deprecated=True)
     def get(self, *args, **kwargs):
         """
-        Get collectibles (ERC721 tokens) and information about them
+        Get collectibles (ERC721 tokens) and information about them. Limited to 50 collectibles due to
+        performance issues, endpoint will be deprecated soon, please migrate to v2 endpoint.
         """
         return super().get(*args, **kwargs)
 


### PR DESCRIPTION
- Add missing kwargs for `_get_collectibles_with_metadata` call
- Add deprecated flag for `v1` collectibles endpoint on swagger
- Update `v1` collectibles endpoint docs on swagger
- 50 is an arbitrary number that the server should handle well and also should not impact normal users, only very big Safes
