### PR TITLE
reindex_last_hours_task executes sequentally each type of indexer

### DIFF
--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -276,7 +276,10 @@ def reindex_last_hours_task(self, hours: int = 2) -> Optional[int]:
                         from_block_number,
                         to_block_number,
                     )
-                    reindex_erc20_events_task.delay(from_block_number, to_block_number)
+                    # countdown of 30 minutes to execute this reindex after mastercopies reindex is finished
+                    reindex_erc20_events_task.apply_async(
+                        (from_block_number, to_block_number), countdown=60 * 30
+                    )
 
 
 @app.shared_task(bind=True, soft_time_limit=SOFT_TIMEOUT, time_limit=LOCK_TIMEOUT)


### PR DESCRIPTION
## Description
This PR modify `reindex_last_hours_task` to avoid execute the `reindex_erc20_task` and `reindex_mastercopies_task` in parallel and do it sequentially. 
## Related issue
Closes #1329 

