### PR TITLE
Fix request 1 block when block_process_limit is 1

### DIFF
--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -164,6 +164,11 @@ class EthereumIndexer(ABC):
         :param current_block_number:
         :return: Top block number to process
         """
+        if self.block_process_limit == 1:
+            return min(
+                from_block_number,
+                current_block_number - self.confirmations,
+            )
         return min(
             from_block_number + self.block_process_limit,
             current_block_number - self.confirmations,

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -145,8 +145,16 @@ class EthereumIndexer(ABC):
         if (from_block_number + self.block_process_limit) >= (
             current_block_number - self.confirmations
         ):
+            reindex_blocks = self.blocks_to_reindex_again
+            if self.blocks_to_reindex_again >= self.block_process_limit:
+                # The following formula ensure that get_to_block_number reach last block
+                reindex_blocks = (
+                    (self.block_process_limit + from_block_number)
+                    - current_block_number
+                ) - 1
+
             # Reindex again when it's almost synced to prevent reorg/missing elements issues
-            from_block_number = max(from_block_number - self.blocks_to_reindex_again, 0)
+            from_block_number = max(from_block_number - reindex_blocks, 0)
 
         if (current_block_number - common_minimum_block_number) <= self.confirmations:
             return  # We don't want problems with reorgs
@@ -164,13 +172,8 @@ class EthereumIndexer(ABC):
         :param current_block_number:
         :return: Top block number to process
         """
-        if self.block_process_limit == 1:
-            return min(
-                from_block_number,
-                current_block_number - self.confirmations,
-            )
         return min(
-            from_block_number + self.block_process_limit,
+            from_block_number + self.block_process_limit - 1,
             current_block_number - self.confirmations,
         )
 

--- a/safe_transaction_service/history/tests/test_erc20_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_erc20_events_indexer.py
@@ -11,8 +11,14 @@ from .factories import SafeContractFactory
 
 
 class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
+    def setUp(self) -> None:
+        self.erc20_events_indexer = Erc20EventsIndexerProvider()
+
+    def tearDown(self) -> None:
+        Erc20EventsIndexerProvider.del_singleton()
+
     def test_erc20_events_indexer(self):
-        erc20_events_indexer = Erc20EventsIndexerProvider()
+        erc20_events_indexer = self.erc20_events_indexer
         erc20_events_indexer.confirmations = 0
         self.assertEqual(erc20_events_indexer.start(), 0)
 
@@ -96,3 +102,10 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
             self.assertEqual(
                 erc20_events_indexer._process_decoded_element(event), original_event
             )
+
+    def test_get_to_block_number(self):
+        self.erc20_events_indexer.block_process_limit = 1
+        self.assertEqual(self.erc20_events_indexer.get_to_block_number(5, 100), 5)
+
+        self.erc20_events_indexer.block_process_limit = 2
+        self.assertEqual(self.erc20_events_indexer.get_to_block_number(5, 100), 6)


### PR DESCRIPTION
Closes #1238 
Also included a fix to possible infinity loop on indexer that happen when `block_process_limit` is less than `blocks_to_reindex_again`.  
This shouldn't happen frequently because `block_process_limit` normally is increasing an reducing the value but could happen. 