### PR TITLE
Limit v1 collectibles endpoint to 10 collectibles

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.15.2"
+__version__ = "4.16.0"
 __version_info__ = tuple(
     int(num) if num.isdigit() else num
     for num in __version__.replace("-", ".", 1).split(".")

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -510,7 +510,7 @@ class CollectiblesService:
         :return: collectibles
         """
         collectibles, _ = self._get_collectibles_with_metadata(
-            safe_address, only_trusted, exclude_spam, limit=50, offset=0
+            safe_address, only_trusted, exclude_spam, limit=10, offset=0
         )
         return collectibles
 


### PR DESCRIPTION
- Fix performance issues detected on production
- We cannot deprecate the endpoint yet as mobile clients are still using it
