### PR TITLE
Add kava (testnet and mainnet) to setup_service and price_service

### DIFF
--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -374,6 +374,14 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 14062206, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 14062208, "1.3.0"),
     ],
+    EthereumNetwork.KAVA_EVM: [
+        ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 2702059, "1.3.0+L2"),
+        ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 2116307, "1.3.0"),
+    ],
+    EthereumNetwork.KAVA_EVM_TESTNET: [
+        ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 2241523, "1.3.0+L2"),
+        ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 2241523, "1.3.0"),
+    ],
 }
 
 PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
@@ -551,6 +559,12 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     ],
     EthereumNetwork.PUBLICMINT_TESTNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 14062193),  # v1.3.0
+    ],
+    EthereumNetwork.KAVA_EVM: [
+        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 2116356),  # v1.3.0
+    ],
+    EthereumNetwork.KAVA_EVM_TESTNET: [
+        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 2241523),  # v1.3.0
     ],
 }
 

--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -375,7 +375,7 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 14062208, "1.3.0"),
     ],
     EthereumNetwork.KAVA_EVM: [
-        ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 2702059, "1.3.0+L2"),
+        ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 2116303, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 2116307, "1.3.0"),
     ],
     EthereumNetwork.KAVA_EVM_TESTNET: [

--- a/safe_transaction_service/tokens/clients/kraken_client.py
+++ b/safe_transaction_service/tokens/clients/kraken_client.py
@@ -74,3 +74,10 @@ class KrakenClient:
         :raises: CannotGetPrice
         """
         return self._get_price("ALGOUSD")
+
+    def get_kava_usd_price(self):
+        """
+        :return: current USD price for Kava
+        :raises: CannotGetPrice
+        """
+        return self._get_price("KAVAUSD")

--- a/safe_transaction_service/tokens/services/price_service.py
+++ b/safe_transaction_service/tokens/services/price_service.py
@@ -158,6 +158,9 @@ class PriceService:
     def get_algorand_usd_price(self) -> float:
         return self.kraken_client.get_algo_usd_price()
 
+    def get_kava_usd_price(self) -> float:
+        return self.kraken_client.get_kava_usd_price()
+
     def get_binance_usd_price(self) -> float:
         try:
             return self.kucoin_client.get_bnb_usd_price()
@@ -267,6 +270,11 @@ class PriceService:
             EthereumNetwork.CELO_BAKLAVA,
         ):
             return self.kucoin_client.get_celo_usd_price()
+        elif self.ethereum_network in (
+            EthereumNetwork.KAVA_EVM_TESTNET,
+            EthereumNetwork.KAVA_EVM,
+        ):
+            return self.get_kava_usd_price()
         else:
             try:
                 return self.kraken_client.get_eth_usd_price()


### PR DESCRIPTION
### Make sure these boxes are checked! 📦✅

- [ 👍] You ran `./run_tests.sh`
- [👍 ] You ran `pre-commit run -a`
- [👍 ] If you want to add your network to `setup_service.py`, provide a link to your
    [safe-deployments PR](https://github.com/safe-global/safe-deployments/pulls) and check network name
    exists in [safe-eth-py](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py)
    - https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py#L261
    - https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py#L381
    - https://github.com/safe-global/safe-deployments/pull/145
    - https://github.com/safe-global/safe-deployments/pull/137
