### PR TITLE
Update safe-eth-py to v5.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,5 @@ psycogreen==1.0.2
 psycopg2==2.9.5
 redis==4.4.2
 requests==2.28.2
-safe-eth-py[django]==4.9.3
+safe-eth-py[django]==5.0.0
 web3==5.31.3

--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -176,7 +176,7 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A", 10638132, "1.0.0"),
         ("0x8942595A2dC5181Df0465AF0D7be08c8f23C93af", 9465686, "0.1.0"),
     ],
-    EthereumNetwork.XDAI: [
+    EthereumNetwork.GNOSIS: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 16236936, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 16236998, "1.3.0"),
         ("0x6851D6fDFAfD08c0295C392436245E5bc78B0185", 10612049, "1.2.0"),
@@ -190,13 +190,13 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x6851D6fDFAfD08c0295C392436245E5bc78B0185", 6398655, "1.2.0"),
         ("0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F", 6399212, "1.1.1"),
     ],
-    EthereumNetwork.VOLTA: [
+    EthereumNetwork.ENERGY_WEB_VOLTA_TESTNET: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 11942450, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 11942451, "1.3.0"),
         ("0x6851D6fDFAfD08c0295C392436245E5bc78B0185", 6876086, "1.2.0"),
         ("0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F", 6876642, "1.1.1"),
     ],
-    EthereumNetwork.MATIC: [
+    EthereumNetwork.POLYGON: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 14306478, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 14306478, "1.3.0"),
     ],
@@ -204,7 +204,7 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 13736914, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 13736914, "1.3.0"),
     ],
-    EthereumNetwork.ARBITRUM: [
+    EthereumNetwork.ARBITRUM_ONE: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 1146, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 1140, "1.3.0"),
     ],
@@ -212,7 +212,7 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 426, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 427, "1.3.0"),
     ],
-    EthereumNetwork.ARBITRUM_TESTNET: [
+    EthereumNetwork.ARBITRUM_RINKEBY: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 57070, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 57070, "1.3.0"),
     ],
@@ -220,23 +220,23 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 11545, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 11546, "1.3.0"),
     ],
-    EthereumNetwork.BINANCE: [
+    EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 8485899, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 8485903, "1.3.0"),
     ],
-    EthereumNetwork.CELO: [
+    EthereumNetwork.CELO_MAINNET: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 8944350, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 8944351, "1.3.0"),
     ],
-    EthereumNetwork.AVALANCHE: [
+    EthereumNetwork.AVALANCHE_C_CHAIN: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 4_949_507, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 4_949_512, "1.3.0"),
     ],
-    EthereumNetwork.MOON_MOONRIVER: [
+    EthereumNetwork.MOONRIVER: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 707_738, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 707_741, "1.3.0"),
     ],
-    EthereumNetwork.MOON_MOONBASE: [
+    EthereumNetwork.MOONBASE_ALPHA: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 939_244, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 939_246, "1.3.0"),
     ],
@@ -244,31 +244,31 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 12_725_078, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 12_725_081, "1.3.0"),
     ],
-    EthereumNetwork.FUSE_SPARK: [
+    EthereumNetwork.FUSE_SPARKNET: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 1_010_518, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 1_010_520, "1.3.0"),
     ],
-    EthereumNetwork.OLYMPUS: [
+    EthereumNetwork.POLIS_MAINNET: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 1227, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 1278, "1.3.0"),
     ],
-    EthereumNetwork.OPTIMISTIC: [
+    EthereumNetwork.OPTIMISM: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 173749, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 173751, "1.3.0"),
     ],
-    EthereumNetwork.BOBA_RINKEBY: [
+    EthereumNetwork.BOBA_NETWORK_RINKEBY_TESTNET: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 18854, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 18855, "1.3.0"),
     ],
-    EthereumNetwork.BOBA: [
+    EthereumNetwork.BOBA_NETWORK: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 170908, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 170910, "1.3.0"),
     ],
-    EthereumNetwork.AURORA: [
+    EthereumNetwork.AURORA_MAINNET: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 52494580, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 52494580, "1.3.0"),
     ],
