### PR TITLE
Bump safe-eth-py to version 4.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,5 @@ psycogreen==1.0.2
 psycopg2==2.9.5
 redis==4.4.1
 requests==2.28.1
-safe-eth-py[django]==4.8.2
+safe-eth-py[django]==4.9.0
 web3==5.31.3


### PR DESCRIPTION
- Bump safe-eth-py version to 4.9.0 
# Release notes
https://github.com/safe-global/safe-eth-py/releases/tag/v4.9.0 
