### PR TITLE
Fix USD prices for tokens

### DIFF
--- a/safe_transaction_service/history/services/balance_service.py
+++ b/safe_transaction_service/history/services/balance_service.py
@@ -261,7 +261,7 @@ class BalanceService:
         :param exclude_spam: If True, exclude spam tokens
         :return: List of BalanceWithFiat
         """
-        # TODO Use price service get_cached_usd_values
+        # TODO Use price service get_token_cached_usd_values
         balances: List[Balance] = self.get_balances(
             safe_address, only_trusted, exclude_spam
         )
@@ -273,7 +273,7 @@ class BalanceService:
         balances_with_usd = []
         price_token_addresses = [balance.get_price_address() for balance in balances]
         token_eth_values_with_timestamp = (
-            self.price_service.get_cached_token_eth_values(price_token_addresses)
+            self.price_service.get_token_cached_eth_values(price_token_addresses)
         )
         for balance, token_eth_value_with_timestamp in zip(
             balances, token_eth_values_with_timestamp

--- a/safe_transaction_service/tokens/clients/binance_client.py
+++ b/safe_transaction_service/tokens/clients/binance_client.py
@@ -36,7 +36,7 @@ class BinanceClient:  # pragma: no cover
     def get_bnb_usd_price(self) -> float:
         return self._get_price("BNBUSDT")
 
-    def get_eth_usd_price(self) -> float:
+    def get_ether_usd_price(self) -> float:
         """
         :return: current USD price for Ethereum
         :raises: CannotGetPrice

--- a/safe_transaction_service/tokens/clients/kraken_client.py
+++ b/safe_transaction_service/tokens/clients/kraken_client.py
@@ -47,7 +47,7 @@ class KrakenClient:
         """
         return self._get_price("DAIUSD")
 
-    def get_eth_usd_price(self) -> float:
+    def get_ether_usd_price(self) -> float:
         """
         :return: current USD price for Ethereum
         :raises: CannotGetPrice

--- a/safe_transaction_service/tokens/clients/kucoin_client.py
+++ b/safe_transaction_service/tokens/clients/kucoin_client.py
@@ -22,7 +22,7 @@ class KucoinClient:
             logger.warning("Cannot get price from url=%s", url)
             raise CannotGetPrice from e
 