-    EthereumNetwork.METIS_TESTNET: [
+    EthereumNetwork.METIS_STARDUST_TESTNET: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 56124, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 56125, "1.3.0"),
     ],
@@ -276,25 +276,21 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 131845, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 131846, "1.3.0"),
     ],
-    EthereumNetwork.METIS: [
+    EthereumNetwork.METIS_ANDROMEDA_MAINNET: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 61767, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 61768, "1.3.0"),
     ],
-    EthereumNetwork.SHYFT: [
+    EthereumNetwork.SHYFT_MAINNET: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 1000, "1.3.0+L2"),  # v1.3.0
     ],
     EthereumNetwork.SHYFT_TESTNET: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 1984340, "1.3.0+L2"),  # v1.3.0
     ],
-    EthereumNetwork.REI_MAINNET: [
+    EthereumNetwork.REI_NETWORK: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 2388036, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 2388042, "1.3.0"),
     ],
-    EthereumNetwork.REI_TESTNET: [
-        ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 748810, "1.3.0+L2"),
-        ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 748815, "1.3.0"),
-    ],
-    EthereumNetwork.METER: [
+    EthereumNetwork.METER_MAINNET: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 23863901, "1.3.0+L2")  # v1.3.0
     ],
     EthereumNetwork.METER_TESTNET: [
@@ -308,7 +304,7 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 12845441, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 12845443, "1.3.0"),
     ],
-    EthereumNetwork.VENIDIUM: [
+    EthereumNetwork.VENIDIUM_MAINNET: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 1127191, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 1127192, "1.3.0"),
     ],
@@ -316,14 +312,14 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 761243, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 761244, "1.3.0"),
     ],
-    EthereumNetwork.GODWOKEN_TESTNET: [
+    EthereumNetwork.GODWOKEN_TESTNET_V1: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 93204, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 93168, "1.3.0"),
     ],
-    EthereumNetwork.KLAY_BAOBAB: [
+    EthereumNetwork.KLAYTN_TESTNET_BAOBAB: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 93821635, "1.3.0+L2"),
     ],
-    EthereumNetwork.KLAY_CYPRESS: [
+    EthereumNetwork.KLAYTN_MAINNET_CYPRESS: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 93507490, "1.3.0+L2"),
     ],
     EthereumNetwork.MILKOMEDA_A1_TESTNET: [
@@ -346,11 +342,11 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 3290833, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 3290835, "1.3.0"),
     ],
-    EthereumNetwork.CRONOS_MAINNET: [
+    EthereumNetwork.CRONOS_MAINNET_BETA: [
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 3002268, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 3002760, "1.3.0"),
     ],
-    EthereumNetwork.RABBIT: [
+    EthereumNetwork.RABBIT_ANALOG_TESTNET_CHAIN: [
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 1434229, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 1434230, "1.3.0"),
     ],
@@ -401,7 +397,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0x50e55Af101C777bA7A1d560a774A82eF002ced9F", 14740731),
         ("0x12302fE9c02ff50939BaAaaf415fc226C078613C", 10629898),
     ],
-    EthereumNetwork.XDAI: [
+    EthereumNetwork.GNOSIS: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 16236878),  # v1.3.0
         ("0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B", 10045327),  # v1.1.1
         ("0x12302fE9c02ff50939BaAaaf415fc226C078613C", 17677119),  # v1.0.0
@@ -410,86 +406,83 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 12028652),  # v1.3.0
         ("0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B", 6399239),
     ],
-    EthereumNetwork.VOLTA: [
+    EthereumNetwork.ENERGY_WEB_VOLTA_TESTNET: [
         # ('0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2', 0),  # v1.3.0
         ("0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B", 6876681),
     ],
-    EthereumNetwork.MATIC: [
+    EthereumNetwork.POLYGON: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 14306478),  # v1.3.0
     ],
     EthereumNetwork.MUMBAI: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 13736914),  # v1.3.0
     ],
-    EthereumNetwork.ARBITRUM: [
+    EthereumNetwork.ARBITRUM_ONE: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 1140),  # v1.3.0
     ],
     EthereumNetwork.ARBITRUM_NOVA: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 419),  # v1.3.0
     ],
