### PR TITLE
Add crontab schedule for periodic tasks

### DIFF
--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db.models import Min
 
-from django_celery_beat.models import IntervalSchedule, PeriodicTask
+from django_celery_beat.models import CrontabSchedule, IntervalSchedule, PeriodicTask
 
 from gnosis.eth import EthereumClientProvider
 from gnosis.safe.addresses import MASTER_COPIES, PROXY_FACTORIES
@@ -14,28 +14,59 @@ from ...models import IndexingStatus, ProxyFactory, SafeMasterCopy
 
 
 @dataclass
+class CronDefinition:
+    minute: str = "*"
+    hour: str = "*"
+    day_of_week: str = "*"
+    day_of_month: str = "*"
+    month_of_year: str = "*"
+
+
+@dataclass
 class CeleryTaskConfiguration:
     name: str
     description: str
-    interval: int
-    period: str
+    interval: int = 0
+    period: str = None
+    cron: CronDefinition = None
     enabled: bool = True
 
     def create_task(self) -> Tuple[PeriodicTask, bool]:
-        interval_schedule, _ = IntervalSchedule.objects.get_or_create(
-            every=self.interval, period=self.period
-        )
-        periodic_task, created = PeriodicTask.objects.get_or_create(
-            task=self.name,
-            defaults={
+        assert self.period or self.cron, "Task must define period or cron"
+        if self.period:
+            interval_schedule, _ = IntervalSchedule.objects.get_or_create(
+                every=self.interval, period=self.period
+            )
+            defaults = {
                 "name": self.description,
                 "interval": interval_schedule,
                 "enabled": self.enabled,
-            },
+            }
+        else:
+            crontab_schedule, _ = CrontabSchedule.objects.get_or_create(
+                minute=self.cron.minute,
+                hour=self.cron.hour,
+                day_of_week=self.cron.day_of_week,
+                day_of_month=self.cron.day_of_month,
+                month_of_year=self.cron.month_of_year,
+            )
+            defaults = {
+                "name": self.description,
+                "crontab": crontab_schedule,
+                "enabled": self.enabled,
+            }
+
+        periodic_task, created = PeriodicTask.objects.get_or_create(
+            task=self.name,
+            defaults=defaults,
         )
         if not created:
             periodic_task.name = self.description
-            periodic_task.interval = interval_schedule
+            if self.period:
+                periodic_task.interval = interval_schedule
+            else:
+                periodic_task.crontab = crontab_schedule
+
             periodic_task.enabled = self.enabled
             periodic_task.save()
 
@@ -44,97 +75,95 @@ class CeleryTaskConfiguration:
 
 TASKS = [
     CeleryTaskConfiguration(
-        "safe_transaction_service.history.tasks.check_reorgs_task",
-        "Check Reorgs",
-        1,
-        IntervalSchedule.MINUTES,
+        name="safe_transaction_service.history.tasks.check_reorgs_task",
+        description="Check Reorgs (every minute)",
+        cron=CronDefinition(),  # cron every minute * * * * *
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.history.tasks.check_sync_status_task",
-        "Check Sync status",
-        10,
-        IntervalSchedule.MINUTES,
+        name="safe_transaction_service.history.tasks.check_sync_status_task",
+        description="Check Sync status (every 10 minutes)",
+        cron=CronDefinition(minute="*/10"),  # cron every 10 minutes */10 * * * *
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.history.tasks.index_internal_txs_task",
-        "Index Internal Txs",
-        5,
-        IntervalSchedule.SECONDS,
+        name="safe_transaction_service.history.tasks.index_internal_txs_task",
+        description="Index Internal Txs (every 5 seconds)",
+        interval=5,
+        period=IntervalSchedule.SECONDS,
         enabled=not settings.ETH_L2_NETWORK,
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.history.tasks.index_safe_events_task",
-        "Index Safe events (L2)",
-        5,
-        IntervalSchedule.SECONDS,
+        name="safe_transaction_service.history.tasks.index_safe_events_task",
+        description="Index Safe events (L2) (every 5 seconds)",
+        interval=5,
+        period=IntervalSchedule.SECONDS,
         enabled=settings.ETH_L2_NETWORK,
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.history.tasks.index_new_proxies_task",
-        "Index new Proxies",
-        15,
-        IntervalSchedule.SECONDS,
+        name="safe_transaction_service.history.tasks.index_new_proxies_task",
+        description="Index new Proxies (every 15 seconds)",
+        interval=15,
+        period=IntervalSchedule.SECONDS,
         enabled=settings.ETH_L2_NETWORK,
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.history.tasks.index_erc20_events_task",
-        "Index ERC20/721 Events",
-        14,
-        IntervalSchedule.SECONDS,
+        name="safe_transaction_service.history.tasks.index_erc20_events_task",
+        description="Index ERC20/721 Events (every 14 seconds)",
+        interval=14,
+        period=IntervalSchedule.SECONDS,
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.history.tasks.reindex_last_hours_task",
-        "Reindex master copies for the last hours",
-        110,
-        IntervalSchedule.MINUTES,
+        name="safe_transaction_service.history.tasks.reindex_mastercopies_last_hours_task",
+        description="Reindex master copies for the last hours (every 2 hours at minute 0)",
+        cron=CronDefinition(
+            minute=0, hour="*/2"
+        ),  # Every 2 hours at minute 0 - * */2 * * *
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.history.tasks.process_decoded_internal_txs_task",
-        "Process Internal Txs",
-        20,
-        IntervalSchedule.MINUTES,
+        name="safe_transaction_service.history.tasks.reindex_erc20_erc721_last_hours_task",
+        description="Reindex erc20/erc721 for the last hours (every 2 hours at minute 30)",
+        cron=CronDefinition(
+            minute=30, hour="*/2"
+        ),  # Every 2 hours at minute 30 - 30 */2 * * *
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.history.tasks.remove_not_trusted_multisig_txs_task",
-        "Remove older than 1 month not trusted Multisig Txs",
-        1,
-        IntervalSchedule.DAYS,
+        name="safe_transaction_service.history.tasks.process_decoded_internal_txs_task",
+        description="Process Internal Txs (every 20 minutes)",
+        cron=CronDefinition(minute="*/20"),  # Every 20 minutes - */20 * * * *
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.contracts.tasks.create_missing_contracts_with_metadata_task",
-        "Index contract names and ABIs",
-        1,
-        IntervalSchedule.HOURS,
+        name="safe_transaction_service.history.tasks.remove_not_trusted_multisig_txs_task",
+        description="Remove older than 1 month not trusted Multisig Txs (every day at 00:00)",
+        cron=CronDefinition(minute=0, hour=0),  # Every day at 00:00 - 0 0 * * *
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.contracts.tasks.create_missing_multisend_contracts_with_metadata_task",
-        "Index contract names and ABIs from MultiSend transactions",
-        6,
-        IntervalSchedule.HOURS,
+        name="safe_transaction_service.contracts.tasks.create_missing_contracts_with_metadata_task",
+        description="Index contract names and ABIs (every hour at minute 0)",
+        cron=CronDefinition(minute=0),  # Every hour at minute 0 - 0 * * * *
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.contracts.tasks.reindex_contracts_without_metadata_task",
-        "Reindex contracts with missing names or ABIs",
-        7,
-        IntervalSchedule.DAYS,
+        name="safe_transaction_service.contracts.tasks.create_missing_multisend_contracts_with_metadata_task",
+        description="Index contract names and ABIs from MultiSend transactions (every 6 hours at minute 0)",
+        cron=CronDefinition(minute=0, hour="*/6"),  # Every 6 hours - 0 */6 * * *
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.tokens.tasks.fix_pool_tokens_task",
-        "Fix Pool Token Names",
-        1,
-        IntervalSchedule.HOURS,
+        name="safe_transaction_service.contracts.tasks.reindex_contracts_without_metadata_task",
+        description="Reindex contracts with missing names or ABIs (every sunday at 00:00)",
+        cron=CronDefinition(minute=0, hour=0, day_of_week=0),  # Every sunday 0 0 * * 0
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.tokens.tasks.update_token_info_from_token_list_task",
-        "Update Token info from token list",
-        1,
-        IntervalSchedule.DAYS,
+        name="safe_transaction_service.tokens.tasks.fix_pool_tokens_task",
+        description="Fix Pool Token Names (every hour at minute 0)",
+        cron=CronDefinition(minute=0),  # Every hour at minute 0 - 0 * * * *
     ),
     CeleryTaskConfiguration(
-        "safe_transaction_service.analytics.tasks.get_transactions_per_safe_app_task",
-        "Run query to get number of transactions grouped by safe-app",
-        7,
-        IntervalSchedule.DAYS,
+        name="safe_transaction_service.tokens.tasks.update_token_info_from_token_list_task",
+        description="Update Token info from token list (every day at 00:00)",
+        cron=CronDefinition(minute=0, hour=0),  # Every day at 00:00 - 0 0 * * *
+    ),
+    CeleryTaskConfiguration(
+        name="safe_transaction_service.analytics.tasks.get_transactions_per_safe_app_task",
+        description="Run query to get number of transactions grouped by safe-app (Every sunday at 00:00)",
+        cron=CronDefinition(minute=0, hour=0, day_of_week=0),  # Every sunday 0 0 * * 0
     ),
 ]
 


### PR DESCRIPTION
# Description
The purpose of this PR is try to improve the accuracy of our current beat scheduler using crontab definitions.
See https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html#crontab-schedules
# Issues related
Closes #1406 

# Other changes
Also because we can get more accuracy when the task is executed the `reindex_last_hours_task` was splitted in `reindex_last_hours_mastercopies_task` defeined every 2 hours at minute 0 and `reindex_last_hours_erc20_task` defined every 2 hours minute 30.


