### PR TITLE
Remove sensitive info from About view

### DIFF
--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -77,7 +77,6 @@ class AboutView(APIView):
             "headers": [x for x in request.META.keys() if "FORWARD" in x],
             "settings": {
                 "AWS_CONFIGURED": settings.AWS_CONFIGURED,
-                "AWS_S3_BUCKET_NAME": settings.AWS_S3_BUCKET_NAME,
                 "AWS_S3_PUBLIC_URL": settings.AWS_S3_PUBLIC_URL,
                 "ETHEREUM_NODE_URL": settings.ETHEREUM_NODE_URL,
                 "ETHEREUM_TRACING_NODE_URL": settings.ETHEREUM_TRACING_NODE_URL,


### PR DESCRIPTION
Because it is not recommended to expose S3_BUCKET_NAME for security reasons.
For example: somebody could "steal" that S3 bucket in the future if it is available or send some specific attacts to it.