-    EthereumNetwork.ARBITRUM_TESTNET: [
+    EthereumNetwork.ARBITRUM_RINKEBY: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 57070),  # v1.3.0
     ],
     EthereumNetwork.ARBITRUM_GOERLI: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 11538),  # v1.3.0
     ],
-    EthereumNetwork.BINANCE: [
+    EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 8485873),  # v1.3.0
     ],
-    EthereumNetwork.CELO: [
+    EthereumNetwork.CELO_MAINNET: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 8944342),  # v1.3.0
     ],
-    EthereumNetwork.AVALANCHE: [
+    EthereumNetwork.AVALANCHE_C_CHAIN: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 4_949_487),  # v1.3.0
     ],
-    EthereumNetwork.MOON_MOONRIVER: [
+    EthereumNetwork.MOONRIVER: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 707_721),  # v1.3.0
     ],
-    EthereumNetwork.MOON_MOONBASE: [
+    EthereumNetwork.MOONBASE_ALPHA: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 939_239),  # v1.3.0
     ],
     EthereumNetwork.FUSE_MAINNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 12_725_072),  # v1.3.0
     ],
-    EthereumNetwork.FUSE_SPARK: [
+    EthereumNetwork.FUSE_SPARKNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 1_010_506),  # v1.3.0
     ],
-    EthereumNetwork.OLYMPUS: [
+    EthereumNetwork.POLIS_MAINNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 1266),  # v1.3.0
     ],
-    EthereumNetwork.OPTIMISTIC: [
+    EthereumNetwork.OPTIMISM: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 173709),  # v1.3.0
     ],
-    EthereumNetwork.BOBA_RINKEBY: [
+    EthereumNetwork.BOBA_NETWORK_RINKEBY_TESTNET: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 18847),  # v1.3.0
     ],
-    EthereumNetwork.BOBA: [
+    EthereumNetwork.BOBA_NETWORK: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 170895),  # v1.3.0
     ],
-    EthereumNetwork.AURORA: [
+    EthereumNetwork.AURORA_MAINNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 52494580),  # v1.3.0
     ],
-    EthereumNetwork.METIS_TESTNET: [
+    EthereumNetwork.METIS_STARDUST_TESTNET: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 56117),  # v1.3.0
     ],
     EthereumNetwork.METIS_GOERLI_TESTNET: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 131842),  # v1.3.0
     ],
-    EthereumNetwork.METIS: [
+    EthereumNetwork.METIS_ANDROMEDA_MAINNET: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 61758),  # v1.3.0
     ],
-    EthereumNetwork.SHYFT: [
+    EthereumNetwork.SHYFT_MAINNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 2000),  # v1.3.0
     ],
     EthereumNetwork.SHYFT_TESTNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 1984340),  # v1.3.0
     ],
-    EthereumNetwork.REI_MAINNET: [
+    EthereumNetwork.REI_NETWORK: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 2387999),  # v1.3.0
     ],
-    EthereumNetwork.REI_TESTNET: [
-        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 748768),  # v1.3.0
-    ],
-    EthereumNetwork.METER: [
+    EthereumNetwork.METER_MAINNET: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 23863720),  # v1.3.0
     ],
     EthereumNetwork.METER_TESTNET: [
@@ -501,19 +494,19 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     EthereumNetwork.EURUS_TESTNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 12845425),  # v1.3.0
     ],
-    EthereumNetwork.VENIDIUM: [
+    EthereumNetwork.VENIDIUM_MAINNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 1127130),  # v1.3.0
     ],
     EthereumNetwork.VENIDIUM_TESTNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 761231),  # v1.3.0
     ],
-    EthereumNetwork.GODWOKEN_TESTNET: [
+    EthereumNetwork.GODWOKEN_TESTNET_V1: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93108),  # v1.3.0
     ],
-    EthereumNetwork.KLAY_BAOBAB: [
+    EthereumNetwork.KLAYTN_TESTNET_BAOBAB: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93821613),  # v1.3.0
     ],
