### PR TITLE
Fix processing `ChangedMasterCopy` event

### DIFF
--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -318,8 +318,8 @@ class SafeEventsIndexer(EventsIndexer):
             internal_tx_decoded = None
         elif event_name == "ChangedMasterCopy":
             internal_tx_decoded.function_name = "changeMasterCopy"
-            internal_tx.arguments = {
-                "_masterCopy": args.get("singleton") or args.get("masterCopy")
+            internal_tx_decoded.arguments = {
+                "_masterCopy": args.get("masterCopy") or args.get("singleton")
             }
         else:
             # 'SignMsg', 'ExecutionFailure', 'ExecutionSuccess',


### PR DESCRIPTION
`ChangedMasterCopy` event was supposed to generate an argument `_masterCopy` instead of `masterCopy`. Due to a typo, it was not.
