### PR TITLE
Ignore coingecko failing tests

### DIFF
--- a/safe_transaction_service/history/tests/utils.py
+++ b/safe_transaction_service/history/tests/utils.py
@@ -1,3 +1,4 @@
+import functools
 import os
 
 import pytest
@@ -32,3 +33,26 @@ def just_test_if_mainnet_node() -> str:
             )
     just_test_if_mainnet_node.checked = True
     return mainnet_node_url
+
+
+def skip_on(exception, reason="Test skipped due to a controlled exception"):
+    """
+    Decorator to skip a test if an exception is raised instead of failing it
+
+    :param exception:
+    :param reason:
+    :return:
+    """
+
+    def decorator_func(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            try:
+                # Run the test
+                return f(*args, **kwargs)
+            except exception:
+                pytest.skip(reason)
+
+        return wrapper
+
+    return decorator_func

--- a/safe_transaction_service/tokens/clients/coingecko_client.py
+++ b/safe_transaction_service/tokens/clients/coingecko_client.py
@@ -11,6 +11,7 @@ from gnosis.eth import EthereumNetwork
 from safe_transaction_service.tokens.clients.exceptions import (
     CannotGetPrice,
     Coingecko404,
+    CoingeckoRateLimitError,
     CoingeckoRequestError,
 )
 
@@ -66,7 +67,9 @@ class CoingeckoClient:
             response = self.http_session.get(url, timeout=10)
             if not response.ok:
                 if response.status_code == 404:
-                    raise Coingecko404
+                    raise Coingecko404(url)
+                if response.status_code == 429:
+                    raise CoingeckoRateLimitError(url)
                 raise CoingeckoRequestError(url)
             return response.json()
         except (ValueError, IOError) as e:

--- a/safe_transaction_service/tokens/clients/exceptions.py
+++ b/safe_transaction_service/tokens/clients/exceptions.py
@@ -6,5 +6,16 @@ class Coingecko404(CoingeckoRequestError):
     pass
 
 
+class CoingeckoRateLimitError(CoingeckoRequestError):
+    """
+    {
+    "status": {
+        "error_code": 429,
+        "error_message": "You've exceeded the Rate Limit. Please visit https://www.coingecko.com/en/api/pricing to subscribe to our API plans for higher rate limits."
+        }
+    }
+    """
+
+
 class CannotGetPrice(CoingeckoRequestError):
     pass

--- a/safe_transaction_service/tokens/tests/clients/test_coingecko_client.py
+++ b/safe_transaction_service/tokens/tests/clients/test_coingecko_client.py
@@ -1,15 +1,21 @@
 from django.test import TestCase
 
+from _pytest.outcomes import importorskip
+
 from gnosis.eth import EthereumNetwork
+
+from safe_transaction_service.history.tests.utils import skip_on
 
 from ...clients import CannotGetPrice
 from ...clients.coingecko_client import CoingeckoClient
+from ...clients.exceptions import CoingeckoRateLimitError
 
 
 class TestCoingeckoClient(TestCase):
     GNO_TOKEN_ADDRESS = "0x6810e776880C02933D47DB1b9fc05908e5386b96"
     GNO_GNOSIS_CHAIN_ADDRESS = "0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb"
 
+    @skip_on(CannotGetPrice, reason="Cannot get price from Coingecko")
     def test_coingecko_client(self):
         self.assertTrue(CoingeckoClient.supports_network(EthereumNetwork.MAINNET))
         self.assertTrue(
@@ -41,6 +47,9 @@ class TestCoingeckoClient(TestCase):
         bnb_pos_address = "0xb33EaAd8d922B1083446DC23f610c2567fB5180f"
         self.assertGreater(polygon_coingecko_client.get_token_price(bnb_pos_address), 0)
 
+    importorskip
+
+    @skip_on(CoingeckoRateLimitError, reason="Coingecko rate limit reached")
     def test_get_logo_url(self):
         # Test Mainnet
         coingecko_client = CoingeckoClient()


### PR DESCRIPTION
- Usually due to rate limits
