### PR TITLE
Remove duplicated warning log

### DIFF
--- a/safe_transaction_service/history/services/reorg_service.py
+++ b/safe_transaction_service/history/services/reorg_service.py
@@ -77,7 +77,6 @@ class ReorgService:
             ):
                 database_block.set_confirmed()
             else:
-                logger.warning("Reorg found for block-number=%d", database_block.number)
                 return database_block.number
 
     def reset_all_to_block(self, block_number: int) -> int:


### PR DESCRIPTION
# Description
The following line appear 2 times at the same instant: 
````
2023-02-03 08:58:07,200 [WARNING] [check_reorgs_task] Reorg found for block-number=16547174
2023-02-03 08:58:07,200 [WARNING] [check_reorgs_task] Reorg found for block-number=16547174
````
This PR remove one of them and leave the following in the task:
https://github.com/safe-global/safe-transaction-service/blob/master/safe_transaction_service/history/tasks.py#L69

