### PR TITLE
Fix wrong order return values

### DIFF
--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -492,8 +492,8 @@ class EthereumIndexer(ABC):
                 # Get real `to_block_number` processed
                 (
                     processed_elements,
-                    to_block_number,
                     from_block_number,
+                    to_block_number,
                     updated,
                 ) = self.process_addresses(
                     not_updated_addresses_to_process,

--- a/safe_transaction_service/history/tests/test_internal_tx_indexer.py
+++ b/safe_transaction_service/history/tests/test_internal_tx_indexer.py
@@ -119,13 +119,15 @@ class TestInternalTxIndexer(TestCase):
         )
         self.assertIsNone(current_block_number_mock.assert_called_with())
 
-        internal_tx_indexer.start()  # No SafeMasterCopy to index
+        self.assertEqual(
+            internal_tx_indexer.start(), (0, 0)
+        )  # No SafeMasterCopy to index
 
         safe_master_copy: SafeMasterCopy = SafeMasterCopyFactory(
             address="0x5aC255889882aCd3da2aA939679E3f3d4cea221e"
         )
         self.assertEqual(safe_master_copy.tx_block_number, 0)
-        internal_tx_indexer.start()
+        self.assertEqual(internal_tx_indexer.start(), (3, 2001))
 
         self.assertEqual(EthereumTx.objects.count(), len(transactions_result))
         self.assertEqual(EthereumBlock.objects.count(), len(block_result))


### PR DESCRIPTION
### What was wrong? 👾
Indexer tasks returned some times negative values to the number of blocks processed. 

### How was it fixed? 🎯
The error was that from_block had the value of to_block and to_block the value of from_block. 
The error was solved setting this variables with the correct value. 