### PR TITLE
Reduce delay countdown for reindex_erc20_events_task

### DIFF
--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -292,7 +292,7 @@ def reindex_last_hours_task(self, hours: int = 2) -> Optional[int]:
                     )
                     # countdown of 30 minutes to execute this reindex after mastercopies reindex is finished
                     reindex_erc20_events_task.apply_async(
-                        (from_block_number, to_block_number), countdown=60 * 30
+                        (from_block_number, to_block_number), countdown=60 * 20
                     )
 
 


### PR DESCRIPTION
### What was wrong? 👾
Some critical errors on our indexer worker because countdown of 30 minutes.
 `[CRITICAL] [???/???] Unrecoverable error: PreconditionFailed(406, 'PRECONDITION_FAILED - delivery acknowledgement on channel 1 timed out. Timeout value used: 1800000 ms.` 
The reason of that critical error is:
https://docs.celeryq.dev/en/stable/userguide/calling.html#eta-and-countdown 

> Warning
> 
> When using RabbitMQ as a message broker when specifying a countdown over 15 minutes, you may encounter the problem that the worker terminates with an [PreconditionFailed](https://docs.celeryq.dev/projects/amqp/en/latest/reference/amqp.exceptions.html#amqp.exceptions.PreconditionFailed) error will be raised:
> 
> amqp.exceptions.PreconditionFailed: (0, 0): (406) PRECONDITION_FAILED - consumer ack timed out on channel
> 
> In RabbitMQ since version 3.8.15 the default value for consumer_timeout is 15 minutes. Since version 3.8.17 it was increased to 30 minutes. If a consumer does not ack its delivery for more than the timeout value, its channel will be closed with a PRECONDITION_FAILED channel exception. See [Delivery Acknowledgement Timeout](https://www.rabbitmq.com/consumers.html#acknowledgement-timeout) for more information.
> 
> To solve the problem, in RabbitMQ configuration file rabbitmq.conf you should specify the consumer_timeout parameter greater than or equal to your countdown value. For example, you can specify a very large value of consumer_timeout = 31622400000, which is equal to 1 year in milliseconds, to avoid problems in the future.

### How was it fixed? 🎯
Reduce countdown until 20 minutes that should be enough.