-    def get_eth_usd_price(self) -> float:
+    def get_ether_usd_price(self) -> float:
         """
         :return: current USD price for ETH Coin
         :raises: CannotGetPrice

--- a/safe_transaction_service/tokens/services/price_service.py
+++ b/safe_transaction_service/tokens/services/price_service.py
@@ -198,15 +198,15 @@ class PriceService:
             return self.coingecko_client.get_kcs_usd_price()
 
     @cachedmethod(cache=operator.attrgetter("cache_ether_usd_price"))
-    @cache_memoize(60 * 30, prefix="balances-get_eth_usd_price")  # 30 minutes
+    @cache_memoize(60 * 30, prefix="balances-get_ether_usd_price")  # 30 minutes
     def get_ether_usd_price(self) -> float:
         """
         :return: USD Price for Ether
         """
         try:
-            return self.kraken_client.get_eth_usd_price()
+            return self.kraken_client.get_ether_usd_price()
         except CannotGetPrice:
-            return self.kucoin_client.get_eth_usd_price()
+            return self.kucoin_client.get_ether_usd_price()
 
     @cachedmethod(cache=operator.attrgetter("cache_native_coin_usd_price"))
     @cache_memoize(60 * 30, prefix="balances-get_native_coin_usd_price")  # 30 minutes

--- a/safe_transaction_service/tokens/tasks.py
+++ b/safe_transaction_service/tokens/tasks.py
@@ -66,9 +66,11 @@ def calculate_token_eth_price_task(
     )  # Expire in 15 minutes
     if key_was_set or force_recalculation:
         price_service = PriceServiceProvider()
-        eth_price = price_service.get_eth_price_from_oracles(token_address)
+        eth_price = price_service.get_token_eth_price_from_oracles(token_address)
         if not eth_price:
-            eth_price = price_service.get_eth_price_from_composed_oracles(token_address)
+            eth_price = price_service.get_token_eth_price_from_composed_oracles(
+                token_address
+            )
 
         logger.debug("Calculated eth-price=%f for token=%s", eth_price, token_address)
         if not eth_price:

--- a/safe_transaction_service/tokens/tests/clients/test_clients.py
+++ b/safe_transaction_service/tokens/tests/clients/test_clients.py
@@ -32,12 +32,12 @@ class TestClients(TestCase):
         self.assertIsInstance(price, float)
         self.assertGreater(price, 0)
 
-    def test_get_eth_usd_price_kraken(self):
+    def test_get_ether_usd_price_kraken(self):
         just_test_if_mainnet_node()
         kraken_client = KrakenClient()
 
         # Kraken is used
-        eth_usd_price = kraken_client.get_eth_usd_price()
+        eth_usd_price = kraken_client.get_ether_usd_price()
         self.assertIsInstance(eth_usd_price, float)
         self.assertGreater(eth_usd_price, 0)
 
@@ -50,11 +50,11 @@ class TestClients(TestCase):
         self.assertIsInstance(price, float)
         self.assertGreater(price, 0)
 
-    def test_get_eth_usd_price_kucoin(self):
+    def test_get_ether_usd_price_kucoin(self):
         just_test_if_mainnet_node()
         kucoin_client = KucoinClient()
 
-        eth_usd_price = kucoin_client.get_eth_usd_price()
+        eth_usd_price = kucoin_client.get_ether_usd_price()
         self.assertIsInstance(eth_usd_price, float)
         self.assertGreater(eth_usd_price, 0)
 

--- a/safe_transaction_service/tokens/tests/test_price_service.py
+++ b/safe_transaction_service/tokens/tests/test_price_service.py
@@ -31,24 +31,46 @@ class TestPriceService(TestCase):
     def tearDown(self) -> None:
         PriceServiceProvider.del_singleton()
 
+    def test_available_price_oracles(self):
+        # Ganache should have no oracle enabled
+        self.assertEqual(len(self.price_service.enabled_price_oracles), 0)
+        self.assertEqual(len(self.price_service.enabled_price_pool_oracles), 0)
+        self.assertEqual(len(self.price_service.enabled_composed_price_oracles), 0)
+
+    def test_available_price_oracles_mainnet(self):
+        # Mainnet should have every oracle enabled
+        mainnet_node = just_test_if_mainnet_node()
+        price_service = PriceService(EthereumClient(mainnet_node), self.redis)
+        self.assertEqual(len(price_service.enabled_price_oracles), 6)
+        self.assertEqual(len(price_service.enabled_price_pool_oracles), 3)
+        self.assertEqual(len(price_service.enabled_composed_price_oracles), 4)
+
     @mock.patch.object(KrakenClient, "get_eth_usd_price", return_value=0.4)
     @mock.patch.object(KucoinClient, "get_eth_usd_price", return_value=0.5)
     def test_get_native_coin_usd_price(
         self, binance_mock: MagicMock, kraken_mock: MagicMock
     ):
         price_service = self.price_service
+
+        # Unsupported network (Ganache)
         eth_usd_price = price_service.get_native_coin_usd_price()
         self.assertEqual(eth_usd_price, kraken_mock.return_value)
         binance_mock.assert_not_called()
 
         kraken_mock.side_effect = CannotGetPrice
 
-        # Cache is still working
+        # cache_native_coin_usd_price is working
         eth_usd_price = price_service.get_native_coin_usd_price()
         self.assertEqual(eth_usd_price, kraken_mock.return_value)
 
-        # Remove cache and test binance is called
-        price_service.cache_eth_price.clear()
+        # Clear cache_native_coin_usd_price, but cache_ether_usd_price is still there
+        price_service.cache_native_coin_usd_price.clear()
+        self.assertEqual(eth_usd_price, kraken_mock.return_value)
+        binance_mock.assert_not_called()
+
+        # Clear both caches and test binance is now called
+        price_service.cache_native_coin_usd_price.clear()
+        price_service.cache_ether_usd_price.clear()
         eth_usd_price = price_service.get_native_coin_usd_price()
         binance_mock.called_once()
         self.assertEqual(eth_usd_price, binance_mock.return_value)
@@ -56,31 +78,31 @@ class TestPriceService(TestCase):
         # Gnosis Chain
         price_service.ethereum_network = EthereumNetwork.GNOSIS
         with mock.patch.object(KrakenClient, "get_dai_usd_price", return_value=1.5):
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 1.5)
 
         with mock.patch.object(
             KrakenClient, "get_dai_usd_price", side_effect=CannotGetPrice
         ):
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 1)
 
         # POLYGON
         price_service.ethereum_network = EthereumNetwork.POLYGON
         with mock.patch.object(KrakenClient, "get_matic_usd_price", return_value=0.7):
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 0.7)
 
         # EWT
         price_service.ethereum_network = EthereumNetwork.ENERGY_WEB_CHAIN
         with mock.patch.object(KrakenClient, "get_ewt_usd_price", return_value=0.9):
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 0.9)
 
         # BINANCE
         price_service.ethereum_network = EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET
         with mock.patch.object(KucoinClient, "get_bnb_usd_price", return_value=1.2):
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 1.2)
 
         # Gather
@@ -88,53 +110,53 @@ class TestPriceService(TestCase):
         with mock.patch.object(
             CoingeckoClient, "get_gather_usd_price", return_value=1.7
         ):
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 1.7)
 
         # Avalanche
         price_service.ethereum_network = EthereumNetwork.AVALANCHE_C_CHAIN
         with mock.patch.object(KrakenClient, "get_avax_usd_price", return_value=6.5):
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 6.5)
 
         # Aurora
         price_service.ethereum_network = EthereumNetwork.AURORA_MAINNET
         with mock.patch.object(KucoinClient, "get_aurora_usd_price", return_value=1.3):
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 1.3)
 
         # Cronos
         with mock.patch.object(KucoinClient, "get_cro_usd_price", return_value=4.4):
             price_service.ethereum_network = EthereumNetwork.CRONOS_MAINNET_BETA
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 4.4)
 
         # KuCoin
         with mock.patch.object(KucoinClient, "get_kcs_usd_price", return_value=4.4):
             price_service.ethereum_network = EthereumNetwork.KCC_MAINNET
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 4.4)
 
         # Milkomeda Cardano
         with mock.patch.object(KrakenClient, "get_ada_usd_price", return_value=5.5):
             price_service.ethereum_network = EthereumNetwork.MILKOMEDA_C1_MAINNET
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_native_coin_usd_price(), 5.5)
 
         # Milkomeda Algorand
         with mock.patch.object(KrakenClient, "get_algo_usd_price", return_value=6.6):
             price_service.ethereum_network = EthereumNetwork.MILKOMEDA_A1_MAINNET
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_algorand_usd_price(), 6.6)
 
         # XDC
         with mock.patch.object(KucoinClient, "get_xdc_usd_price", return_value=7.7):
             price_service.ethereum_network = EthereumNetwork.XINFIN_XDC_NETWORK
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_xdc_usd_price(), 7.7)
 
             price_service.ethereum_network = EthereumNetwork.XDC_APOTHEM_NETWORK
-            price_service.cache_eth_price.clear()
+            price_service.cache_native_coin_usd_price.clear()
             self.assertEqual(price_service.get_xdc_usd_price(), 7.7)
 
     @mock.patch.object(CoingeckoClient, "get_bnb_usd_price", return_value=3.0)
@@ -197,7 +219,7 @@ class TestPriceService(TestCase):
         price = price_service.get_matic_usd_price()
         self.assertEqual(price, 3.0)
 
-    def test_token_eth_value(self):
+    def test_get_token_eth_value(self):
         mainnet_node = just_test_if_mainnet_node()
         price_service = PriceService(EthereumClient(mainnet_node), self.redis)
         gno_token_address = "0x6810e776880C02933D47DB1b9fc05908e5386b96"
@@ -205,22 +227,8 @@ class TestPriceService(TestCase):
         self.assertIsInstance(token_eth_value, float)
         self.assertGreater(token_eth_value, 0)
 
-    def test_available_price_oracles(self):
-        # Ganache should have no oracle enabled
-        self.assertEqual(len(self.price_service.enabled_price_oracles), 0)
-        self.assertEqual(len(self.price_service.enabled_price_pool_oracles), 0)
-        self.assertEqual(len(self.price_service.enabled_composed_price_oracles), 0)
-
-    def test_available_price_oracles_mainnet(self):
-        # Mainnet should have every oracle enabled
-        mainnet_node = just_test_if_mainnet_node()
-        price_service = PriceService(EthereumClient(mainnet_node), self.redis)
-        self.assertEqual(len(price_service.enabled_price_oracles), 6)
-        self.assertEqual(len(price_service.enabled_price_pool_oracles), 3)
-        self.assertEqual(len(price_service.enabled_composed_price_oracles), 4)
-
     @mock.patch.object(KyberOracle, "get_price", return_value=1.23, autospec=True)
-    def test_token_eth_value_mocked(self, kyber_get_price_mock: MagicMock):
+    def test_get_token_eth_value_mocked(self, kyber_get_price_mock: MagicMock):
         price_service = self.price_service
         oracle_1 = mock.MagicMock()
         oracle_1.get_price.return_value = 1.23
@@ -252,7 +260,7 @@ class TestPriceService(TestCase):
     @mock.patch.object(
         PriceService, "get_token_eth_value", autospec=True, return_value=1.0
     )
-    def test_eth_price_from_composed_oracles(
+    def test_get_token_eth_price_from_composed_oracles(
         self, get_token_eth_value_mock: MagicMock, price_service_mock: MagicMock
     ):
         price_service = self.price_service
@@ -261,5 +269,5 @@ class TestPriceService(TestCase):
         token_three = UnderlyingToken("0xA0b86991c6218b36c1d19D4a2e9Eb0cE360", 0.142)
         price_service_mock.return_value = [token_one, token_two, token_three]
         curve_price = "0xe7ce624c00381b4b7abb03e633fb4acac4537dd6"
-        eth_price = price_service.get_eth_price_from_composed_oracles(curve_price)
+        eth_price = price_service.get_token_eth_price_from_composed_oracles(curve_price)
         self.assertEqual(eth_price, 1.0)

--- a/safe_transaction_service/tokens/tests/test_views.py
+++ b/safe_transaction_service/tokens/tests/test_views.py
@@ -134,10 +134,10 @@ class TestTokenViews(SafeTestCaseMixin, APITestCase):
         )
         with mock.patch.object(
             PriceService,
-            "get_cached_usd_values",
+            "get_token_cached_usd_values",
             autospec=True,
             return_value=iter([fiat_price_with_timestamp]),
-        ) as get_cached_usd_values_mock:
+        ) as get_token_cached_usd_values_mock:
             response = self.client.get(
                 reverse("v1:tokens:price-usd", args=(token.address,))
             )
@@ -148,11 +148,13 @@ class TestTokenViews(SafeTestCaseMixin, APITestCase):
             )
             self.assertTrue(response.data["timestamp"])
             self.assertEqual(
-                get_cached_usd_values_mock.call_args.args[1], [token.address]
+                get_token_cached_usd_values_mock.call_args.args[1], [token.address]
             )
 
             # Test copy price address
-            get_cached_usd_values_mock.return_value = iter([fiat_price_with_timestamp])
+            get_token_cached_usd_values_mock.return_value = iter(
+                [fiat_price_with_timestamp]
+            )
             token.copy_price = Account.create().address
             token.save(update_fields=["copy_price"])
             response = self.client.get(
@@ -165,7 +167,7 @@ class TestTokenViews(SafeTestCaseMixin, APITestCase):
             )
             self.assertTrue(response.data["timestamp"])
             self.assertEqual(
-                get_cached_usd_values_mock.call_args.args[1], [token.copy_price]
+                get_token_cached_usd_values_mock.call_args.args[1], [token.copy_price]
             )
 
     @mock.patch.object(

--- a/safe_transaction_service/tokens/views.py
+++ b/safe_transaction_service/tokens/views.py
@@ -84,7 +84,9 @@ class TokenPriceView(RetrieveAPIView):
             else:
                 token = self.get_object()  # Raises 404 if not found
                 fiat_price_with_timestamp = next(
-                    price_service.get_cached_usd_values([token.get_price_address()])
+                    price_service.get_token_cached_usd_values(
+                        [token.get_price_address()]
+                    )
                 )
                 data = {
                     "fiat_code": fiat_price_with_timestamp.fiat_code.name,


### PR DESCRIPTION
- `Token/ETH` value was retrieved in every network, but then the `Native token/USD` value was used to calculate the token `USD` value for every network.
- For example, for Gnosis Chain `Token/ETH` value was retrieved and then `DAI/USD` value was used to turn it into `USD`, instead of `ETH/USD`.
- Closes #1407
