### PR TITLE
Refactor ERC20 indexing

### DIFF
--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -3,12 +3,10 @@ from collections import OrderedDict
 from logging import getLogger
 from typing import Iterator, List, Sequence
 
-import gevent
 from cache_memoize import cache_memoize
 from cachetools import cachedmethod
 from eth_abi.exceptions import DecodingError
 from eth_typing import ChecksumAddress
-from gevent import pool
 from web3.contract import ContractEvent
 from web3.exceptions import BadFunctionCallOutput
 from web3.types import EventData, LogReceipt
@@ -16,7 +14,6 @@ from web3.types import EventData, LogReceipt
 from gnosis.eth import EthereumClient
 
 from safe_transaction_service.tokens.models import Token
-from safe_transaction_service.utils.utils import chunks
 
 from ..models import ERC20Transfer, ERC721Transfer, SafeContract, TokenTransfer
 from .events_indexer import EventsIndexer
@@ -76,30 +73,26 @@ class Erc20EventsIndexer(EventsIndexer):
         :param to_block_number:
         :return:
         """
-        if self.query_chunk_size:
-            addresses_chunks = chunks(addresses, self.query_chunk_size)
-        else:
-            addresses_chunks = [addresses]
 
-        jobs = []
+        # If not too much addresses it's alright to filter in the RPC server
+        parameter_addresses = (
+            None if len(addresses) > self.query_chunk_size else addresses
+        )
+        transfer_events = self.ethereum_client.erc20.get_total_transfer_history(
+            parameter_addresses, from_block=from_block_number, to_block=to_block_number
+        )
 
-        gevent_pool = pool.Pool(self.get_logs_concurrency)
-        jobs = [
-            gevent_pool.spawn(
-                self.ethereum_client.erc20.get_total_transfer_history,
-                addresses_chunk,
-                from_block=from_block_number,
-                to_block=to_block_number,
-            )
-            for addresses_chunk in addresses_chunks
+        if parameter_addresses:
+            return transfer_events
+
+        # Every ERC20/721 event is returned, we need to filter ourselves
+        addresses_set = set(addresses)
+        return [
+            transfer_event
+            for transfer_event in transfer_events
+            if transfer_event["args"]["to"] in addresses_set
+            or transfer_event["args"]["from"] in addresses_set
         ]
-
-        with self.auto_adjust_block_limit(from_block_number, to_block_number):
-            # Check how long the first job takes
-            gevent.joinall(jobs[:1])
-
-        gevent.joinall(jobs)
-        return [transfer_event for job in jobs for transfer_event in job.get()]
 
     @cachedmethod(cache=operator.attrgetter("_cache_is_erc20"))
     @cache_memoize(60 * 60 * 24, prefix="erc20-events-indexer-is-erc20")  # 1 day


### PR DESCRIPTION
Don't filter by address on the RPC, it's not feasible with a high number of Safes. Get every event and filter them locally.

This should fix ERC20/721 indexing issues on networks with big number of Safes, like Polygon