### PR TITLE
Configure automatic release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+changelog:
+  categories:
+    - title: 🏕 Features
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+          - breaking_change
+    - title: 🛠 Breaking Changes
+      labels:
+        - breaking_change
+    - title: 👒 Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
- Dependabot will go into its own category
- PRs with `breaking_change` label will go in its own category

References:
- https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes