### PR TITLE
Split tracing calls for TxProcessor and SafeService

### DIFF
--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -32,7 +32,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         cls.safe_events_indexer = SafeEventsIndexer(
             cls.ethereum_client, confirmations=0, blocks_to_reindex_again=0
         )
-        cls.safe_tx_processor = SafeTxProcessor(cls.ethereum_client)
+        cls.safe_tx_processor = SafeTxProcessor(cls.ethereum_client, None)
 
     def test_safe_events_indexer_provider(self):
         safe_events_indexer = SafeEventsIndexerProvider()


### PR DESCRIPTION
- Currently if tracing was enabled every RPC call from this service was performed to the tracing node, even if not required
- With this update, only tracing specific calls will be performed to the tracing node
