### PR TITLE
Bump redis version 4.5.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ packaging>=21.0
 pillow==9.4.0
 psycogreen==1.0.2
 psycopg2==2.9.5
-redis==4.5.3
+redis==4.5.4
 requests==2.28.2
 safe-eth-py[django]==5.1.0
 web3==5.31.3


### PR DESCRIPTION
## Bump redis version 4.5.4
Release note [v4.5.4](https://github.com/redis/redis-py/releases/tag/v4.5.4)