-    EthereumNetwork.KLAY_CYPRESS: [
+    EthereumNetwork.KLAYTN_MAINNET_CYPRESS: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 93506870),  # v1.3.0
     ],
     EthereumNetwork.MILKOMEDA_A1_TESTNET: [
@@ -531,10 +524,10 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     EthereumNetwork.CRONOS_TESTNET: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 3290819),  # v1.3.0
     ],
-    EthereumNetwork.CRONOS_MAINNET: [
+    EthereumNetwork.CRONOS_MAINNET_BETA: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 2958469),  # v1.3.0
     ],
-    EthereumNetwork.RABBIT: [
+    EthereumNetwork.RABBIT_ANALOG_TESTNET_CHAIN: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 1434222),  # v1.3.0
     ],
     EthereumNetwork.CLOUDWALK_TESTNET: [

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -403,7 +403,7 @@ class TestCommands(TestCase):
         self.assertIn("EthereumRPC chainId 1 looks good", buf.getvalue())
 
         # Use different chainId
-        get_ethereum_network_mock.return_value = EthereumNetwork.XDAI
+        get_ethereum_network_mock.return_value = EthereumNetwork.GNOSIS
         with self.assertRaisesMessage(
             CommandError,
             "EthereumRPC chainId 100 does not match previously used chainId 1",

--- a/safe_transaction_service/tokens/clients/coingecko_client.py
+++ b/safe_transaction_service/tokens/clients/coingecko_client.py
@@ -22,25 +22,25 @@ class CoingeckoClient:
 
     def __init__(self, network: Optional[EthereumNetwork] = None):
         self.http_session = requests.Session()
-        if network == EthereumNetwork.ARBITRUM:
+        if network == EthereumNetwork.ARBITRUM_ONE:
             self.asset_platform = "arbitrum-one"
-        elif network == EthereumNetwork.AURORA:
+        elif network == EthereumNetwork.AURORA_MAINNET:
             self.asset_platform = "aurora"
-        elif network == EthereumNetwork.AVALANCHE:
+        elif network == EthereumNetwork.AVALANCHE_C_CHAIN:
             self.asset_platform = "avalanche"
-        elif network == EthereumNetwork.BINANCE:
+        elif network == EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET:
             self.asset_platform = "binance-smart-chain"
-        elif network == EthereumNetwork.MATIC:
+        elif network == EthereumNetwork.POLYGON:
             self.asset_platform = "polygon-pos"
-        elif network == EthereumNetwork.OPTIMISTIC:
+        elif network == EthereumNetwork.OPTIMISM:
             self.asset_platform = "optimistic-ethereum"
-        elif network == EthereumNetwork.XDAI:
+        elif network == EthereumNetwork.GNOSIS:
             self.asset_platform = "xdai"
         elif network == EthereumNetwork.FUSE_MAINNET:
             self.asset_platform = "fuse"
         elif network == EthereumNetwork.KCC_MAINNET:
             self.asset_platform = "kucoin-community-chain"
-        elif network == EthereumNetwork.METIS:
+        elif network == EthereumNetwork.METIS_ANDROMEDA_MAINNET:
             self.asset_platform = "metis-andromeda"
         else:
             self.asset_platform = "ethereum"
@@ -48,17 +48,17 @@ class CoingeckoClient:
     @staticmethod
     def supports_network(network: EthereumNetwork):
         return network in (
-            EthereumNetwork.ARBITRUM,
-            EthereumNetwork.AURORA,
-            EthereumNetwork.AVALANCHE,
-            EthereumNetwork.BINANCE,
+            EthereumNetwork.ARBITRUM_ONE,
+            EthereumNetwork.AURORA_MAINNET,
+            EthereumNetwork.AVALANCHE_C_CHAIN,
+            EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET,
             EthereumNetwork.MAINNET,
-            EthereumNetwork.MATIC,
-            EthereumNetwork.OPTIMISTIC,
-            EthereumNetwork.XDAI,
+            EthereumNetwork.POLYGON,
+            EthereumNetwork.OPTIMISM,
+            EthereumNetwork.GNOSIS,
             EthereumNetwork.FUSE_MAINNET,
             EthereumNetwork.KCC_MAINNET,
-            EthereumNetwork.METIS,
+            EthereumNetwork.METIS_ANDROMEDA_MAINNET,
         )
 
     def _do_request(self, url: str) -> Dict[str, Any]:

--- a/safe_transaction_service/tokens/migrations/0010_tokenlist.py
+++ b/safe_transaction_service/tokens/migrations/0010_tokenlist.py
@@ -12,20 +12,20 @@ TOKEN_LIST_BY_NETWORK = {
         "https://tokens.coingecko.com/uniswap/all.json",
         "Coingecko",
     ),
-    EthereumNetwork.MATIC: (
+    EthereumNetwork.POLYGON: (
         "https://api-polygon-tokens.polygon.technology/tokenlists/polygonTokens.tokenlist.json",
         "Official",
     ),
-    EthereumNetwork.OPTIMISTIC: (
+    EthereumNetwork.OPTIMISM: (
         "https://static.optimism.io/optimism.tokenlist.json",
         "Official",
     ),
-    EthereumNetwork.XDAI: ("https://tokens.honeyswap.org/", "HoneySwap"),
-    EthereumNetwork.BINANCE: (
+    EthereumNetwork.GNOSIS: ("https://tokens.honeyswap.org/", "HoneySwap"),
+    EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET: (
         "https://tokens.pancakeswap.finance/pancakeswap-extended.json",
         "PancakeSwap",
     ),
-    EthereumNetwork.AURORA: ("https://aurora.dev/tokens.json", "Official"),
+    EthereumNetwork.AURORA_MAINNET: ("https://aurora.dev/tokens.json", "Official"),
 }
 
 

--- a/safe_transaction_service/tokens/services/price_service.py
+++ b/safe_transaction_service/tokens/services/price_service.py
@@ -202,27 +202,27 @@ class PriceService:
 
         :return: USD price for Ether
         """
-        if self.ethereum_network == EthereumNetwork.XDAI:
+        if self.ethereum_network == EthereumNetwork.GNOSIS:
             try:
                 return self.kraken_client.get_dai_usd_price()
             except CannotGetPrice:
                 return 1  # DAI/USD should be close to 1
         elif self.ethereum_network in (
             EthereumNetwork.ENERGY_WEB_CHAIN,
-            EthereumNetwork.VOLTA,
+            EthereumNetwork.ENERGY_WEB_VOLTA_TESTNET,
         ):
             return self.get_ewt_usd_price()
-        elif self.ethereum_network in (EthereumNetwork.MATIC, EthereumNetwork.MUMBAI):
+        elif self.ethereum_network in (EthereumNetwork.POLYGON, EthereumNetwork.MUMBAI):
             return self.get_matic_usd_price()
-        elif self.ethereum_network == EthereumNetwork.BINANCE:
+        elif self.ethereum_network == EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET:
             return self.get_binance_usd_price()
         elif self.ethereum_network in (
-            EthereumNetwork.GATHER_DEVNET,
-            EthereumNetwork.GATHER_TESTNET,
-            EthereumNetwork.GATHER_MAINNET,
+            EthereumNetwork.GATHER_DEVNET_NETWORK,
+            EthereumNetwork.GATHER_TESTNET_NETWORK,
+            EthereumNetwork.GATHER_MAINNET_NETWORK,
         ):
             return self.coingecko_client.get_gather_usd_price()
-        elif self.ethereum_network == EthereumNetwork.AVALANCHE:
+        elif self.ethereum_network == EthereumNetwork.AVALANCHE_C_CHAIN:
             return self.get_avalanche_usd_price()
         elif self.ethereum_network in (
             EthereumNetwork.MILKOMEDA_C1_TESTNET,
@@ -230,19 +230,18 @@ class PriceService:
         ):
             return self.get_cardano_usd_price()
         elif self.ethereum_network in (
-            EthereumNetwork.AURORA,
-            EthereumNetwork.AURORA_BETANET,
-            EthereumNetwork.ARBITRUM_TESTNET,
+            EthereumNetwork.AURORA_MAINNET,
+            EthereumNetwork.ARBITRUM_RINKEBY,
         ):
             return self.get_aurora_usd_price()
         elif self.ethereum_network in (
             EthereumNetwork.CRONOS_TESTNET,
-            EthereumNetwork.CRONOS_MAINNET,
+            EthereumNetwork.CRONOS_MAINNET_BETA,
         ):
             return self.get_cronos_usd_price()
         elif self.ethereum_network in (
             EthereumNetwork.FUSE_MAINNET,
-            EthereumNetwork.FUSE_SPARK,
+            EthereumNetwork.FUSE_SPARKNET,
         ):
             return self.coingecko_client.get_fuse_usd_price()
         elif self.ethereum_network in (
@@ -251,9 +250,9 @@ class PriceService:
         ):
             return self.get_kcs_usd_price()
         elif self.ethereum_network in (
-            EthereumNetwork.METIS,
-            EthereumNetwork.METIS_TESTNET,
+            EthereumNetwork.METIS_ANDROMEDA_MAINNET,
             EthereumNetwork.METIS_GOERLI_TESTNET,
+            EthereumNetwork.METIS_STARDUST_TESTNET,
         ):
             return self.coingecko_client.get_metis_usd_price()
         elif self.ethereum_network in (
@@ -262,9 +261,9 @@ class PriceService:
         ):
             return self.get_algorand_usd_price()
         elif self.ethereum_network in (
-            EthereumNetwork.CELO,
-            EthereumNetwork.CELO_ALFAJORES,
-            EthereumNetwork.CELO_BAKLAVA,
+            EthereumNetwork.CELO_MAINNET,
+            EthereumNetwork.CELO_ALFAJORES_TESTNET,
+            EthereumNetwork.CELO_BAKLAVA_TESTNET,
         ):
             return self.kucoin_client.get_celo_usd_price()
         else:

--- a/safe_transaction_service/tokens/tests/clients/test_coingecko_client.py
+++ b/safe_transaction_service/tokens/tests/clients/test_coingecko_client.py
@@ -12,9 +12,13 @@ class TestCoingeckoClient(TestCase):
 
     def test_coingecko_client(self):
         self.assertTrue(CoingeckoClient.supports_network(EthereumNetwork.MAINNET))
-        self.assertTrue(CoingeckoClient.supports_network(EthereumNetwork.BINANCE))
-        self.assertTrue(CoingeckoClient.supports_network(EthereumNetwork.MATIC))
-        self.assertTrue(CoingeckoClient.supports_network(EthereumNetwork.XDAI))
+        self.assertTrue(
+            CoingeckoClient.supports_network(
+                EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET
+            )
+        )
+        self.assertTrue(CoingeckoClient.supports_network(EthereumNetwork.POLYGON))
+        self.assertTrue(CoingeckoClient.supports_network(EthereumNetwork.GNOSIS))
 
         # Test Mainnet
         coingecko_client = CoingeckoClient()
@@ -24,14 +28,16 @@ class TestCoingeckoClient(TestCase):
             coingecko_client.get_token_price(non_existing_token_address)
 
         # Test Binance
-        bsc_coingecko_client = CoingeckoClient(EthereumNetwork.BINANCE)
+        bsc_coingecko_client = CoingeckoClient(
+            EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET
+        )
         binance_peg_ethereum_address = "0x2170Ed0880ac9A755fd29B2688956BD959F933F8"
         self.assertGreater(
             bsc_coingecko_client.get_token_price(binance_peg_ethereum_address), 0
         )
 
         # Test Polygon
-        polygon_coingecko_client = CoingeckoClient(EthereumNetwork.MATIC)
+        polygon_coingecko_client = CoingeckoClient(EthereumNetwork.POLYGON)
         bnb_pos_address = "0xb33EaAd8d922B1083446DC23f610c2567fB5180f"
         self.assertGreater(polygon_coingecko_client.get_token_price(bnb_pos_address), 0)
 
@@ -46,7 +52,7 @@ class TestCoingeckoClient(TestCase):
         )
 
         # Test Gnosis Chain
-        coingecko_client = CoingeckoClient(EthereumNetwork.XDAI)
+        coingecko_client = CoingeckoClient(EthereumNetwork.GNOSIS)
         self.assertIn(
             "http", coingecko_client.get_token_logo_url(self.GNO_GNOSIS_CHAIN_ADDRESS)
         )

--- a/safe_transaction_service/tokens/tests/migrations/test_migrations.py
+++ b/safe_transaction_service/tokens/tests/migrations/test_migrations.py
@@ -38,7 +38,7 @@ class TestMigrations(TestCase):
 
     @mock.patch(
         "safe_transaction_service.tokens.migrations.0010_tokenlist.get_ethereum_network",
-        return_value=EthereumNetwork.ACA,
+        return_value=EthereumNetwork.AIOZ_NETWORK,
     )
     def test_migration_forward_0010_network_without_data(
         self, get_ethereum_network_mock: MagicMock

--- a/safe_transaction_service/tokens/tests/test_price_service.py
+++ b/safe_transaction_service/tokens/tests/test_price_service.py
@@ -54,7 +54,7 @@ class TestPriceService(TestCase):
         self.assertEqual(eth_usd_price, binance_mock.return_value)
 
         # Gnosis Chain
-        price_service.ethereum_network = EthereumNetwork.XDAI
+        price_service.ethereum_network = EthereumNetwork.GNOSIS
         with mock.patch.object(KrakenClient, "get_dai_usd_price", return_value=1.5):
             price_service.cache_eth_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 1.5)
@@ -66,7 +66,7 @@ class TestPriceService(TestCase):
             self.assertEqual(price_service.get_native_coin_usd_price(), 1)
 
         # POLYGON
-        price_service.ethereum_network = EthereumNetwork.MATIC
+        price_service.ethereum_network = EthereumNetwork.POLYGON
         with mock.patch.object(KrakenClient, "get_matic_usd_price", return_value=0.7):
             price_service.cache_eth_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 0.7)
@@ -78,13 +78,13 @@ class TestPriceService(TestCase):
             self.assertEqual(price_service.get_native_coin_usd_price(), 0.9)
 
         # BINANCE
-        price_service.ethereum_network = EthereumNetwork.BINANCE
+        price_service.ethereum_network = EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET
         with mock.patch.object(KucoinClient, "get_bnb_usd_price", return_value=1.2):
             price_service.cache_eth_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 1.2)
 
         # Gather
-        price_service.ethereum_network = EthereumNetwork.GATHER_MAINNET
+        price_service.ethereum_network = EthereumNetwork.GATHER_MAINNET_NETWORK
         with mock.patch.object(
             CoingeckoClient, "get_gather_usd_price", return_value=1.7
         ):
@@ -92,20 +92,20 @@ class TestPriceService(TestCase):
             self.assertEqual(price_service.get_native_coin_usd_price(), 1.7)
 
         # Avalanche
-        price_service.ethereum_network = EthereumNetwork.AVALANCHE
+        price_service.ethereum_network = EthereumNetwork.AVALANCHE_C_CHAIN
         with mock.patch.object(KrakenClient, "get_avax_usd_price", return_value=6.5):
             price_service.cache_eth_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 6.5)
 
         # Aurora
-        price_service.ethereum_network = EthereumNetwork.AURORA
+        price_service.ethereum_network = EthereumNetwork.AURORA_MAINNET
         with mock.patch.object(KucoinClient, "get_aurora_usd_price", return_value=1.3):
             price_service.cache_eth_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 1.3)
 
         # Cronos
         with mock.patch.object(KucoinClient, "get_cro_usd_price", return_value=4.4):
-            price_service.ethereum_network = EthereumNetwork.CRONOS_MAINNET
+            price_service.ethereum_network = EthereumNetwork.CRONOS_MAINNET_BETA
             price_service.cache_eth_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 4.4)
 


### PR DESCRIPTION
- Rename required EthereumNetwork values
- Remove not existing networks
