### PR TITLE
Fix InternalTxDecoded admin search

### DIFF
--- a/safe_transaction_service/history/admin.py
+++ b/safe_transaction_service/history/admin.py
@@ -251,8 +251,7 @@ class InternalTxDecodedAdmin(BinarySearchAdmin):
     ]
     raw_id_fields = ("internal_tx",)
     search_fields = [
-        "function_name",
-        "arguments",
+        "=function_name",
         "=internal_tx__to",
         "=internal_tx___from",
         "=internal_tx__ethereum_tx__tx_hash",

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -844,7 +844,9 @@ class InternalTx(models.Model):
     )  # For SELF-DESTRUCT it can be null
     gas = Uint256Field()
     data = models.BinaryField(null=True)  # `input` for Call, `init` for Create
-    to = EthereumAddressV2Field(null=True)
+    to = EthereumAddressV2Field(
+        null=True
+    )  # Already exists a multicolumn index for field
     value = Uint256Field()
     gas_used = Uint256Field()
     contract_address = EthereumAddressV2Field(null=True, db_index=True)  # Create


### PR DESCRIPTION
Search was not possible as it times out when no indexed fields are involved:
- Remove `arguments` field search
- Use exact search for `function_name` to use the db index
