### PR TITLE
Fix admin search firebasedeviceowner

### DIFF
--- a/safe_transaction_service/notifications/admin.py
+++ b/safe_transaction_service/notifications/admin.py
@@ -37,4 +37,4 @@ class FirebaseDeviceAdmin(BinarySearchAdmin):
 class FirebaseDeviceOwnerAdmin(BinarySearchAdmin):
     list_display = ("firebase_device_id", "owner")
     ordering = ["firebase_device_id"]
-    search_fields = ["firebase_device_id", "=owner"]
+    search_fields = ["firebase_device_id__uuid", "=owner"]


### PR DESCRIPTION
### What was wrong? 👾
Admin search for `FirebaseDeviceOwner` return an error because the field that the query is trying to search doesn't exist. 

### How was fixed
The issue was that the search field was the `FirebaseDevice` instance instead the `uuid` field. 
