### PR TITLE
Add release event to github actions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,6 +5,8 @@ on:
       - master
       - develop
   pull_request:
+  release:
+    types: [ released ]
 
 jobs:
   linting:


### PR DESCRIPTION
- If not no event will be triggered on release and docker image will not be generated
