### PR TITLE
Process `InternalTxDecoded` in batches

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -405,6 +405,9 @@ ETH_EVENTS_UPDATED_BLOCK_BEHIND = env.int(
 ETH_REORG_BLOCKS = env.int(
     "ETH_REORG_BLOCKS", default=100 if ETH_L2_NETWORK else 10
 )  # Number of blocks from the current block number needed to consider a block valid/stable
+ETH_INTERNAL_TX_DECODED_PROCESS_BATCH = env.int(
+    "ETH_INTERNAL_TX_DECODED_PROCESS_BATCH", default=500
+)  # Number of InternalTxDecoded to process together
 
 # Tokens
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
- An iterator was used to process InternalDecodedTx. Either all were processed, or none was be (atomic update)
- Refactor method so we process InternalTxDecoded in batches, so even if they take a lot to process service can slowly process them all
- This issue was detected on production with the indexer stuck for days processing a Safe with more than 11k of InternalTxDecoded
