### PR TITLE
Add the number of processed blocks to indexer tasks return

### DIFF
--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -495,7 +495,7 @@ class EthereumIndexer(ABC):
             logger.debug(
                 "%s: No not updated addresses to process", self.__class__.__name__
             )
-        if start_block and last_block:
+        if start_block is not None and last_block is not None:
             number_of_blocks_processed = last_block - start_block + 1
 
         return number_processed_elements, number_of_blocks_processed

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -486,16 +486,16 @@ class EthereumIndexer(ABC):
                 )
                 if start_block is None or from_block_number < start_block:
                     start_block = from_block_number
-                if last_block is None or to_block_number > last_block:
-                    last_block = to_block_number
 
                 number_processed_elements += len(processed_elements)
                 from_block_number = to_block_number + 1
+            if last_block is None or to_block_number > last_block:
+                last_block = to_block_number
         else:
             logger.debug(
                 "%s: No not updated addresses to process", self.__class__.__name__
             )
         if start_block and last_block:
-            number_of_blocks_processed = last_block - start_block
+            number_of_blocks_processed = last_block - start_block + 1
 
         return number_processed_elements, number_of_blocks_processed

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -409,7 +409,6 @@ class EthereumIndexer(ABC):
             current_block_number,
         )
         number_processed_elements = 0
-        number_of_blocks_processed = 0
         start_block: Optional[int] = None
         last_block: Optional[int] = None
         almost_updated_addresses = list(
@@ -497,5 +496,7 @@ class EthereumIndexer(ABC):
             )
         if start_block is not None and last_block is not None:
             number_of_blocks_processed = last_block - start_block + 1
+        else:
+            number_of_blocks_processed = 0
 
         return number_processed_elements, number_of_blocks_processed

--- a/safe_transaction_service/history/tests/test_erc20_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_erc20_events_indexer.py
@@ -8,7 +8,6 @@ from gnosis.eth.tests.ethereum_test_case import EthereumTestCaseMixin
 from ..indexers import Erc20EventsIndexer, Erc20EventsIndexerProvider
 from ..models import ERC20Transfer, EthereumTx, IndexingStatus
 from .factories import SafeContractFactory
-from .utils import get_blocks_processed
 
 
 class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
@@ -31,8 +30,12 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
         self.assertFalse(
             ERC20Transfer.objects.tokens_used_by_address(safe_contract.address)
         )
