### PR TITLE
Fix log message when reducing block range

### DIFF
--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -344,13 +344,13 @@ class EthereumIndexer(ABC):
                 self.block_process_limit_max
                 and self.block_process_limit > self.block_process_limit_max
             ):
-                self.block_process_limit = self.block_process_limit_max
                 logger.info(
                     "%s: block_process_limit %d is bigger than block_process_limit_max %d, reducing",
                     self.__class__.__name__,
                     self.block_process_limit,
                     self.block_process_limit_max,
                 )
+                self.block_process_limit = self.block_process_limit_max
 
     def process_addresses(
         self, addresses: Sequence[str], current_block_number: Optional[int] = None


### PR DESCRIPTION
Due to updating the variable before logging, the log message `block_process_limit %d is bigger than block_process_limit_max %d, reducing` had the same value for `block_process_limit` and for `block_process_limit_max`