### PR TITLE
Fix indexing same block with trace_filter and trace_block

### DIFF
--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -418,7 +418,7 @@ class EthereumIndexer(ABC):
             self.__class__.__name__,
             current_block_number,
         )
-        number_processed_elements = 0
+        total_number_processed_elements = 0
         start_block: Optional[int] = None
         last_block: Optional[int] = None
         almost_updated_addresses = list(
@@ -445,7 +445,15 @@ class EthereumIndexer(ABC):
                     almost_updated_addresses_to_process,
                     current_block_number=current_block_number,
                 )
-                number_processed_elements += len(processed_elements)
+                number_processed_elements = len(processed_elements)
+                logger.debug(
+                    "%s: Processed %d elements for almost updated addresses. From-block-number=%d to-block-number=%d",
+                    self.__class__.__name__,
+                    number_processed_elements,
+                    from_block_number,
+                    to_block_number,
+                )
+                total_number_processed_elements += number_processed_elements
                 if start_block is None:
                     start_block = from_block_number
             last_block = to_block_number
@@ -493,7 +501,15 @@ class EthereumIndexer(ABC):
                 if start_block is None or from_block_number < start_block:
                     start_block = from_block_number
 
-                number_processed_elements += len(processed_elements)
+                number_processed_elements = len(processed_elements)
+                logger.debug(
+                    "%s: Processed %d elements for not updated addresses. From-block-number=%d to-block-number=%d",
+                    self.__class__.__name__,
+                    number_processed_elements,
+                    from_block_number,
+                    to_block_number,
+                )
+                total_number_processed_elements += number_processed_elements
                 from_block_number += 1
             if last_block is None or to_block_number > last_block:
                 last_block = to_block_number
@@ -506,4 +522,4 @@ class EthereumIndexer(ABC):
         else:
             number_of_blocks_processed = 0
 
-        return number_processed_elements, number_of_blocks_processed
+        return total_number_processed_elements, number_of_blocks_processed

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -139,7 +139,7 @@ class BulkCreateSignalMixin:
     ) -> int:
         """
         Implementation in Django is not ok, as it will do `objs = list(objs)`. If objects come from a generator
-        they will be brought to RAM. This approach is more friendly
+        they will be brought to RAM. This approach is more RAM friendly.
 
         :return: Count of inserted elements
         """

--- a/safe_transaction_service/history/tests/test_internal_tx_indexer.py
+++ b/safe_transaction_service/history/tests/test_internal_tx_indexer.py
@@ -169,7 +169,7 @@ class TestInternalTxIndexer(TestCase):
             internal_tx_indexer.ethereum_client.parity,
             list(
                 range(
-                    current_block_number - internal_tx_indexer.number_trace_blocks,
+                    current_block_number - internal_tx_indexer.number_trace_blocks + 1,
                     current_block_number + 1 - internal_tx_indexer.confirmations,
                 )
             ),
@@ -245,7 +245,7 @@ class TestInternalTxIndexer(TestCase):
             internal_tx_indexer.ethereum_client.parity,
             list(
                 range(
-                    current_block_number - internal_tx_indexer.number_trace_blocks,
+                    current_block_number - internal_tx_indexer.number_trace_blocks + 1,
                     current_block_number + 1,
                 )
             ),


### PR DESCRIPTION
- Previously when indexing in mixed `trace_filter`/`trace_block `mode last block for `trace_filter `was also indexed by `trace_block`

Also:
- Add more debug log messages on the indexers
- Update some function docstrings