-        blocks_processed = get_blocks_processed(
-            erc20_events_indexer, self.ethereum_client
+        erc20_721_indexing_block = (
+            IndexingStatus.objects.get_erc20_721_indexing_status().block_number
+        )
+        blocks_processed = (
+            erc20_events_indexer.ethereum_client.current_block_number
+            - erc20_721_indexing_block
         )
         self.assertEqual(erc20_events_indexer.start(), (1, blocks_processed))
 

--- a/safe_transaction_service/history/tests/test_erc20_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_erc20_events_indexer.py
@@ -8,6 +8,7 @@ from gnosis.eth.tests.ethereum_test_case import EthereumTestCaseMixin
 from ..indexers import Erc20EventsIndexer, Erc20EventsIndexerProvider
 from ..models import ERC20Transfer, EthereumTx, IndexingStatus
 from .factories import SafeContractFactory
+from .utils import get_blocks_processed
 
 
 class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
@@ -30,9 +31,9 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
         self.assertFalse(
             ERC20Transfer.objects.tokens_used_by_address(safe_contract.address)
         )
-        from_block_number = erc20_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
+        blocks_processed = get_blocks_processed(
+            erc20_events_indexer, self.ethereum_client
+        )
         self.assertEqual(erc20_events_indexer.start(), (1, blocks_processed))
 
         # Erc20/721 last indexed block number is stored on IndexingStatus

--- a/safe_transaction_service/history/tests/test_erc20_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_erc20_events_indexer.py
@@ -14,7 +14,7 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
     def test_erc20_events_indexer(self):
         erc20_events_indexer = Erc20EventsIndexerProvider()
         erc20_events_indexer.confirmations = 0
-        self.assertEqual(erc20_events_indexer.start(), 0)
+        self.assertEqual(erc20_events_indexer.start(), (0, 0))
 
         account = self.ethereum_test_account
         amount = 10
@@ -30,8 +30,10 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
         self.assertFalse(
             ERC20Transfer.objects.tokens_used_by_address(safe_contract.address)
         )
-
-        self.assertEqual(erc20_events_indexer.start(), 1)
+        from_block_number = erc20_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
+        self.assertEqual(erc20_events_indexer.start(), (1, blocks_processed))
 
         # Erc20/721 last indexed block number is stored on IndexingStatus
         self.assertGreater(

--- a/safe_transaction_service/history/tests/test_erc20_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_erc20_events_indexer.py
@@ -30,14 +30,9 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
         self.assertFalse(
             ERC20Transfer.objects.tokens_used_by_address(safe_contract.address)
         )
-        erc20_721_indexing_block = (
-            IndexingStatus.objects.get_erc20_721_indexing_status().block_number
+        self.assertEqual(
+            erc20_events_indexer.start(), (1, self.ethereum_client.current_block_number)
         )
-        blocks_processed = (
-            erc20_events_indexer.ethereum_client.current_block_number
-            - erc20_721_indexing_block
-        )
-        self.assertEqual(erc20_events_indexer.start(), (1, blocks_processed))
 
         # Erc20/721 last indexed block number is stored on IndexingStatus
         self.assertGreater(

--- a/safe_transaction_service/history/tests/test_proxy_factory_indexer.py
+++ b/safe_transaction_service/history/tests/test_proxy_factory_indexer.py
@@ -11,7 +11,7 @@ class TestProxyFactoryIndexer(SafeTestCaseMixin, TestCase):
     def test_proxy_factory_indexer(self):
         proxy_factory_indexer = ProxyFactoryIndexerProvider()
         proxy_factory_indexer.confirmations = 0
-        self.assertEqual(proxy_factory_indexer.start(), 0)
+        self.assertEqual(proxy_factory_indexer.start(), (0, 0))
 
         ProxyFactoryFactory(address=self.proxy_factory.address)
         ethereum_tx_sent = self.proxy_factory.deploy_proxy_contract(
@@ -19,6 +19,9 @@ class TestProxyFactoryIndexer(SafeTestCaseMixin, TestCase):
         )
         safe_contract_address = ethereum_tx_sent.contract_address
         self.w3.eth.wait_for_transaction_receipt(ethereum_tx_sent.tx_hash)
-        self.assertEqual(proxy_factory_indexer.start(), 1)
+        from_block_number = proxy_factory_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
+        self.assertEqual(proxy_factory_indexer.start(), (1, blocks_processed))
         self.assertEqual(SafeContract.objects.count(), 1)
         self.assertTrue(SafeContract.objects.get(address=safe_contract_address))

--- a/safe_transaction_service/history/tests/test_proxy_factory_indexer.py
+++ b/safe_transaction_service/history/tests/test_proxy_factory_indexer.py
@@ -5,6 +5,7 @@ from gnosis.safe.tests.safe_test_case import SafeTestCaseMixin
 from ..indexers import ProxyFactoryIndexerProvider
 from ..models import SafeContract
 from .factories import ProxyFactoryFactory
+from .utils import get_blocks_processed
 
 
 class TestProxyFactoryIndexer(SafeTestCaseMixin, TestCase):
@@ -19,9 +20,9 @@ class TestProxyFactoryIndexer(SafeTestCaseMixin, TestCase):
         )
         safe_contract_address = ethereum_tx_sent.contract_address
         self.w3.eth.wait_for_transaction_receipt(ethereum_tx_sent.tx_hash)
-        from_block_number = proxy_factory_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
+        blocks_processed = get_blocks_processed(
+            proxy_factory_indexer, self.ethereum_client
+        )
         self.assertEqual(proxy_factory_indexer.start(), (1, blocks_processed))
         self.assertEqual(SafeContract.objects.count(), 1)
         self.assertTrue(SafeContract.objects.get(address=safe_contract_address))

--- a/safe_transaction_service/history/tests/test_proxy_factory_indexer.py
+++ b/safe_transaction_service/history/tests/test_proxy_factory_indexer.py
@@ -5,7 +5,6 @@ from gnosis.safe.tests.safe_test_case import SafeTestCaseMixin
 from ..indexers import ProxyFactoryIndexerProvider
 from ..models import SafeContract
 from .factories import ProxyFactoryFactory
-from .utils import get_blocks_processed
 
 
 class TestProxyFactoryIndexer(SafeTestCaseMixin, TestCase):
@@ -13,16 +12,16 @@ class TestProxyFactoryIndexer(SafeTestCaseMixin, TestCase):
         proxy_factory_indexer = ProxyFactoryIndexerProvider()
         proxy_factory_indexer.confirmations = 0
         self.assertEqual(proxy_factory_indexer.start(), (0, 0))
-
         ProxyFactoryFactory(address=self.proxy_factory.address)
         ethereum_tx_sent = self.proxy_factory.deploy_proxy_contract(
             self.ethereum_test_account, self.safe_contract_address
         )
         safe_contract_address = ethereum_tx_sent.contract_address
         self.w3.eth.wait_for_transaction_receipt(ethereum_tx_sent.tx_hash)
-        blocks_processed = get_blocks_processed(
-            proxy_factory_indexer, self.ethereum_client
+        initial_block = proxy_factory_indexer.get_minimum_block_number(
+            addresses=[self.proxy_factory.address]
         )
+        blocks_processed = self.ethereum_client.current_block_number - initial_block
         self.assertEqual(proxy_factory_indexer.start(), (1, blocks_processed))
         self.assertEqual(SafeContract.objects.count(), 1)
         self.assertTrue(SafeContract.objects.get(address=safe_contract_address))

--- a/safe_transaction_service/history/tests/test_proxy_factory_indexer.py
+++ b/safe_transaction_service/history/tests/test_proxy_factory_indexer.py
@@ -18,10 +18,16 @@ class TestProxyFactoryIndexer(SafeTestCaseMixin, TestCase):
         )
         safe_contract_address = ethereum_tx_sent.contract_address
         self.w3.eth.wait_for_transaction_receipt(ethereum_tx_sent.tx_hash)
-        initial_block = proxy_factory_indexer.get_minimum_block_number(
-            addresses=[self.proxy_factory.address]
-        )
-        blocks_processed = self.ethereum_client.current_block_number - initial_block
+        if (
+            self.ethereum_client.current_block_number
+            - proxy_factory_indexer.block_process_limit
+            < 0
+        ):
+            # From 0 to current block
+            blocks_processed = self.ethereum_client.current_block_number + 1
+        else:
+            # From 1 to current block
+            blocks_processed = self.ethereum_client.current_block_number
         self.assertEqual(proxy_factory_indexer.start(), (1, blocks_processed))
         self.assertEqual(SafeContract.objects.count(), 1)
         self.assertTrue(SafeContract.objects.get(address=safe_contract_address))

--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -174,7 +174,12 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
 
         self.assertEqual(InternalTx.objects.count(), 0)
         self.assertEqual(InternalTxDecoded.objects.count(), 0)
-        self.assertEqual(self.safe_events_indexer.start(), 2)
+
+        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
+
+        self.assertEqual(self.safe_events_indexer.start(), (2, blocks_processed))
         self.assertEqual(InternalTxDecoded.objects.count(), 1)
         self.assertEqual(InternalTx.objects.count(), 2)  # Proxy factory and setup
         create_internal_tx = InternalTx.objects.filter(
@@ -216,8 +221,11 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx = safe.build_multisig_tx(safe_address, 0, data)
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
+        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
         # Process events: SafeMultiSigTransaction, AddedOwner, ExecutionSuccess
-        self.assertEqual(self.safe_events_indexer.start(), 3)
+        self.assertEqual(self.safe_events_indexer.start(), (3, blocks_processed))
         self.assertEqual(InternalTx.objects.count(), 5)
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # Add one SafeStatus increasing the nonce and another one adding the owner
@@ -255,8 +263,11 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx = safe.build_multisig_tx(safe_address, 0, data)
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
+        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
         # Process events: SafeMultiSigTransaction, ChangedThreshold, ExecutionSuccess
-        self.assertEqual(self.safe_events_indexer.start(), 3)
+        self.assertEqual(self.safe_events_indexer.start(), (3, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # Add one SafeStatus increasing the nonce and another one changing the threshold
         self.assertEqual(SafeStatus.objects.count(), 5)
@@ -292,8 +303,11 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.sign(owner_account_2.key)
         multisig_tx.execute(self.ethereum_test_account.key)
+        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
         # Process events: SafeMultiSigTransaction, RemovedOwner, ChangedThreshold, ExecutionSuccess
-        self.assertEqual(self.safe_events_indexer.start(), 4)
+        self.assertEqual(self.safe_events_indexer.start(), (4, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # Add one SafeStatus increasing the nonce and another one removing the owner
         self.assertEqual(SafeStatus.objects.count(), 8)
@@ -340,8 +354,11 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx = safe.build_multisig_tx(safe_address, 0, data)
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
+        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
         # Process events: SafeMultiSigTransaction, EnabledModule, ExecutionSuccess
-        self.assertEqual(self.safe_events_indexer.start(), 3)
+        self.assertEqual(self.safe_events_indexer.start(), (3, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # Add one SafeStatus increasing the nonce and another one enabling the module
         self.assertEqual(SafeStatus.objects.count(), 10)
@@ -372,7 +389,10 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
             self.send_ether(safe_address, value)
         )
         # Process events: SafeReceived
-        self.assertEqual(self.safe_events_indexer.start(), 1)
+        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
+        self.assertEqual(self.safe_events_indexer.start(), (1, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # Check there's an ether transaction
         internal_tx_queryset = InternalTx.objects.filter(
@@ -395,7 +415,10 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
         # Process events: SafeMultiSigTransaction, ChangedFallbackHandler, ExecutionSuccess
-        self.assertEqual(self.safe_events_indexer.start(), 3)
+        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
+        self.assertEqual(self.safe_events_indexer.start(), (3, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # Add one SafeStatus increasing the nonce and another one changing the fallback handler
         self.assertEqual(SafeStatus.objects.count(), 12)
@@ -433,7 +456,10 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
         # Process events: SafeMultiSigTransaction, DisabledModule, ExecutionSuccess
-        self.assertEqual(self.safe_events_indexer.start(), 3)
+        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
+        self.assertEqual(self.safe_events_indexer.start(), (3, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # Add one SafeStatus increasing the nonce and another one disabling the module
         self.assertEqual(SafeStatus.objects.count(), 14)
@@ -471,7 +497,10 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         tx = owner_account_1.sign_transaction(tx)
         self.w3.eth.send_raw_transaction(tx["rawTransaction"])
         # Process events: ApproveHash
-        self.assertEqual(self.safe_events_indexer.start(), 1)
+        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
+        self.assertEqual(self.safe_events_indexer.start(), (1, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # No SafeStatus was added
         self.assertEqual(SafeStatus.objects.count(), 14)
@@ -495,8 +524,11 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx = safe.build_multisig_tx(to, value, data)
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
+        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
         # Process events: SafeMultiSigTransaction, ExecutionSuccess
-        self.assertEqual(self.safe_events_indexer.start(), 2)
+        self.assertEqual(self.safe_events_indexer.start(), (2, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # Add one SafeStatus increasing the nonce
         self.assertEqual(SafeStatus.objects.count(), 15)
@@ -528,8 +560,11 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx = safe.build_multisig_tx(safe_address, 0, data)
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
+        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
         # Process events: SafeMultiSigTransaction, ChangedGuard, ExecutionSuccess
-        self.assertEqual(self.safe_events_indexer.start(), 3)
+        self.assertEqual(self.safe_events_indexer.start(), (3, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # Add one SafeStatus increasing the nonce and another one changing the guard
         self.assertEqual(SafeStatus.objects.count(), 17)
@@ -578,8 +613,11 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         self.assertTrue(self.safe_events_indexer._is_setup_indexed(safe_address))
         safe_l2_master_copy.tx_block_number = initial_block_number
         safe_l2_master_copy.save(update_fields=["tx_block_number"])
+        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
+        current_block_number = self.ethereum_client.current_block_number
+        blocks_processed = current_block_number - from_block_number
         self.assertEqual(
-            self.safe_events_indexer.start(), 0
+            self.safe_events_indexer.start(), (0, blocks_processed)
         )  # No new events are processed when reindexing
         InternalTxDecoded.objects.update(processed=False)
         SafeStatus.objects.all().delete()

--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -23,6 +23,7 @@ from ..models import (
     SafeStatus,
 )
 from .factories import SafeMasterCopyFactory
+from .utils import get_blocks_processed
 
 
 class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
@@ -175,9 +176,9 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         self.assertEqual(InternalTx.objects.count(), 0)
         self.assertEqual(InternalTxDecoded.objects.count(), 0)
 
-        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
+        blocks_processed = get_blocks_processed(
+            self.safe_events_indexer, self.ethereum_client
+        )
 
         self.assertEqual(self.safe_events_indexer.start(), (2, blocks_processed))
         self.assertEqual(InternalTxDecoded.objects.count(), 1)
@@ -221,9 +222,9 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx = safe.build_multisig_tx(safe_address, 0, data)
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
-        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
+        blocks_processed = get_blocks_processed(
+            self.safe_events_indexer, self.ethereum_client
+        )
         # Process events: SafeMultiSigTransaction, AddedOwner, ExecutionSuccess
         self.assertEqual(self.safe_events_indexer.start(), (3, blocks_processed))
         self.assertEqual(InternalTx.objects.count(), 5)
@@ -263,9 +264,9 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx = safe.build_multisig_tx(safe_address, 0, data)
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
-        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
+        blocks_processed = get_blocks_processed(
+            self.safe_events_indexer, self.ethereum_client
+        )
         # Process events: SafeMultiSigTransaction, ChangedThreshold, ExecutionSuccess
         self.assertEqual(self.safe_events_indexer.start(), (3, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
@@ -303,9 +304,9 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.sign(owner_account_2.key)
         multisig_tx.execute(self.ethereum_test_account.key)
-        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
+        blocks_processed = get_blocks_processed(
+            self.safe_events_indexer, self.ethereum_client
+        )
         # Process events: SafeMultiSigTransaction, RemovedOwner, ChangedThreshold, ExecutionSuccess
         self.assertEqual(self.safe_events_indexer.start(), (4, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
@@ -354,9 +355,9 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx = safe.build_multisig_tx(safe_address, 0, data)
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
-        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
+        blocks_processed = get_blocks_processed(
+            self.safe_events_indexer, self.ethereum_client
+        )
         # Process events: SafeMultiSigTransaction, EnabledModule, ExecutionSuccess
         self.assertEqual(self.safe_events_indexer.start(), (3, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
@@ -388,10 +389,10 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         self.ethereum_client.get_transaction_receipt(
             self.send_ether(safe_address, value)
         )
+        blocks_processed = get_blocks_processed(
+            self.safe_events_indexer, self.ethereum_client
+        )
         # Process events: SafeReceived
-        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
         self.assertEqual(self.safe_events_indexer.start(), (1, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # Check there's an ether transaction
@@ -414,10 +415,10 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx = safe.build_multisig_tx(safe_address, 0, data)
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
+        blocks_processed = get_blocks_processed(
+            self.safe_events_indexer, self.ethereum_client
+        )
         # Process events: SafeMultiSigTransaction, ChangedFallbackHandler, ExecutionSuccess
-        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
         self.assertEqual(self.safe_events_indexer.start(), (3, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # Add one SafeStatus increasing the nonce and another one changing the fallback handler
@@ -455,10 +456,10 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx = safe.build_multisig_tx(safe_address, 0, data)
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
+        blocks_processed = get_blocks_processed(
+            self.safe_events_indexer, self.ethereum_client
+        )
         # Process events: SafeMultiSigTransaction, DisabledModule, ExecutionSuccess
-        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
         self.assertEqual(self.safe_events_indexer.start(), (3, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # Add one SafeStatus increasing the nonce and another one disabling the module
@@ -496,10 +497,10 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         )
         tx = owner_account_1.sign_transaction(tx)
         self.w3.eth.send_raw_transaction(tx["rawTransaction"])
+        blocks_processed = get_blocks_processed(
+            self.safe_events_indexer, self.ethereum_client
+        )
         # Process events: ApproveHash
-        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
         self.assertEqual(self.safe_events_indexer.start(), (1, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
         # No SafeStatus was added
@@ -524,9 +525,9 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx = safe.build_multisig_tx(to, value, data)
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
-        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
+        blocks_processed = get_blocks_processed(
+            self.safe_events_indexer, self.ethereum_client
+        )
         # Process events: SafeMultiSigTransaction, ExecutionSuccess
         self.assertEqual(self.safe_events_indexer.start(), (2, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
@@ -560,9 +561,9 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         multisig_tx = safe.build_multisig_tx(safe_address, 0, data)
         multisig_tx.sign(owner_account_1.key)
         multisig_tx.execute(self.ethereum_test_account.key)
-        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
+        blocks_processed = get_blocks_processed(
+            self.safe_events_indexer, self.ethereum_client
+        )
         # Process events: SafeMultiSigTransaction, ChangedGuard, ExecutionSuccess
         self.assertEqual(self.safe_events_indexer.start(), (3, blocks_processed))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
@@ -613,9 +614,9 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         self.assertTrue(self.safe_events_indexer._is_setup_indexed(safe_address))
         safe_l2_master_copy.tx_block_number = initial_block_number
         safe_l2_master_copy.save(update_fields=["tx_block_number"])
-        from_block_number = self.safe_events_indexer.get_minimum_block_number() + 1
-        current_block_number = self.ethereum_client.current_block_number
-        blocks_processed = current_block_number - from_block_number
+        blocks_processed = get_blocks_processed(
+            self.safe_events_indexer, self.ethereum_client
+        )
         self.assertEqual(
             self.safe_events_indexer.start(), (0, blocks_processed)
         )  # No new events are processed when reindexing

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -56,7 +56,7 @@ class TestTasks(TestCase):
         self.assertFalse(check_sync_status_task.delay().result)
 
     def test_index_erc20_events_task(self):
-        self.assertEqual(index_erc20_events_task.delay().result, 0)
+        self.assertEqual(index_erc20_events_task.delay().result, (0, 0))
 
     def test_index_erc20_events_out_of_sync_task(self):
         with self.assertLogs(logger=task_logger) as cm:
@@ -76,13 +76,13 @@ class TestTasks(TestCase):
             )
 
     def test_index_internal_txs_task(self):
-        self.assertEqual(index_internal_txs_task.delay().result, 0)
+        self.assertEqual(index_internal_txs_task.delay().result, (0, 0))
 
     def test_index_new_proxies_task(self):
-        self.assertEqual(index_new_proxies_task.delay().result, 0)
+        self.assertEqual(index_new_proxies_task.delay().result, (0, 0))
 
     def test_index_safe_events_task(self):
-        self.assertEqual(index_safe_events_task.delay().result, 0)
+        self.assertEqual(index_safe_events_task.delay().result, (0, 0))
 
     @patch.object(IndexService, "reindex_erc20_events")
     @patch.object(IndexService, "reindex_master_copies")

--- a/safe_transaction_service/history/tests/utils.py
+++ b/safe_transaction_service/history/tests/utils.py
@@ -3,6 +3,10 @@ import os
 import pytest
 import requests
 
+from gnosis.eth import EthereumClient
+
+from safe_transaction_service.history.indexers.events_indexer import EventsIndexer
+
 
 def just_test_if_mainnet_node() -> str:
     mainnet_node_url = os.environ.get("ETHEREUM_MAINNET_NODE")
@@ -32,3 +36,9 @@ def just_test_if_mainnet_node() -> str:
             )
     just_test_if_mainnet_node.checked = True
     return mainnet_node_url
+
+
+def get_blocks_processed(indexer: EventsIndexer, ethereum_client: EthereumClient):
+    from_block_number, _ = indexer.get_block_numbers_for_search(addresses=None)
+    current_block_number = ethereum_client.current_block_number
+    return current_block_number - from_block_number

--- a/safe_transaction_service/history/tests/utils.py
+++ b/safe_transaction_service/history/tests/utils.py
@@ -3,10 +3,6 @@ import os
 import pytest
 import requests
 
-from gnosis.eth import EthereumClient
-
-from safe_transaction_service.history.indexers.events_indexer import EventsIndexer
-
 
 def just_test_if_mainnet_node() -> str:
     mainnet_node_url = os.environ.get("ETHEREUM_MAINNET_NODE")
@@ -36,9 +32,3 @@ def just_test_if_mainnet_node() -> str:
             )
     just_test_if_mainnet_node.checked = True
     return mainnet_node_url
-
-
-def get_blocks_processed(indexer: EventsIndexer, ethereum_client: EthereumClient):
-    from_block_number, _ = indexer.get_block_numbers_for_search(addresses=None)
-    current_block_number = ethereum_client.current_block_number
-    return current_block_number - from_block_number


### PR DESCRIPTION
Close #1319 
# Main change
This PR modify the return int of every indexer task to return a `Tuple[int, int]` where the second integer is the number of blocks processed by the task. 
# Tasks modified
-  def index_erc20_events_task(self) -> Optional[Tuple[int, int]]
-  def index_internal_txs_task(self) -> Optional[Tuple[int, int]]
-  def index_new_proxies_task(self) -> Optional[Tuple[int, int]]
-  def index_safe_events_task(self) -> Optional[Tuple[int, int]]
# Collateral changes
To achieve the PR purpose was necessary modify the return value of:
- `def start(self) ` to return a `Tuple[int, int]`  where the second int is the number of blocks processed
- ` def process_addresses(...)` to return `Tuple[Sequence[Any], int, int, bool]` where the second int is the `from_block_number`
# Change log level 
- "Indexing of erc20/721 events task processed %d events" to debug  