### PR TITLE
Don't index events previous to a Safe creation

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.12.0"
+__version__ = "4.12.1"
 __version_info__ = tuple(
     int(num) if num.isdigit() else num
     for num in __version__.replace("-", ".", 1).split(".")

--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -336,13 +336,10 @@ class SafeTxProcessor(TxProcessor):
                         update_fields=["ethereum_tx", "erc20_block_number"]
                     )
             except SafeContract.DoesNotExist:
-                blocks_one_day = int(24 * 60 * 60 / 15)  # 15 seconds block
                 SafeContract.objects.create(
                     address=contract_address,
                     ethereum_tx=internal_tx.ethereum_tx,
-                    erc20_block_number=max(
-                        internal_tx.block_number - blocks_one_day, 0
-                    ),
+                    erc20_block_number=internal_tx.block_number,
                 )
                 logger.info("Found new Safe=%s", contract_address)
 


### PR DESCRIPTION
- Previously, as we inherited the logic from the relay, it was possible that an ERC20 token was sent to a Safe address before the Safe was created, so by default we were indexing one day before was indexed.
- When a Safe was created the service could be marked out of sync even if it's not
- We were spending resources for a very rare case
- We can always index manually if needed
- Set v4.12.1 for a hotfix