### PR TITLE
Refactor block range calculation for indexers

### DIFF
--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -210,5 +210,5 @@ class Erc20EventsIndexer(EventsIndexer):
         self, addresses: Sequence[str], from_block_number: int, to_block_number: int
     ) -> int:
         return int(
-            IndexingStatus.objects.set_erc20_721_indexing_status(to_block_number)
+            IndexingStatus.objects.set_erc20_721_indexing_status(to_block_number + 1)
         )

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -160,7 +160,6 @@ class EthereumIndexer(ABC):
             )
             from_block_number = max(from_block_number - blocks_to_reindex, 0)
 
-        print(from_block_number, to_block_number)
         return from_block_number, to_block_number
 
     def get_to_block_number(
@@ -507,5 +506,4 @@ class EthereumIndexer(ABC):
         else:
             number_of_blocks_processed = 0
 
-        print("processed", last_block, start_block, number_of_blocks_processed)
         return number_processed_elements, number_of_blocks_processed

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -494,7 +494,7 @@ class EthereumIndexer(ABC):
                     start_block = from_block_number
 
                 number_processed_elements += len(processed_elements)
-                from_block_number = to_block_number + 1
+                from_block_number += 1
             if last_block is None or to_block_number > last_block:
                 last_block = to_block_number
         else:

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -169,6 +169,7 @@ class EthereumIndexer(ABC):
         """
         :param from_block_number:
         :param current_block_number:
+
         :return: Top block number to process
         """
         return min(
@@ -478,7 +479,7 @@ class EthereumIndexer(ABC):
                     monitored_contract.address
                     for monitored_contract in not_updated_addresses
                     if getattr(monitored_contract, self.database_field)
-                    < to_block_number_expected
+                    <= to_block_number_expected
                 ]
                 # Get real `to_block_number` processed
                 (

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -137,23 +137,30 @@ class EthereumIndexer(ABC):
             current_block_number or self.ethereum_client.current_block_number
         )
 
-        common_minimum_block_number = self.get_minimum_block_number(addresses)
-        if common_minimum_block_number is None:  # Empty queryset
+        from_block_number = self.get_minimum_block_number(addresses)
+        if from_block_number is None:  # Empty queryset
             return None
 
-        from_block_number = common_minimum_block_number + 1
-        if (from_block_number + self.block_process_limit) >= (
-            current_block_number - self.confirmations
-        ):
-            # Reindex again when it's almost synced to prevent reorg/missing elements issues
-            from_block_number = max(from_block_number - self.blocks_to_reindex_again, 0)
-
-        if (current_block_number - common_minimum_block_number) <= self.confirmations:
+        if (current_block_number - from_block_number) < self.confirmations:
             return  # We don't want problems with reorgs
 
         to_block_number = self.get_to_block_number(
             from_block_number, current_block_number
         )
+
+        # Reindex again when it's almost synced to prevent reorg/missing elements issues
+        if (
+            from_block_number + self.block_process_limit
+            > current_block_number - self.confirmations
+        ):
+            # Check if there's room on `block_process_limit` to reindex some blocks
+            blocks_to_reindex = min(
+                self.block_process_limit - (to_block_number - from_block_number + 1),
+                self.blocks_to_reindex_again,
+            )
+            from_block_number = max(from_block_number - blocks_to_reindex, 0)
+
+        print(from_block_number, to_block_number)
         return from_block_number, to_block_number
 
     def get_to_block_number(
@@ -165,7 +172,7 @@ class EthereumIndexer(ABC):
         :return: Top block number to process
         """
         return min(
-            from_block_number + self.block_process_limit,
+            from_block_number + self.block_process_limit - 1,
             current_block_number - self.confirmations,
         )
 
@@ -240,7 +247,7 @@ class EthereumIndexer(ABC):
         )
 
         not_updated_addresses = self.database_queryset.filter(
-            **{self.database_field + "__lt": current_block_number - self.confirmations}
+            **{self.database_field + "__lte": current_block_number - self.confirmations}
         ).order_by(self.database_field)
 
         logger.debug(
@@ -264,6 +271,9 @@ class EthereumIndexer(ABC):
             self.__class__.__name__,
         )
 
+        # Keep indexing going on the next block
+        new_to_block_number = to_block_number + 1
+
         updated_addresses = self.database_queryset.filter(
             **{
                 "address__in": addresses,
@@ -271,9 +281,9 @@ class EthereumIndexer(ABC):
                 + "__gte": from_block_number
                 - 1,  # Protect in case of reorg
                 self.database_field
-                + "__lte": to_block_number,  # Don't update to a lower block number
+                + "__lt": new_to_block_number,  # Don't update to a lower block number
             }
-        ).update(**{self.database_field: to_block_number})
+        ).update(**{self.database_field: new_to_block_number})
 
         if updated_addresses != len(addresses):
             logger.warning(
@@ -283,7 +293,7 @@ class EthereumIndexer(ABC):
                 updated_addresses,
                 len(addresses),
                 from_block_number,
-                to_block_number,
+                new_to_block_number,
             )
 
         logger.debug(
@@ -400,7 +410,7 @@ class EthereumIndexer(ABC):
         """
         Find and process relevant data for existing database addresses
 
-        :return: Number of elements processed and the number of blocks processed
+        :return: (number of elements processed, number of blocks processed)
         """
         current_block_number = self.ethereum_client.current_block_number
         logger.debug(
@@ -455,10 +465,7 @@ class EthereumIndexer(ABC):
             )
 
             # Not updated addresses are sorted by tx_block_number
-            minimum_block_number = getattr(
-                not_updated_addresses[0], self.database_field
-            )
-            from_block_number = minimum_block_number + 1
+            from_block_number = getattr(not_updated_addresses[0], self.database_field)
             updated = False
             while not updated:
                 # Estimate to_block_number
@@ -499,4 +506,5 @@ class EthereumIndexer(ABC):
         else:
             number_of_blocks_processed = 0
 
+        print("processed", last_block, start_block, number_of_blocks_processed)
         return number_processed_elements, number_of_blocks_processed

--- a/safe_transaction_service/history/tests/test_erc20_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_erc20_events_indexer.py
@@ -36,7 +36,8 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
             ERC20Transfer.objects.tokens_used_by_address(safe_contract.address)
         )
         self.assertEqual(
-            erc20_events_indexer.start(), (1, self.ethereum_client.current_block_number)
+            erc20_events_indexer.start(),
+            (1, self.ethereum_client.current_block_number + 1),
         )
 
         # Erc20/721 last indexed block number is stored on IndexingStatus
@@ -47,7 +48,8 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
         self.assertEqual(
             IndexingStatus.objects.get_erc20_721_indexing_status().block_number,
             self.ethereum_client.current_block_number
-            - erc20_events_indexer.confirmations,
+            - erc20_events_indexer.confirmations
+            + 1,
         )
         self.assertTrue(EthereumTx.objects.filter(tx_hash=tx_hash).exists())
         self.assertTrue(

--- a/safe_transaction_service/history/tests/test_internal_tx_indexer.py
+++ b/safe_transaction_service/history/tests/test_internal_tx_indexer.py
@@ -161,7 +161,7 @@ class TestInternalTxIndexer(TestCase):
 
         trace_filter_mock.assert_called_once_with(
             internal_tx_indexer.ethereum_client.parity,
-            from_block=1,
+            from_block=0,
             to_block=current_block_number - internal_tx_indexer.number_trace_blocks,
             to_address=[safe_master_copy.address],
         )

--- a/safe_transaction_service/history/tests/test_proxy_factory_indexer.py
+++ b/safe_transaction_service/history/tests/test_proxy_factory_indexer.py
@@ -18,16 +18,9 @@ class TestProxyFactoryIndexer(SafeTestCaseMixin, TestCase):
         )
         safe_contract_address = ethereum_tx_sent.contract_address
         self.w3.eth.wait_for_transaction_receipt(ethereum_tx_sent.tx_hash)
-        if (
-            self.ethereum_client.current_block_number
-            - proxy_factory_indexer.block_process_limit
-            < 0
-        ):
-            # From 0 to current block
-            blocks_processed = self.ethereum_client.current_block_number + 1
-        else:
-            # From 1 to current block
-            blocks_processed = self.ethereum_client.current_block_number
-        self.assertEqual(proxy_factory_indexer.start(), (1, blocks_processed))
+        self.assertEqual(
+            proxy_factory_indexer.start(),
+            (1, self.ethereum_client.current_block_number + 1),
+        )
         self.assertEqual(SafeContract.objects.count(), 1)
         self.assertTrue(SafeContract.objects.get(address=safe_contract_address))

--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -157,7 +157,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
                 payment_receiver,
             ).build_transaction({"gas": 1, "gasPrice": 1})["data"]
         )
-        initial_block_number = self.ethereum_client.current_block_number
+        initial_block_number = self.ethereum_client.current_block_number + 1
         safe_l2_master_copy = SafeMasterCopyFactory(
             address=self.safe_contract.address,
             initial_block_number=initial_block_number,
@@ -177,7 +177,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
 
         self.assertEqual(InternalTx.objects.count(), 0)
         self.assertEqual(InternalTxDecoded.objects.count(), 0)
-        self.assertEqual(self.safe_events_indexer.start(), (2, 2))
+        self.assertEqual(self.safe_events_indexer.start(), (2, 1))
         self.assertEqual(InternalTxDecoded.objects.count(), 1)
         self.assertEqual(InternalTx.objects.count(), 2)  # Proxy factory and setup
         create_internal_tx = InternalTx.objects.filter(

--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -177,7 +177,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
 
         self.assertEqual(InternalTx.objects.count(), 0)
         self.assertEqual(InternalTxDecoded.objects.count(), 0)
-        self.assertEqual(self.safe_events_indexer.start(), (2, 1))
+        self.assertEqual(self.safe_events_indexer.start(), (2, 2))
         self.assertEqual(InternalTxDecoded.objects.count(), 1)
         self.assertEqual(InternalTx.objects.count(), 2)  # Proxy factory and setup
         create_internal_tx = InternalTx.objects.filter(
@@ -584,6 +584,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         blocks_processed = (
             self.safe_events_indexer.ethereum_client.current_block_number
             - initial_block_number
+            + 1
         )
         self.assertEqual(
             self.safe_events_indexer.start(), (0, blocks_processed)


### PR DESCRIPTION
- Store next block to index in database instead of last indexed block
- Allow to process only 1 block (until now 2 was the minimum)
- Allow to index the current block number if `confirmations=0`
