### PR TITLE
Bump safe-eth-py and refactor for Web3 v6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ psycogreen==1.0.2
 psycopg2==2.9.6
 redis==4.5.4
 requests==2.28.2
-safe-eth-py[django]==5.2.1
-web3==5.31.3
+safe-eth-py[django]==5.3.0
+web3==6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,5 @@ psycogreen==1.0.2
 psycopg2==2.9.6
 redis==4.5.4
 requests==2.28.2
-safe-eth-py[django]==6.0.0
+safe-eth-py[django]==5.3.0
 web3==6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ djangorestframework==3.14.0
 djangorestframework-camel-case==1.4.2
 docutils==0.19
 drf-yasg[validation]==1.21.5
-eth-rlp==0.2.1  # Prevent dependency issues
 firebase-admin==6.1.0
 flower==1.2.0
 gunicorn[gevent]==20.1.0
@@ -32,5 +31,5 @@ psycogreen==1.0.2
 psycopg2==2.9.6
 redis==4.5.4
 requests==2.28.2
-safe-eth-py[django]==5.3.0
+safe-eth-py[django]==6.0.0
 web3==6.2.0

--- a/safe_transaction_service/contracts/tx_decoder.py
+++ b/safe_transaction_service/contracts/tx_decoder.py
@@ -18,6 +18,7 @@ from typing import (
 
 import gevent
 from cachetools import TTLCache, cachedmethod
+from eth_abi import decode as decode_abi
 from eth_abi.exceptions import DecodingError
 from eth_typing import ChecksumAddress, HexStr
 from eth_utils import function_abi_to_4byte_selector
@@ -199,7 +200,7 @@ class SafeTxDecoder:
         try:
             names = get_abi_input_names(fn_abi)
             types = get_abi_input_types(fn_abi)
-            decoded = self.dummy_w3.codec.decode_abi(types, cast(HexBytes, params))
+            decoded = decode_abi(types, cast(HexBytes, params))
             normalized = map_abi_data(BASE_RETURN_NORMALIZERS, types, decoded)
             values = map(self._parse_decoded_arguments, normalized)
         except (ValueError, DecodingError) as exc:

--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -5,7 +5,7 @@ from typing import Iterator, List, Optional, Sequence
 from django.db.models import QuerySet
 
 from eth_typing import ChecksumAddress
-from web3.contract import ContractEvent
+from web3.contract.contract import ContractEvent
 from web3.types import EventData, LogReceipt
 
 from gnosis.eth import EthereumClient

--- a/safe_transaction_service/history/indexers/events_indexer.py
+++ b/safe_transaction_service/history/indexers/events_indexer.py
@@ -10,7 +10,7 @@ from eth_typing import ChecksumAddress
 from eth_utils import event_abi_to_log_topic
 from gevent import pool
 from hexbytes import HexBytes
-from web3.contract import ContractEvent
+from web3.contract.contract import ContractEvent
 from web3.exceptions import LogTopicError
 from web3.types import EventData, FilterParams, LogReceipt
 

--- a/safe_transaction_service/history/indexers/events_indexer.py
+++ b/safe_transaction_service/history/indexers/events_indexer.py
@@ -253,7 +253,7 @@ class EventsIndexer(EthereumIndexer):
         for event_to_listen in self.events_to_listen[log_receipt["topics"][0].hex()]:
             # Try to decode using all the existing ABIs
             try:
-                return event_to_listen.processLog(log_receipt)
+                return event_to_listen.process_log(log_receipt)
             except LogTopicError:
                 continue
 

--- a/safe_transaction_service/history/indexers/internal_tx_indexer.py
+++ b/safe_transaction_service/history/indexers/internal_tx_indexer.py
@@ -149,7 +149,7 @@ class InternalTxIndexer(EthereumIndexer):
             block_numbers = list(range(from_block_number, to_block_number + 1))
 
             with self.auto_adjust_block_limit(from_block_number, to_block_number):
-                blocks_traces: BlockTrace = self.ethereum_client.parity.trace_blocks(
+                blocks_traces: BlockTrace = self.ethereum_client.tracing.trace_blocks(
                     block_numbers
                 )
             traces: OrderedDict[HexStr, FilterTrace] = OrderedDict()
@@ -200,7 +200,7 @@ class InternalTxIndexer(EthereumIndexer):
         try:
             # We only need to search for traces `to` the provided addresses
             with self.auto_adjust_block_limit(from_block_number, to_block_number):
-                to_traces = self.ethereum_client.parity.trace_filter(
+                to_traces = self.ethereum_client.tracing.trace_filter(
                     from_block=from_block_number,
                     to_block=to_block_number,
                     to_address=addresses,
@@ -262,7 +262,9 @@ class InternalTxIndexer(EthereumIndexer):
         for tx_hash_chunk in chunks(list(tx_hashes), batch_size):
             tx_hash_chunk = list(tx_hash_chunk)
             try:
-                yield from self.ethereum_client.parity.trace_transactions(tx_hash_chunk)
+                yield from self.ethereum_client.tracing.trace_transactions(
+                    tx_hash_chunk
+                )
             except IOError:
                 logger.error(
                     "Problem calling `trace_transactions` with %d txs. "
@@ -324,7 +326,7 @@ class InternalTxIndexer(EthereumIndexer):
         internal_txs = (
             InternalTx.objects.build_from_trace(trace, ethereum_tx)
             for ethereum_tx in ethereum_txs
-            for trace in self.ethereum_client.parity.filter_out_errored_traces(
+            for trace in self.ethereum_client.tracing.filter_out_errored_traces(
                 tx_hash_with_traces[ethereum_tx.tx_hash]
             )
         )

--- a/safe_transaction_service/history/indexers/internal_tx_indexer.py
+++ b/safe_transaction_service/history/indexers/internal_tx_indexer.py
@@ -104,7 +104,7 @@ class InternalTxIndexer(EthereumIndexer):
         from_block_number: int,
         to_block_number: int,
         current_block_number: Optional[int] = None,
-    ) -> OrderedDict[HexStr, Optional[FilterTrace]]:
+    ) -> OrderedDict[HexBytes, Optional[FilterTrace]]:
         current_block_number = (
             current_block_number or self.ethereum_client.current_block_number
         )
@@ -138,7 +138,7 @@ class InternalTxIndexer(EthereumIndexer):
 
     def _find_relevant_elements_using_trace_block(
         self, addresses: Sequence[str], from_block_number: int, to_block_number: int
-    ) -> OrderedDict[HexStr, FilterTrace]:
+    ) -> OrderedDict[HexBytes, FilterTrace]:
         addresses_set = set(addresses)  # More optimal to use with `in`
         logger.debug(
             "Using trace_block from-block=%d to-block=%d",
@@ -211,7 +211,7 @@ class InternalTxIndexer(EthereumIndexer):
             ) from e
 
         # Log INFO if traces found, DEBUG if not
-        traces: OrderedDict[HexStr, None] = OrderedDict()
+        traces: OrderedDict[HexBytes, None] = OrderedDict()
         for trace in to_traces:
             transaction_hash = trace.get("transactionHash")
             if transaction_hash:
@@ -275,8 +275,8 @@ class InternalTxIndexer(EthereumIndexer):
                 raise
 
     def process_elements(
-        self, tx_hash_with_traces: OrderedDict[HexStr, Optional[FilterTrace]]
-    ) -> List[InternalTx]:
+        self, tx_hash_with_traces: OrderedDict[HexBytes, Optional[FilterTrace]]
+    ) -> List[HexBytes]:
         """
         :param tx_hash_with_traces:
         :return: Inserted `InternalTx` objects
@@ -327,7 +327,7 @@ class InternalTxIndexer(EthereumIndexer):
             InternalTx.objects.build_from_trace(trace, ethereum_tx)
             for ethereum_tx in ethereum_txs
             for trace in self.ethereum_client.tracing.filter_out_errored_traces(
-                tx_hash_with_traces[ethereum_tx.tx_hash]
+                tx_hash_with_traces[HexBytes(ethereum_tx.tx_hash)]
             )
         )
 

--- a/safe_transaction_service/history/indexers/proxy_factory_indexer.py
+++ b/safe_transaction_service/history/indexers/proxy_factory_indexer.py
@@ -2,7 +2,7 @@ from functools import cached_property
 from logging import getLogger
 from typing import List, Optional, Sequence
 
-from web3.contract import ContractEvent
+from web3.contract.contract import ContractEvent
 from web3.types import EventData, LogReceipt
 
 from gnosis.eth import EthereumClient

--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -7,7 +7,7 @@ from django.db import IntegrityError, transaction
 from eth_abi import decode as decode_abi
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
-from web3.contract import ContractEvent
+from web3.contract.contract import ContractEvent
 from web3.types import EventData
 
 from gnosis.eth import EthereumClient

--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -451,7 +451,7 @@ class SafeTxProcessor(TxProcessor):
                     # Someone calls Module -> Module calls Safe Proxy -> Safe Proxy delegate calls Master Copy
                     # The trace that is being processed is the last one, so indexer needs to get the previous trace
                     previous_trace = (
-                        self.ethereum_tracing_client.parity.get_previous_trace(
+                        self.ethereum_tracing_client.tracing.get_previous_trace(
                             internal_tx.ethereum_tx_id,
                             internal_tx.trace_address_as_list,
                             skip_delegate_calls=True,
@@ -496,7 +496,7 @@ class SafeTxProcessor(TxProcessor):
                     owner = arguments["owner"]
                 else:
                     previous_trace = (
-                        self.ethereum_tracing_client.parity.get_previous_trace(
+                        self.ethereum_tracing_client.tracing.get_previous_trace(
                             internal_tx.ethereum_tx_id,
                             internal_tx.trace_address_as_list,
                             skip_delegate_calls=True,

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -310,6 +310,7 @@ class EthereumTxManager(models.Manager):
         tx_receipt: Optional[Dict[str, Any]] = None,
         ethereum_block: Optional[EthereumBlock] = None,
     ) -> "EthereumTx":
+        print(tx, tx_receipt)
         data = HexBytes(tx.get("data") or tx.get("input"))
         logs = tx_receipt and [
             clean_receipt_log(log) for log in tx_receipt.get("logs", [])

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -338,7 +338,7 @@ class EthereumTxManager(models.Manager):
             nonce=tx["nonce"],
             to=tx.get("to"),
             value=tx["value"],
-            type=int(tx.get("type", "0x0"), 0),
+            type=tx.get("type", 0),
         )
 
 

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -310,7 +310,6 @@ class EthereumTxManager(models.Manager):
         tx_receipt: Optional[Dict[str, Any]] = None,
         ethereum_block: Optional[EthereumBlock] = None,
     ) -> "EthereumTx":
-        print(tx, tx_receipt)
         data = HexBytes(tx.get("data") or tx.get("input"))
         logs = tx_receipt and [
             clean_receipt_log(log) for log in tx_receipt.get("logs", [])

--- a/safe_transaction_service/history/services/safe_service.py
+++ b/safe_transaction_service/history/services/safe_service.py
@@ -215,7 +215,7 @@ class SafeService:
         if not self.ethereum_tracing_client:
             return None
         try:
-            next_traces = self.ethereum_tracing_client.parity.get_next_traces(
+            next_traces = self.ethereum_tracing_client.tracing.get_next_traces(
                 internal_tx.ethereum_tx_id,
                 internal_tx.trace_address_as_list,
                 remove_calls=True,
@@ -232,7 +232,7 @@ class SafeService:
         if not self.ethereum_tracing_client:
             return None
         try:
-            previous_trace = self.ethereum_tracing_client.parity.get_previous_trace(
+            previous_trace = self.ethereum_tracing_client.tracing.get_previous_trace(
                 internal_tx.ethereum_tx_id,
                 internal_tx.trace_address_as_list,
                 skip_delegate_calls=True,

--- a/safe_transaction_service/history/tests/mocks/mocks_ethereum_tx.py
+++ b/safe_transaction_service/history/tests/mocks/mocks_ethereum_tx.py
@@ -3,153 +3,184 @@ from hexbytes import HexBytes
 type_0_tx = {
     "tx": {
         "blockHash": HexBytes(
-            "0x062b97322d353ee94bea68bf2b131420f399e8dcca74e235fe4ef730f7111691"
+            "0x153276c610e9d2e0ca737377c6c877d6cb4913b80324a2ebb13cb8ff7e899f17"
         ),
-        "blockNumber": 9030821,
-        "chainId": "0x4",
-        "condition": None,
-        "creates": None,
-        "from": "0x8305aBB71A2354C98433a82F108Df73820CE3133",
-        "gas": 3000000,
-        "gasPrice": 1000000000,
+        "blockNumber": 10137240,
+        "from": "0x7ed8e2004a9ff9Ea76119EF7CCA2D721a0a95254",
+        "gas": 83361,
+        "gasPrice": 20000000000,
         "hash": HexBytes(
-            "0xc2f804ef639b534b7cd30bf3062d71baa324233cfdf2f42e62a090aea1606ae2"
+            "0x58863b13ccfc6904c0e7f277b099cd9282aa624d1d1ea3ee05644aa9e4283962"
         ),
-        "input": "0xa9059cbb0000000000000000000000009bc7d0c2850184c5f75f5e3a9e9dec7491f0103a00000000000000000000000000000000000000000000152d02c7e14af6800000",
-        "nonce": 1776,
-        "publicKey": HexBytes(
-            "0xb7fe8abd703add5b75ca3c726980f2fadeb19d3fed6156f4815e00c7bbbe4481d52eeda616f93bcf460406580cb8b5ab0d32a2675b5c4a98f28cc9e1dc921d84"
-        ),
+        "input": "0xf6838a720000000000000000000000000000000000000000000000000000000000000002",
+        "nonce": 1,
+        "to": "0xbCF935D206Ca32929e1b887a07Ed240f0D8CCD22",
+        "transactionIndex": 113,
+        "value": 50000000000000000,
+        "type": 0,
+        "chainId": 1,
+        "v": 37,
         "r": HexBytes(
-            "0x9e52b424ed922806e0f73fe835bf22df8caa7c3bcbe23dd6a329899a6c938ca2"
-        ),
-        "raw": HexBytes(
-            "0xf8ab8206f0843b9aca00832dc6c094c666d239cbda32aa7ebca894b6dc598ddb88128580b844a9059cbb0000000000000000000000009bc7d0c2850184c5f75f5e3a9e9dec7491f0103a00000000000000000000000000000000000000000000152d02c7e14af68000002ca09e52b424ed922806e0f73fe835bf22df8caa7c3bcbe23dd6a329899a6c938ca2a0785f6cfd004e1cb617004d9f1357e76f55ff4ecfa24476712784be1d9e297b09"
+            "0x7da7ec6f26c61354c37d4d30429e28ecd35b9a6362f1d79bee109c387eb07518"
         ),
         "s": HexBytes(
-            "0x785f6cfd004e1cb617004d9f1357e76f55ff4ecfa24476712784be1d9e297b09"
+            "0x6bdf364ca0a9cdf5ae199f69e282d3ca99a54b2b9ee19419dfae2577d2ad221b"
         ),
-        "standardV": 1,
-        "to": "0xC666d239cbda32AA7ebCA894B6dC598dDb881285",
-        "transactionIndex": 30,
-        "type": "0x0",
-        "v": 44,
-        "value": 0,
     },
     "receipt": {
         "blockHash": HexBytes(
-            "0x062b97322d353ee94bea68bf2b131420f399e8dcca74e235fe4ef730f7111691"
+            "0x153276c610e9d2e0ca737377c6c877d6cb4913b80324a2ebb13cb8ff7e899f17"
         ),
-        "blockNumber": 9030821,
+        "blockNumber": 10137240,
         "contractAddress": None,
-        "cumulativeGasUsed": 10058813,
-        "effectiveGasPrice": 1000000000,
-        "from": "0x8305aBB71A2354C98433a82F108Df73820CE3133",
-        "gasUsed": 34573,
+        "cumulativeGasUsed": 9659305,
+        "effectiveGasPrice": 20000000000,
+        "from": "0x7ed8e2004a9ff9Ea76119EF7CCA2D721a0a95254",
+        "gasUsed": 64124,
         "logs": [
             {
-                "address": "0xC666d239cbda32AA7ebCA894B6dC598dDb881285",
-                "blockHash": HexBytes(
-                    "0x062b97322d353ee94bea68bf2b131420f399e8dcca74e235fe4ef730f7111691"
-                ),
-                "blockNumber": 9030821,
-                "data": "0x00000000000000000000000000000000000000000000152d02c7e14af6800000",
-                "logIndex": 85,
-                "removed": False,
+                "address": "0xbCF935D206Ca32929e1b887a07Ed240f0D8CCD22",
                 "topics": [
                     HexBytes(
-                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+                        "0xce7dc747411ac40191c5335943fcc79d8c2d8c01ca5ae83d9fed160409fa6120"
                     ),
                     HexBytes(
-                        "0x0000000000000000000000008305abb71a2354c98433a82f108df73820ce3133"
+                        "0x000000000000000000000000082cd8f1bf25329528fddcb7b365abb34911ac6b"
                     ),
                     HexBytes(
-                        "0x0000000000000000000000009bc7d0c2850184c5f75f5e3a9e9dec7491f0103a"
+                        "0x0000000000000000000000007ed8e2004a9ff9ea76119ef7cca2d721a0a95254"
                     ),
                 ],
-                "transactionHash": HexBytes(
-                    "0xc2f804ef639b534b7cd30bf3062d71baa324233cfdf2f42e62a090aea1606ae2"
+                "data": HexBytes(
+                    "0x0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000005ecc3350"
                 ),
-                "transactionIndex": 30,
-                "transactionLogIndex": "0x0",
-                "type": "mined",
-            }
+                "blockNumber": 10137240,
+                "transactionHash": HexBytes(
+                    "0x58863b13ccfc6904c0e7f277b099cd9282aa624d1d1ea3ee05644aa9e4283962"
+                ),
+                "transactionIndex": 113,
+                "blockHash": HexBytes(
+                    "0x153276c610e9d2e0ca737377c6c877d6cb4913b80324a2ebb13cb8ff7e899f17"
+                ),
+                "logIndex": 134,
+                "removed": False,
+            },
+            {
+                "address": "0xbCF935D206Ca32929e1b887a07Ed240f0D8CCD22",
+                "topics": [
+                    HexBytes(
+                        "0x9ea70f0eb33d898c3336ecf2c0e3cf1c0195c13ad3fbcb34447777dbfd5ff2d0"
+                    ),
+                    HexBytes(
+                        "0x0000000000000000000000007ed8e2004a9ff9ea76119ef7cca2d721a0a95254"
+                    ),
+                ],
+                "data": HexBytes(
+                    "0x0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000005ecc3350"
+                ),
+                "blockNumber": 10137240,
+                "transactionHash": HexBytes(
+                    "0x58863b13ccfc6904c0e7f277b099cd9282aa624d1d1ea3ee05644aa9e4283962"
+                ),
+                "transactionIndex": 113,
+                "blockHash": HexBytes(
+                    "0x153276c610e9d2e0ca737377c6c877d6cb4913b80324a2ebb13cb8ff7e899f17"
+                ),
+                "logIndex": 135,
+                "removed": False,
+            },
         ],
         "logsBloom": HexBytes(
-            "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000010000000000000000000000008010000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000010000000000000000000000000000000000000000008000000008000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000002000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000004000000000000"
+            "0x00000000000000010000000000000000000000000400000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000002000100001000000000000100000000000000000000000000008000000000000000000000000040000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000100000040000000000000000000100000000000000000000000000000000000000000000000000000000000000000000040"
         ),
         "status": 1,
-        "to": "0xC666d239cbda32AA7ebCA894B6dC598dDb881285",
+        "to": "0xbCF935D206Ca32929e1b887a07Ed240f0D8CCD22",
         "transactionHash": HexBytes(
-            "0xc2f804ef639b534b7cd30bf3062d71baa324233cfdf2f42e62a090aea1606ae2"
+            "0x58863b13ccfc6904c0e7f277b099cd9282aa624d1d1ea3ee05644aa9e4283962"
         ),
-        "transactionIndex": 30,
-        "type": "0x0",
+        "transactionIndex": 113,
+        "type": 0,
     },
 }
 
 type_2_tx = {
     "tx": {
-        "accessList": [],
         "blockHash": HexBytes(
-            "0x0113567d08f0fd2f5aef6593aa9055d6fb67af0f2bd63667c6fa06cbbf440b1a"
+            "0x8d54f5d3837503abd9058de0fb3197077289855e1a009794598e968f1c5a4d0e"
         ),
-        "blockNumber": 10530755,
-        "chainId": "0x4",
-        "condition": None,
-        "creates": None,
-        "from": "0xa7a82DD06901F29aB14AF63faF3358AD101724A8",
-        "gas": 60000,
-        "gasPrice": 2500000022,
+        "blockNumber": 17137240,
+        "from": "0x1c7c15e45ad58d8b487B028fe0842c702595E0D8",
+        "gas": 94813,
+        "gasPrice": 32297846431,
+        "maxPriorityFeePerGas": 71866838,
+        "maxFeePerGas": 40579350040,
         "hash": HexBytes(
-            "0x02d70902fed45c6e3dc602d6df9ef19596f3ff7255a6bd261a62b474c95ef232"
+            "0xf6025f11f8583d30d3a227bc4616cb377c29e797e5f18ff881397988ac8a644a"
         ),
-        "input": "0x",
-        "maxFeePerGas": 2500000042,
-        "maxPriorityFeePerGas": 2500000000,
-        "nonce": 4523150,
-        "publicKey": HexBytes(
-            "0x873c2c1b9852ac9b0de12bafa88cadee81bb9ee549248ba3b250ce0153e277a6233242d2fdc02"
-            "eff09c5399f71f25a4c4476517b95124cd0aaad67d3be11fe91"
-        ),
+        "input": "0xa9059cbb000000000000000000000000c8f0f077e53f86f6c11a59c519f953338fba7f0000000000000000000000000000000000000000000000000000000005f4173c80",
+        "nonce": 1,
+        "to": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+        "transactionIndex": 108,
+        "value": 0,
+        "type": 2,
+        "accessList": [],
+        "chainId": 1,
+        "v": 0,
         "r": HexBytes(
-            "0x0c03fe496f4bf8cfc4ced71044955213d0f3d076460ea45803f219fc89deb424"
-        ),
-        "raw": HexBytes(
-            "0x02f875048345048e849502f900849502f92a82ea6094a417ef0c2ec3d820fbb3d9b6bebc39d35"
-            "361584988016345785d8a000080c080a00c03fe496f4bf8cfc4ced71044955213d0f3d076460ea4"
-            "5803f219fc89deb424a055604f66eb0800546dcdd38933de856acc2f6ff423ab39bedaa7f2cb968"
-            "ea252"
+            "0x0dbc6fb91dca40e9105bdd7b51853a18bdae73f12b28444dc5d3d2feed7914ff"
         ),
         "s": HexBytes(
-            "0x55604f66eb0800546dcdd38933de856acc2f6ff423ab39bedaa7f2cb968ea252"
+            "0x57f7c1e2da8f0595b0874298eee775b35754ea8c97b43845e134a4a08d5d0ded"
         ),
-        "to": "0xa417eF0c2ec3D820fbb3d9B6BeBc39d353615849",
-        "transactionIndex": 15,
-        "type": "0x2",
-        "v": 0,
-        "value": 100000000000000000,
     },
     "receipt": {
         "blockHash": HexBytes(
-            "0x0113567d08f0fd2f5aef6593aa9055d6fb67af0f2bd63667c6fa06cbbf440b1a"
+            "0x8d54f5d3837503abd9058de0fb3197077289855e1a009794598e968f1c5a4d0e"
         ),
-        "blockNumber": 10530755,
+        "blockNumber": 17137240,
         "contractAddress": None,
-        "cumulativeGasUsed": 977116,
-        "effectiveGasPrice": 2500000022,
-        "from": "0xa7a82DD06901F29aB14AF63faF3358AD101724A8",
-        "gasUsed": 21000,
-        "logs": [],
+        "cumulativeGasUsed": 9777448,
+        "effectiveGasPrice": 32297846431,
+        "from": "0x1c7c15e45ad58d8b487B028fe0842c702595E0D8",
+        "gasUsed": 63209,
+        "logs": [
+            {
+                "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                "topics": [
+                    HexBytes(
+                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+                    ),
+                    HexBytes(
+                        "0x0000000000000000000000001c7c15e45ad58d8b487b028fe0842c702595e0d8"
+                    ),
+                    HexBytes(
+                        "0x000000000000000000000000c8f0f077e53f86f6c11a59c519f953338fba7f00"
+                    ),
+                ],
+                "data": HexBytes(
+                    "0x00000000000000000000000000000000000000000000000000000005f4173c80"
+                ),
+                "blockNumber": 17137240,
+                "transactionHash": HexBytes(
+                    "0xf6025f11f8583d30d3a227bc4616cb377c29e797e5f18ff881397988ac8a644a"
+                ),
+                "transactionIndex": 108,
+                "blockHash": HexBytes(
+                    "0x8d54f5d3837503abd9058de0fb3197077289855e1a009794598e968f1c5a4d0e"
+                ),
+                "logIndex": 218,
+                "removed": False,
+            }
+        ],
         "logsBloom": HexBytes(
-            "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            "0x00000008000000000000000000000000000000000020000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000008000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000100000000000000000010000000080000000000000000000000000000010000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000"
         ),
         "status": 1,
-        "to": "0xa417eF0c2ec3D820fbb3d9B6BeBc39d353615849",
+        "to": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
         "transactionHash": HexBytes(
-            "0x02d70902fed45c6e3dc602d6df9ef19596f3ff7255a6bd261a62b474c95ef232"
+            "0xf6025f11f8583d30d3a227bc4616cb377c29e797e5f18ff881397988ac8a644a"
         ),
-        "transactionIndex": 15,
-        "type": "0x2",
+        "transactionIndex": 108,
+        "type": 2,
     },
 }

--- a/safe_transaction_service/history/tests/mocks/mocks_internal_tx_indexer.py
+++ b/safe_transaction_service/history/tests/mocks/mocks_internal_tx_indexer.py
@@ -11,7 +11,9 @@ trace_filter_result = [
                 "0x608060405234801561001057600080fd5b506040516101e73803806101e78339818101604052602081101561003357600080fd5b8101908080519060200190929190505050600073ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff1614156100ca576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260248152602001806101c36024913960400191505060405180910390fd5b806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505060aa806101196000396000f3fe608060405273ffffffffffffffffffffffffffffffffffffffff600054167fa619486e0000000000000000000000000000000000000000000000000000000060003514156050578060005260206000f35b3660008037600080366000845af43d6000803e60008114156070573d6000fd5b3d6000f3fea265627a7a72315820d8a00dc4fe6bf675a9d7416fc2d00bb3433362aa8186b750f76c4027269667ff64736f6c634300050e0032496e76616c6964206d617374657220636f707920616464726573732070726f766964656400000000000000000000000034cfac646f301356faa8b21e94227e3583fe3f5f"
             ),
         },
-        "blockHash": "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923",
+        "blockHash": HexBytes(
+            "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923"
+        ),
         "blockNumber": 6045252,
         "result": {
             "gasUsed": 55109,
@@ -22,7 +24,9 @@ trace_filter_result = [
         },
         "subtraces": 0,
         "traceAddress": [0],
-        "transactionHash": "0x18f8eb25336203d4e561229c08a3a0ef88db1dd9767b641301d9ea3121dfeaea",
+        "transactionHash": HexBytes(
+            "0x18f8eb25336203d4e561229c08a3a0ef88db1dd9767b641301d9ea3121dfeaea"
+        ),
         "transactionPosition": 0,
         "type": "create",
     },
@@ -37,12 +41,16 @@ trace_filter_result = [
             ),
             "to": "0x673Fd582FED2CD8201d58552B912F0D1DaA37bB2",
         },
-        "blockHash": "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923",
+        "blockHash": HexBytes(
+            "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923"
+        ),
         "blockNumber": 6045252,
         "result": {"gasUsed": 150098, "output": HexBytes("0x")},
         "subtraces": 1,
         "traceAddress": [1],
-        "transactionHash": "0x18f8eb25336203d4e561229c08a3a0ef88db1dd9767b641301d9ea3121dfeaea",
+        "transactionHash": HexBytes(
+            "0x18f8eb25336203d4e561229c08a3a0ef88db1dd9767b641301d9ea3121dfeaea"
+        ),
         "transactionPosition": 0,
         "type": "call",
     },
@@ -55,12 +63,16 @@ trace_filter_result = [
             "input": HexBytes("0x"),
             "to": "0x673Fd582FED2CD8201d58552B912F0D1DaA37bB2",
         },
-        "blockHash": "0x08df561efd3d242263d8a117e32c1beb08454c87df0a287cf93fa39f0675cf04",
+        "blockHash": HexBytes(
+            "0x08df561efd3d242263d8a117e32c1beb08454c87df0a287cf93fa39f0675cf04"
+        ),
         "blockNumber": 6045275,
         "result": {"gasUsed": 1718, "output": HexBytes("0x")},
         "subtraces": 1,
         "traceAddress": [],
-        "transactionHash": "0xf554b52dcb336b83bf31e7e2e7aa94853a456f01a139a6b7dec71329460dfb61",
+        "transactionHash": HexBytes(
+            "0xf554b52dcb336b83bf31e7e2e7aa94853a456f01a139a6b7dec71329460dfb61"
+        ),
         "transactionPosition": 2,
         "type": "call",
     },
@@ -80,12 +92,16 @@ trace_blocks_result = [
                 ),
                 "to": "0xC17E0AeB794Ccf893D77222fbeAe37a4dDf64d7F",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 0, "output": HexBytes("0x")},
             "subtraces": 0,
             "traceAddress": [],
-            "transactionHash": "0xf65e0ed93640a6405614c6ed6aa3afbe344b01bbb0d75c8d5683eb2317bc24ff",
+            "transactionHash": HexBytes(
+                "0xf65e0ed93640a6405614c6ed6aa3afbe344b01bbb0d75c8d5683eb2317bc24ff"
+            ),
             "transactionPosition": 0,
             "type": "call",
         },
@@ -98,7 +114,9 @@ trace_blocks_result = [
                     "0x60806040523480156200001157600080fd5b50604051620014fb380380620014fb83398101604090815281516020808401518385015160608601516080870151336000908152808652968720869055600586905592870180519597909692959181019493019287918791879187916200007e916002918601906200013f565b506003805460ff191660ff84161790558051620000a39060049060208401906200013f565b505060068054600160a060020a0319163317905550508251620000cf91506007906020850190620001c4565b50600090505b6007548110156200013357600160086000600784815481101515620000f657fe5b600091825260208083209190910154600160a060020a031683528201929092526040019020805460ff1916911515919091179055600101620000d5565b50505050505062000271565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f106200018257805160ff1916838001178555620001b2565b82800160010185558215620001b2579182015b82811115620001b257825182559160200191906001019062000195565b50620001c09291506200022a565b5090565b8280548282559060005260206000209081019282156200021c579160200282015b828111156200021c5782518254600160a060020a031916600160a060020a03909116178255602090920191600190910190620001e5565b50620001c09291506200024a565b6200024791905b80821115620001c0576000815560010162000231565b90565b6200024791905b80821115620001c0578054600160a060020a031916815560010162000251565b61127a80620002816000396000f3006080604052600436106100fb5763ffffffff7c010000000000000000000000000000000000000000000000000000000060003504166306e48538811461010057806306fdde0314610165578063095ea7b3146101ef57806318160ddd1461022757806323b872dd1461024e578063313ce5671461027857806342966c68146102a3578063449a52f8146102bd57806370a08231146102e15780638da5cb5b14610302578063959b8c3f1461033357806395d89b4114610354578063a0712d6814610369578063a9059cbb14610381578063bcb378fa146103a5578063d95b6371146103c9578063dd62ed3e146103f0578063fad8b32a14610417575b600080fd5b34801561010c57600080fd5b50610115610438565b60408051602080825283518183015283519192839290830191858101910280838360005b83811015610151578181015183820152602001610139565b505050509050019250505060405180910390f35b34801561017157600080fd5b5061017a61049a565b6040805160208082528351818301528351919283929083019185019080838360005b838110156101b457818101518382015260200161019c565b50505050905090810190601f1680156101e15780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b3480156101fb57600080fd5b50610213600160a060020a0360043516602435610525565b604080519115158252519081900360200190f35b34801561023357600080fd5b5061023c610638565b60408051918252519081900360200190f35b34801561025a57600080fd5b50610213600160a060020a036004358116906024351660443561063e565b34801561028457600080fd5b5061028d61083d565b6040805160ff9092168252519081900360200190f35b3480156102af57600080fd5b506102bb600435610846565b005b3480156102c957600080fd5b506102bb600160a060020a0360043516602435610854565b3480156102ed57600080fd5b5061023c600160a060020a03600435166108eb565b34801561030e57600080fd5b50610317610906565b60408051600160a060020a039092168252519081900360200190f35b34801561033f57600080fd5b506102bb600160a060020a0360043516610915565b34801561036057600080fd5b5061017a610a55565b34801561037557600080fd5b506102bb600435610ab0565b34801561038d57600080fd5b50610213600160a060020a0360043516602435610b43565b3480156103b157600080fd5b506102bb600160a060020a0360043516602435610d73565b3480156103d557600080fd5b50610213600160a060020a0360043581169060243516610dde565b3480156103fc57600080fd5b5061023c600160a060020a0360043581169060243516610e80565b34801561042357600080fd5b506102bb600160a060020a0360043516610eab565b6060600780548060200260200160405190810160405280929190818152602001828054801561049057602002820191906000526020600020905b8154600160a060020a03168152600190910190602001808311610472575b5050505050905090565b6002805460408051602060018416156101000260001901909316849004601f8101849004840282018401909252818152929183018282801561051d5780601f106104f25761010080835404028352916020019161051d565b820191906000526020600020905b81548152906001019060200180831161050057829003601f168201915b505050505081565b60008115806105555750336000908152600160209081526040808320600160a060020a0387168452909152902054155b15156105d1576040805160e560020a62461bcd02815260206004820152602660248201527f596f752061726520616c726561647920617070726f766520746f20275f73706560448201527f6e646572272e0000000000000000000000000000000000000000000000000000606482015290519081900360840190fd5b336000818152600160209081526040808320600160a060020a03881680855290835292819020869055805186815290519293927f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925929181900390910190a350600192915050565b60055481565b600160a060020a0383166000908152602081905260408120548211156106ae576040805160e560020a62461bcd02815260206004820152601060248201527f4e6f7420656e6f7567682066756e647300000000000000000000000000000000604482015290519081900360640190fd5b6106b83385610dde565b151561079257600160a060020a0384166000908152600160209081526040808320338452909152902054821115610739576040805160e560020a62461bcd02815260206004820152601860248201527f4e6f7420656e6f75676820617070726f76652066756e64730000000000000000604482015290519081900360640190fd5b600160a060020a038416600090815260016020908152604080832033845290915290205461076d908363ffffffff610feb16565b600160a060020a03851660009081526001602090815260408083203384529091529020555b600160a060020a0384166000908152602081905260409020546107bb908363ffffffff610feb16565b600160a060020a0380861660009081526020819052604080822093909355908516815220546107f0908363ffffffff610ffd16565b600160a060020a0380851660008181526020818152604091829020949094558051868152905191939288169260008051602061122f83398151915292918290030190a35060019392505050565b60035460ff1681565b610851333383611010565b50565b600654600160a060020a031633146108dc576040805160e560020a62461bcd02815260206004820152602160248201527f4f6e6c79206f776e65722063616e2063616c6c20746869732066756e6374696f60448201527f6e00000000000000000000000000000000000000000000000000000000000000606482015290519081900360840190fd5b6108e7338383611157565b5050565b600160a060020a031660009081526020819052604090205490565b600654600160a060020a031681565b600160a060020a03811633141561099c576040805160e560020a62461bcd02815260206004820152602860248201527f43616e6e6f7420617574686f72697a6520796f757273656c6620617320616e2060448201527f6f70657261746f72000000000000000000000000000000000000000000000000606482015290519081900360840190fd5b600160a060020a03811660009081526008602052604090205460ff16156109ed57600160a060020a03811660009081526009602090815260408083203384529091529020805460ff19169055610a1c565b600160a060020a0381166000908152600a602090815260408083203384529091529020805460ff191660011790555b6040513390600160a060020a038316907ff4caeb2d6ca8932a215a353d0703c326ec2d81fc68170f320eb2ab49e9df61f990600090a350565b6004805460408051602060026001851615610100026000190190941693909304601f8101849004840282018401909252818152929183018282801561051d5780601f106104f25761010080835404028352916020019161051d565b600654600160a060020a03163314610b38576040805160e560020a62461bcd02815260206004820152602160248201527f4f6e6c79206f776e65722063616e2063616c6c20746869732066756e6374696f60448201527f6e00000000000000000000000000000000000000000000000000000000000000606482015290519081900360840190fd5b610851333383611157565b3360009081526020819052604081205481908190841115610bae576040805160e560020a62461bcd02815260206004820152601060248201527f4e6f7420656e6f7567682066756e647300000000000000000000000000000000604482015290519081900360640190fd5b33600090815260208190526040902054853b9250610bd2908563ffffffff610feb16565b3360009081526020819052604080822092909255600160a060020a03871681522054610c04908563ffffffff610ffd16565b600160a060020a038616600090815260208190526040812091909155821115610d3a5750604080517f3b66d02b0000000000000000000000000000000000000000000000000000000081523360048201526024810185905290518591600160a060020a03831691633b66d02b916044808201926020929091908290030181600087803b158015610c9357600080fd5b505af1158015610ca7573d6000803e3d6000fd5b505050506040513d6020811015610cbd57600080fd5b50511515610d3a576040805160e560020a62461bcd028152602060048201526024808201527f436f6e7472616374285f746f29206973206e6f7420737570706f72742065726360448201527f3232332e00000000000000000000000000000000000000000000000000000000606482015290519081900360840190fd5b604080518581529051600160a060020a03871691339160008051602061122f8339815191529181900360200190a3506001949350505050565b610d7d3383610dde565b1515610dd3576040805160e560020a62461bcd02815260206004820152600f60248201527f4e6f7420616e206f70657261746f720000000000000000000000000000000000604482015290519081900360640190fd5b6108e7338383611010565b600081600160a060020a031683600160a060020a03161480610e255750600160a060020a038084166000908152600a602090815260408083209386168352929052205460ff165b80610e795750600160a060020a03831660009081526008602052604090205460ff168015610e795750600160a060020a0380841660009081526009602090815260408083209386168352929052205460ff16155b9392505050565b600160a060020a03918216600090815260016020908152604080832093909416825291909152205490565b600160a060020a038116331415610f32576040805160e560020a62461bcd02815260206004820152602560248201527f43616e6e6f74207265766f6b6520796f757273656c6620617320616e206f706560448201527f7261746f72000000000000000000000000000000000000000000000000000000606482015290519081900360840190fd5b600160a060020a03811660009081526008602052604090205460ff1615610f8657600160a060020a03811660009081526009602090815260408083203384529091529020805460ff19166001179055610fb2565b600160a060020a0381166000908152600a602090815260408083203384529091529020805460ff191690555b6040513390600160a060020a038316907f50546e66e5f44d728365dc3908c63bc5cfeeab470722c1677e3073a6ac294aa190600090a350565b600082821115610ff757fe5b50900390565b8181018281101561100a57fe5b92915050565b600160a060020a038216600090815260208190526040902054811115611080576040805160e560020a62461bcd02815260206004820152601060248201527f4e6f7420656e6f7567682066756e647300000000000000000000000000000000604482015290519081900360640190fd5b600160a060020a0382166000908152602081905260409020546110a9908263ffffffff610feb16565b600160a060020a0383166000908152602081905260409020556005546110d5908263ffffffff610feb16565b600555604080518281529051600091600160a060020a0385169160008051602061122f8339815191529181900360200190a381600160a060020a031683600160a060020a03167f6ab368f832c266c8eb942b84fbcaa20aedc24a699d2a05fae2568028733b1d09836040518082815260200191505060405180910390a3505050565b600160a060020a038216600090815260208190526040902054611180908263ffffffff610ffd16565b600160a060020a0383166000908152602081905260409020556005546111ac908263ffffffff610ffd16565b600555604080518281529051600160a060020a0384169160009160008051602061122f8339815191529181900360200190a381600160a060020a031683600160a060020a03167f9d228d69b5fdb8d273a2336f8fb8612d039631024ea9bf09c424a9503aa078f0836040518082815260200191505060405180910390a35050505600ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3efa165627a7a72305820586457ea2e4b7f945fb718570f57c91efd6b4bef7cfae9d10016e81c95ae6d4b0029000000000000000000000000000000000013426172c74d822b878fe80000000000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000004444630390000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044446303900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000015b1a87b648384033fdca1b7656cb534b91ffe56"
                 ),
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {
                 "gasUsed": 1137795,
@@ -109,7 +127,9 @@ trace_blocks_result = [
             },
             "subtraces": 0,
             "traceAddress": [],
-            "transactionHash": "0x51418f51ce8ea8763a928a165040622dc82dcf5c73ace3aa2894d61d37a27db6",
+            "transactionHash": HexBytes(
+                "0x51418f51ce8ea8763a928a165040622dc82dcf5c73ace3aa2894d61d37a27db6"
+            ),
             "transactionPosition": 1,
             "type": "create",
         },
@@ -124,12 +144,16 @@ trace_blocks_result = [
                 ),
                 "to": "0xb0F3eAddc0A382B898CF6A03E971aCe9E3830D94",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 58736, "output": HexBytes("0x")},
             "subtraces": 1,
             "traceAddress": [],
-            "transactionHash": "0xefb8b297bf871854ecc5f186af967d28afe4376259268817e79a603abefafe6b",
+            "transactionHash": HexBytes(
+                "0xefb8b297bf871854ecc5f186af967d28afe4376259268817e79a603abefafe6b"
+            ),
             "transactionPosition": 2,
             "type": "call",
         },
@@ -144,12 +168,16 @@ trace_blocks_result = [
                 ),
                 "to": "0x15e5a50b4b348941ffA6bC214dF6d383Cf4b4944",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 55533, "output": HexBytes("0x")},
             "subtraces": 0,
             "traceAddress": [0],
-            "transactionHash": "0xefb8b297bf871854ecc5f186af967d28afe4376259268817e79a603abefafe6b",
+            "transactionHash": HexBytes(
+                "0xefb8b297bf871854ecc5f186af967d28afe4376259268817e79a603abefafe6b"
+            ),
             "transactionPosition": 2,
             "type": "call",
         },
@@ -164,7 +192,9 @@ trace_blocks_result = [
                 ),
                 "to": "0x673Fd582FED2CD8201d58552B912F0D1DaA37bB2",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {
                 "gasUsed": 40133,
@@ -174,7 +204,9 @@ trace_blocks_result = [
             },
             "subtraces": 1,
             "traceAddress": [],
-            "transactionHash": "0x304fa041d09c6d61295d479e4d0d0ac93f957c048feaf61e18d8322ec379fd3b",
+            "transactionHash": HexBytes(
+                "0x304fa041d09c6d61295d479e4d0d0ac93f957c048feaf61e18d8322ec379fd3b"
+            ),
             "transactionPosition": 3,
             "type": "call",
         },
@@ -189,7 +221,9 @@ trace_blocks_result = [
                 ),
                 "to": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {
                 "gasUsed": 38418,
@@ -199,7 +233,9 @@ trace_blocks_result = [
             },
             "subtraces": 1,
             "traceAddress": [0],
-            "transactionHash": "0x304fa041d09c6d61295d479e4d0d0ac93f957c048feaf61e18d8322ec379fd3b",
+            "transactionHash": HexBytes(
+                "0x304fa041d09c6d61295d479e4d0d0ac93f957c048feaf61e18d8322ec379fd3b"
+            ),
             "transactionPosition": 3,
             "type": "call",
         },
@@ -212,12 +248,16 @@ trace_blocks_result = [
                 "input": HexBytes("0x"),
                 "to": "0xe5738C4cF66f7d288Ef4fe3CaBd678FfB39CFF8A",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 1636, "output": HexBytes("0x")},
             "subtraces": 1,
             "traceAddress": [0, 0],
-            "transactionHash": "0x304fa041d09c6d61295d479e4d0d0ac93f957c048feaf61e18d8322ec379fd3b",
+            "transactionHash": HexBytes(
+                "0x304fa041d09c6d61295d479e4d0d0ac93f957c048feaf61e18d8322ec379fd3b"
+            ),
             "transactionPosition": 3,
             "type": "call",
         },
@@ -230,12 +270,16 @@ trace_blocks_result = [
                 "input": HexBytes("0x"),
                 "to": "0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 40, "output": HexBytes("0x")},
             "subtraces": 0,
             "traceAddress": [0, 0, 0],
-            "transactionHash": "0x304fa041d09c6d61295d479e4d0d0ac93f957c048feaf61e18d8322ec379fd3b",
+            "transactionHash": HexBytes(
+                "0x304fa041d09c6d61295d479e4d0d0ac93f957c048feaf61e18d8322ec379fd3b"
+            ),
             "transactionPosition": 3,
             "type": "call",
         },
@@ -250,12 +294,16 @@ trace_blocks_result = [
                 ),
                 "to": "0x724D1B69a7Ba352F11D73fDBdEB7fF869cB22E19",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 949489, "output": HexBytes("0x")},
             "subtraces": 1,
             "traceAddress": [],
-            "transactionHash": "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d",
+            "transactionHash": HexBytes(
+                "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d"
+            ),
             "transactionPosition": 4,
             "type": "call",
         },
@@ -270,12 +318,16 @@ trace_blocks_result = [
                 ),
                 "to": "0x265215c116122869b33962F73CeBE2275c933572",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 947224, "output": HexBytes("0x")},
             "subtraces": 1,
             "traceAddress": [0],
-            "transactionHash": "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d",
+            "transactionHash": HexBytes(
+                "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d"
+            ),
             "transactionPosition": 4,
             "type": "call",
         },
@@ -290,12 +342,16 @@ trace_blocks_result = [
                 ),
                 "to": "0x42BDd8667c52BB4F09AA443ED4864c1911e9D90A",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 944984, "output": HexBytes("0x")},
             "subtraces": 6,
             "traceAddress": [0, 0],
-            "transactionHash": "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d",
+            "transactionHash": HexBytes(
+                "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d"
+            ),
             "transactionPosition": 4,
             "type": "call",
         },
@@ -310,12 +366,16 @@ trace_blocks_result = [
                 ),
                 "to": "0x229f5b5A2cFF8C152a888ebE1c2F1eB82546A517",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 97879, "output": HexBytes("0x")},
             "subtraces": 0,
             "traceAddress": [0, 0, 0],
-            "transactionHash": "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d",
+            "transactionHash": HexBytes(
+                "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d"
+            ),
             "transactionPosition": 4,
             "type": "call",
         },
@@ -330,12 +390,16 @@ trace_blocks_result = [
                 ),
                 "to": "0x229f5b5A2cFF8C152a888ebE1c2F1eB82546A517",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 71122, "output": HexBytes("0x")},
             "subtraces": 0,
             "traceAddress": [0, 0, 1],
-            "transactionHash": "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d",
+            "transactionHash": HexBytes(
+                "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d"
+            ),
             "transactionPosition": 4,
             "type": "call",
         },
@@ -350,12 +414,16 @@ trace_blocks_result = [
                 ),
                 "to": "0x229f5b5A2cFF8C152a888ebE1c2F1eB82546A517",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 71122, "output": HexBytes("0x")},
             "subtraces": 0,
             "traceAddress": [0, 0, 2],
-            "transactionHash": "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d",
+            "transactionHash": HexBytes(
+                "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d"
+            ),
             "transactionPosition": 4,
             "type": "call",
         },
@@ -370,12 +438,16 @@ trace_blocks_result = [
                 ),
                 "to": "0x229f5b5A2cFF8C152a888ebE1c2F1eB82546A517",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 71122, "output": HexBytes("0x")},
             "subtraces": 0,
             "traceAddress": [0, 0, 3],
-            "transactionHash": "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d",
+            "transactionHash": HexBytes(
+                "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d"
+            ),
             "transactionPosition": 4,
             "type": "call",
         },
@@ -390,12 +462,16 @@ trace_blocks_result = [
                 ),
                 "to": "0x229f5b5A2cFF8C152a888ebE1c2F1eB82546A517",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 71122, "output": HexBytes("0x")},
             "subtraces": 0,
             "traceAddress": [0, 0, 4],
-            "transactionHash": "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d",
+            "transactionHash": HexBytes(
+                "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d"
+            ),
             "transactionPosition": 4,
             "type": "call",
         },
@@ -410,12 +486,16 @@ trace_blocks_result = [
                 ),
                 "to": "0x229f5b5A2cFF8C152a888ebE1c2F1eB82546A517",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {"gasUsed": 71122, "output": HexBytes("0x")},
             "subtraces": 0,
             "traceAddress": [0, 0, 5],
-            "transactionHash": "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d",
+            "transactionHash": HexBytes(
+                "0x34d153cd5d0a9bbda4a6bf135ed8b1372cf224765579d986edd1a7f9c9633f1d"
+            ),
             "transactionPosition": 4,
             "type": "call",
         },
@@ -430,7 +510,9 @@ trace_blocks_result = [
                 ),
                 "to": "0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {
                 "gasUsed": 15437,
@@ -440,7 +522,9 @@ trace_blocks_result = [
             },
             "subtraces": 0,
             "traceAddress": [],
-            "transactionHash": "0xc61d773aaa48301c71fc00bb51d554a939b3b9d4c70aab137624661234f82cb0",
+            "transactionHash": HexBytes(
+                "0xc61d773aaa48301c71fc00bb51d554a939b3b9d4c70aab137624661234f82cb0"
+            ),
             "transactionPosition": 5,
             "type": "call",
         },
@@ -460,7 +544,9 @@ trace_blocks_filtered_0x5aC2_result = [
                 ),
                 "to": "0x673Fd582FED2CD8201d58552B912F0D1DaA37bB2",
             },
-            "blockHash": "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283",
+            "blockHash": HexBytes(
+                "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
+            ),
             "blockNumber": 6067026,
             "result": {
                 "gasUsed": 40133,
@@ -470,7 +556,9 @@ trace_blocks_filtered_0x5aC2_result = [
             },
             "subtraces": 1,
             "traceAddress": [],
-            "transactionHash": "0x304fa041d09c6d61295d479e4d0d0ac93f957c048feaf61e18d8322ec379fd3b",
+            "transactionHash": HexBytes(
+                "0x304fa041d09c6d61295d479e4d0d0ac93f957c048feaf61e18d8322ec379fd3b"
+            ),
             "transactionPosition": 3,
             "type": "call",
         }
@@ -492,7 +580,9 @@ trace_transactions_result = [
                 ),
                 "to": "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B",
             },
-            "blockHash": "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923",
+            "blockHash": HexBytes(
+                "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923"
+            ),
             "blockNumber": 6045252,
             "result": {
                 "gasUsed": 240081,
@@ -502,7 +592,9 @@ trace_transactions_result = [
             },
             "subtraces": 2,
             "traceAddress": [],
-            "transactionHash": "0x18f8eb25336203d4e561229c08a3a0ef88db1dd9767b641301d9ea3121dfeaea",
+            "transactionHash": HexBytes(
+                "0x18f8eb25336203d4e561229c08a3a0ef88db1dd9767b641301d9ea3121dfeaea"
+            ),
             "transactionPosition": 0,
             "type": "call",
         },
@@ -515,7 +607,9 @@ trace_transactions_result = [
                     "0x608060405234801561001057600080fd5b506040516101e73803806101e78339818101604052602081101561003357600080fd5b8101908080519060200190929190505050600073ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff1614156100ca576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260248152602001806101c36024913960400191505060405180910390fd5b806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505060aa806101196000396000f3fe608060405273ffffffffffffffffffffffffffffffffffffffff600054167fa619486e0000000000000000000000000000000000000000000000000000000060003514156050578060005260206000f35b3660008037600080366000845af43d6000803e60008114156070573d6000fd5b3d6000f3fea265627a7a72315820d8a00dc4fe6bf675a9d7416fc2d00bb3433362aa8186b750f76c4027269667ff64736f6c634300050e0032496e76616c6964206d617374657220636f707920616464726573732070726f766964656400000000000000000000000034cfac646f301356faa8b21e94227e3583fe3f5f"
                 ),
             },
-            "blockHash": "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923",
+            "blockHash": HexBytes(
+                "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923"
+            ),
             "blockNumber": 6045252,
             "result": {
                 "gasUsed": 55109,
@@ -526,7 +620,9 @@ trace_transactions_result = [
             },
             "subtraces": 0,
             "traceAddress": [0],
-            "transactionHash": "0x18f8eb25336203d4e561229c08a3a0ef88db1dd9767b641301d9ea3121dfeaea",
+            "transactionHash": HexBytes(
+                "0x18f8eb25336203d4e561229c08a3a0ef88db1dd9767b641301d9ea3121dfeaea"
+            ),
             "transactionPosition": 0,
             "type": "create",
         },
@@ -541,12 +637,16 @@ trace_transactions_result = [
                 ),
                 "to": "0x673Fd582FED2CD8201d58552B912F0D1DaA37bB2",
             },
-            "blockHash": "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923",
+            "blockHash": HexBytes(
+                "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923"
+            ),
             "blockNumber": 6045252,
             "result": {"gasUsed": 150098, "output": HexBytes("0x")},
             "subtraces": 1,
             "traceAddress": [1],
-            "transactionHash": "0x18f8eb25336203d4e561229c08a3a0ef88db1dd9767b641301d9ea3121dfeaea",
+            "transactionHash": HexBytes(
+                "0x18f8eb25336203d4e561229c08a3a0ef88db1dd9767b641301d9ea3121dfeaea"
+            ),
             "transactionPosition": 0,
             "type": "call",
         },
@@ -561,12 +661,16 @@ trace_transactions_result = [
                 ),
                 "to": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
             },
-            "blockHash": "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923",
+            "blockHash": HexBytes(
+                "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923"
+            ),
             "blockNumber": 6045252,
             "result": {"gasUsed": 148410, "output": HexBytes("0x")},
             "subtraces": 0,
             "traceAddress": [1, 0],
-            "transactionHash": "0x18f8eb25336203d4e561229c08a3a0ef88db1dd9767b641301d9ea3121dfeaea",
+            "transactionHash": HexBytes(
+                "0x18f8eb25336203d4e561229c08a3a0ef88db1dd9767b641301d9ea3121dfeaea"
+            ),
             "transactionPosition": 0,
             "type": "call",
         },
@@ -581,12 +685,16 @@ trace_transactions_result = [
                 "input": HexBytes("0x"),
                 "to": "0x673Fd582FED2CD8201d58552B912F0D1DaA37bB2",
             },
-            "blockHash": "0x08df561efd3d242263d8a117e32c1beb08454c87df0a287cf93fa39f0675cf04",
+            "blockHash": HexBytes(
+                "0x08df561efd3d242263d8a117e32c1beb08454c87df0a287cf93fa39f0675cf04"
+            ),
             "blockNumber": 6045275,
             "result": {"gasUsed": 1718, "output": HexBytes("0x")},
             "subtraces": 1,
             "traceAddress": [],
-            "transactionHash": "0xf554b52dcb336b83bf31e7e2e7aa94853a456f01a139a6b7dec71329460dfb61",
+            "transactionHash": HexBytes(
+                "0xf554b52dcb336b83bf31e7e2e7aa94853a456f01a139a6b7dec71329460dfb61"
+            ),
             "transactionPosition": 2,
             "type": "call",
         },
@@ -599,12 +707,16 @@ trace_transactions_result = [
                 "input": HexBytes("0x"),
                 "to": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
             },
-            "blockHash": "0x08df561efd3d242263d8a117e32c1beb08454c87df0a287cf93fa39f0675cf04",
+            "blockHash": HexBytes(
+                "0x08df561efd3d242263d8a117e32c1beb08454c87df0a287cf93fa39f0675cf04"
+            ),
             "blockNumber": 6045275,
             "result": {"gasUsed": 93, "output": HexBytes("0x")},
             "subtraces": 0,
             "traceAddress": [0],
-            "transactionHash": "0xf554b52dcb336b83bf31e7e2e7aa94853a456f01a139a6b7dec71329460dfb61",
+            "transactionHash": HexBytes(
+                "0xf554b52dcb336b83bf31e7e2e7aa94853a456f01a139a6b7dec71329460dfb61"
+            ),
             "transactionPosition": 2,
             "type": "call",
         },
@@ -847,7 +959,7 @@ transactions_result = [
             "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923"
         ),
         "blockNumber": 6045252,
-        "chainId": "0x4",
+        "chainId": 4,
         "condition": None,
         "creates": None,
         "from": "0x5aC255889882aCd3da2aA939679E3f3d4cea221e",
@@ -881,7 +993,7 @@ transactions_result = [
             "0x08df561efd3d242263d8a117e32c1beb08454c87df0a287cf93fa39f0675cf04"
         ),
         "blockNumber": 6045275,
-        "chainId": "0x4",
+        "chainId": 4,
         "condition": None,
         "creates": None,
         "from": "0x5aC255889882aCd3da2aA939679E3f3d4cea221e",
@@ -915,7 +1027,7 @@ transactions_result = [
             "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
         ),
         "blockNumber": 6067026,
-        "chainId": "0x4",
+        "chainId": 4,
         "condition": None,
         "creates": None,
         "from": "0x5aC255889882aCd3da2aA939679E3f3d4cea221e",
@@ -963,7 +1075,9 @@ transaction_receipts_result = [
                     "0x39ba45ad930dece3aec537c8c5cd615daf7ee39a2513475e7680ec226e90b923"
                 ),
                 "blockNumber": 6045252,
-                "data": "0x000000000000000000000000673fd582fed2cd8201d58552b912f0d1daa37bb2",
+                "data": HexBytes(
+                    "0x000000000000000000000000673fd582fed2cd8201d58552b912f0d1daa37bb2"
+                ),
                 "logIndex": 0,
                 "removed": False,
                 "topics": [
@@ -1025,7 +1139,9 @@ transaction_receipts_result = [
                     "0x842df51860be4dc03bbd1a08812f13db00bfe70cdaa0f68b3b29facb1a5bf283"
                 ),
                 "blockNumber": 6067026,
-                "data": "0x2c33121a2f432d6cec593c2d756bd8d69a4833eb55ae993428cf50c748a1ab4d0000000000000000000000000000000000000000000000000000000000000000",
+                "data": HexBytes(
+                    "0x2c33121a2f432d6cec593c2d756bd8d69a4833eb55ae993428cf50c748a1ab4d0000000000000000000000000000000000000000000000000000000000000000"
+                ),
                 "logIndex": 1,
                 "removed": False,
                 "topics": [

--- a/safe_transaction_service/history/tests/test_internal_tx_indexer.py
+++ b/safe_transaction_service/history/tests/test_internal_tx_indexer.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from eth_typing import HexStr
 
 from gnosis.eth import EthereumClient
-from gnosis.eth.ethereum_client import ParityManager
+from gnosis.eth.ethereum_client import TracingManager
 
 from ..indexers import InternalTxIndexer, InternalTxIndexerProvider
 from ..indexers.internal_tx_indexer import InternalTxIndexerWithTraceBlock
@@ -68,13 +68,13 @@ class TestInternalTxIndexer(TestCase):
         return [block_dict[provided_hash] for provided_hash in hashes]
 
     @mock.patch.object(
-        ParityManager, "trace_blocks", autospec=True, return_value=trace_blocks_result
+        TracingManager, "trace_blocks", autospec=True, return_value=trace_blocks_result
     )
     @mock.patch.object(
-        ParityManager, "trace_filter", autospec=True, return_value=trace_filter_result
+        TracingManager, "trace_filter", autospec=True, return_value=trace_filter_result
     )
     @mock.patch.object(
-        ParityManager,
+        TracingManager,
         "trace_transactions",
         autospec=True,
         return_value=trace_transactions_result,
@@ -162,13 +162,13 @@ class TestInternalTxIndexer(TestCase):
         self.assertEqual(ethereum_tx.logs, [])
 
         trace_filter_mock.assert_called_once_with(
-            internal_tx_indexer.ethereum_client.parity,
+            internal_tx_indexer.ethereum_client.tracing,
             from_block=0,
             to_block=current_block_number - internal_tx_indexer.number_trace_blocks,
             to_address=[safe_master_copy.address],
         )
         trace_block_mock.assert_called_with(
-            internal_tx_indexer.ethereum_client.parity,
+            internal_tx_indexer.ethereum_client.tracing,
             list(
                 range(
                     current_block_number - internal_tx_indexer.number_trace_blocks + 1,
@@ -181,13 +181,13 @@ class TestInternalTxIndexer(TestCase):
         self._test_internal_tx_indexer()
 
     @mock.patch.object(
-        ParityManager,
+        TracingManager,
         "trace_blocks",
         autospec=True,
         return_value=trace_blocks_filtered_0x5aC2_result,
     )
     @mock.patch.object(
-        ParityManager, "trace_filter", autospec=True, return_value=trace_filter_result
+        TracingManager, "trace_filter", autospec=True, return_value=trace_filter_result
     )
     @mock.patch.object(
         EthereumClient,
@@ -223,7 +223,7 @@ class TestInternalTxIndexer(TestCase):
         )
         self.assertEqual(trace_filter_transactions, elements)
         trace_filter_mock.assert_called_once_with(
-            internal_tx_indexer.ethereum_client.parity,
+            internal_tx_indexer.ethereum_client.tracing,
             from_block=1,
             to_block=current_block_number - 50,
             to_address=addresses,
@@ -237,14 +237,14 @@ class TestInternalTxIndexer(TestCase):
         )
         self.assertEqual(trace_filter_transactions | trace_block_transactions, elements)
         trace_filter_mock.assert_called_once_with(
-            internal_tx_indexer.ethereum_client.parity,
+            internal_tx_indexer.ethereum_client.tracing,
             from_block=current_block_number - 50,
             to_block=current_block_number - internal_tx_indexer.number_trace_blocks,
             to_address=addresses,
         )
 
         trace_block_mock.assert_called_with(
-            internal_tx_indexer.ethereum_client.parity,
+            internal_tx_indexer.ethereum_client.tracing,
             list(
                 range(
                     current_block_number - internal_tx_indexer.number_trace_blocks + 1,
@@ -264,7 +264,7 @@ class TestInternalTxIndexer(TestCase):
         trace_filter_mock.assert_not_called()
 
         trace_block_mock.assert_called_with(
-            internal_tx_indexer.ethereum_client.parity,
+            internal_tx_indexer.ethereum_client.tracing,
             list(range(current_block_number - 3, current_block_number + 1)),
         )
 

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -289,7 +289,7 @@ class TestEthereumTx(TestCase):
             with self.subTest(tx_mock=tx_mock):
                 tx_dict = tx_mock["tx"]
                 ethereum_tx = EthereumTx.objects.create_from_tx_dict(tx_dict)
-                self.assertEqual(ethereum_tx.type, int(tx_dict["type"], 0))
+                self.assertEqual(ethereum_tx.type, tx_dict["type"], 0)
                 self.assertEqual(ethereum_tx.gas_price, tx_dict["gasPrice"])
                 self.assertEqual(
                     ethereum_tx.max_fee_per_gas, tx_dict.get("maxFeePerGas")

--- a/safe_transaction_service/history/tests/test_safe_service.py
+++ b/safe_transaction_service/history/tests/test_safe_service.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from eth_account import Account
 
 from gnosis.eth.constants import NULL_ADDRESS
-from gnosis.eth.ethereum_client import ParityManager
+from gnosis.eth.ethereum_client import TracingManager
 from gnosis.safe.tests.safe_test_case import SafeTestCaseMixin
 
 from ..models import SafeMasterCopy
@@ -36,7 +36,7 @@ class TestSafeService(SafeTestCaseMixin, TestCase):
         self.assertIsNone(self.safe_service.get_safe_creation_info(random_address))
 
         with mock.patch.object(
-            ParityManager,
+            TracingManager,
             "trace_transaction",
             autospec=True,
             return_value=[create_trace],
@@ -81,7 +81,7 @@ class TestSafeService(SafeTestCaseMixin, TestCase):
         self.assertEqual(bytes(safe_creation.setup_data), b"1234")
 
     @mock.patch.object(
-        ParityManager, "trace_transaction", return_value=creation_internal_txs
+        TracingManager, "trace_transaction", return_value=creation_internal_txs
     )
     def test_get_safe_creation_info_with_next_trace(
         self, trace_transaction_mock: MagicMock

--- a/safe_transaction_service/history/tests/test_tx_processor.py
+++ b/safe_transaction_service/history/tests/test_tx_processor.py
@@ -7,7 +7,7 @@ from eth_account import Account
 from eth_utils import keccak
 from web3 import Web3
 
-from gnosis.eth.ethereum_client import ParityManager
+from gnosis.eth.ethereum_client import TracingManager
 from gnosis.safe.safe_signature import SafeSignatureType
 from gnosis.safe.tests.safe_test_case import SafeTestCaseMixin
 
@@ -253,7 +253,7 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         self.assertEqual(safe_status.nonce, 7)
 
         with mock.patch.object(
-            ParityManager,
+            TracingManager,
             "trace_transaction",
             autospec=True,
             return_value=rinkeby_traces,
@@ -299,7 +299,7 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         # Not needed
         # approve_hash_call_trace['transactionHash'] = approve_hash_decoded_tx.internal_tx.ethereum_tx_id
         with mock.patch.object(
-            ParityManager,
+            TracingManager,
             "trace_transaction",
             autospec=True,
             return_value=[approve_hash_previous_call_trace],
@@ -467,7 +467,7 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
             self.assertEqual(ModuleTransaction.objects.count(), 0)
 
         with mock.patch.object(
-            ParityManager,
+            TracingManager,
             "trace_transaction",
             autospec=True,
             return_value=module_traces,

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -17,7 +17,7 @@ from rest_framework.test import APIRequestFactory, APITestCase, force_authentica
 from web3 import Web3
 
 from gnosis.eth.constants import NULL_ADDRESS
-from gnosis.eth.ethereum_client import EthereumClient, ParityManager
+from gnosis.eth.ethereum_client import EthereumClient, TracingManager
 from gnosis.eth.utils import fast_is_checksum_address
 from gnosis.safe import CannotEstimateGas, Safe, SafeOperation
 from gnosis.safe.safe_signature import SafeSignature, SafeSignatureType
@@ -2600,7 +2600,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         with mock.patch.object(
-            ParityManager, "trace_transaction", autospec=True, return_value=[]
+            TracingManager, "trace_transaction", autospec=True, return_value=[]
         ):
             # Insert create contract internal tx
             internal_tx = InternalTxFactory(
@@ -2631,7 +2631,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         another_trace = dict(call_trace)
         another_trace["traceAddress"] = [0, 0, 0]
         with mock.patch.object(
-            ParityManager,
+            TracingManager,
             "trace_transaction",
             autospec=True,
             return_value=[another_trace],
@@ -2646,7 +2646,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         another_trace_2 = dict(call_trace)
         another_trace_2["traceAddress"] = [0]
         with mock.patch.object(
-            ParityManager,
+            TracingManager,
             "trace_transaction",
             autospec=True,
             return_value=[another_trace, another_trace_2],

--- a/safe_transaction_service/history/utils.py
+++ b/safe_transaction_service/history/utils.py
@@ -45,7 +45,7 @@ def clean_receipt_log(receipt_log: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """
     parsed_log = {
         "address": receipt_log["address"],
-        "data": receipt_log["data"],
+        "data": receipt_log["data"].hex(),
         "topics": [topic.hex() for topic in receipt_log["topics"]],
     }
     return parsed_log

--- a/safe_transaction_service/history/utils.py
+++ b/safe_transaction_service/history/utils.py
@@ -43,6 +43,7 @@ def clean_receipt_log(receipt_log: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     :param receipt_log:
     :return:
     """
+
     parsed_log = {
         "address": receipt_log["address"],
         "data": receipt_log["data"].hex(),

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -106,7 +106,7 @@ class AboutEthereumRPCView(APIView):
 
     def _get_info(self, ethereum_client: EthereumClient) -> Dict[str, Any]:
         try:
-            client_version = ethereum_client.w3.clientVersion
+            client_version = ethereum_client.w3.client_version
         except (IOError, ValueError):
             client_version = "Error getting client version"
 

--- a/safe_transaction_service/safe_messages/tests/test_models.py
+++ b/safe_transaction_service/safe_messages/tests/test_models.py
@@ -62,7 +62,7 @@ class TestSafeMessage(SafeTestCaseMixin, TestCase):
             message_hash,
             get_safe_message_hash_for_message(safe_message.safe, message).hex(),
         )
-        recovered_owner = Account.recoverHash(
+        recovered_owner = Account._recover_hash(
             safe_message.message_hash,
             signature=safe_message_confirmation_1.signature,
         )
@@ -80,7 +80,7 @@ class TestSafeMessage(SafeTestCaseMixin, TestCase):
         safe_message_confirmation_2 = SafeMessageConfirmationFactory(
             signing_owner=owner_2_account, safe_message=safe_message
         )
-        recovered_owner = Account.recoverHash(
+        recovered_owner = Account._recover_hash(
             safe_message.message_hash,
             signature=safe_message_confirmation_2.signature,
         )

--- a/safe_transaction_service/tokens/clients/kleros_client.py
+++ b/safe_transaction_service/tokens/clients/kleros_client.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import List, Sequence
 
+from hexbytes import HexBytes
+
 from gnosis.eth import EthereumClient
 from gnosis.eth.constants import NULL_ADDRESS
 
@@ -62,7 +64,7 @@ class KlerosClient:
         token_ids: List[bytes]
         has_more: bool
         token_ids, has_more = self.kleros_contract.functions.queryTokens(
-            b"",
+            HexBytes("0" * 64),  # bytes32
             token_count,
             [
                 False,  # Include absent tokens in result.

--- a/safe_transaction_service/tokens/migrations/0002_auto_20200903_1045.py
+++ b/safe_transaction_service/tokens/migrations/0002_auto_20200903_1045.py
@@ -3,7 +3,7 @@
 from django.db import migrations, models
 
 from eth_abi.exceptions import DecodingError
-from web3.exceptions import BadFunctionCallOutput
+from web3.exceptions import Web3Exception
 
 from gnosis.eth import EthereumClientProvider
 
@@ -18,7 +18,7 @@ def fix_token_decimals(apps, schema_editor):
             if decimals != token.decimals:
                 token.decimals = decimals
                 token.save(update_fields=["decimals"])
-        except (ValueError, BadFunctionCallOutput, DecodingError):
+        except (Web3Exception, DecodingError, ValueError):
             token.decimals = None
             token.save(update_fields=["decimals"])
 

--- a/safe_transaction_service/tokens/models.py
+++ b/safe_transaction_service/tokens/models.py
@@ -16,7 +16,7 @@ from eth_abi.exceptions import DecodingError
 from eth_typing import ChecksumAddress
 from imagekit.models import ProcessedImageField
 from pilkit.processors import Resize
-from web3.exceptions import BadFunctionCallOutput
+from web3.exceptions import Web3Exception
 
 from gnosis.eth import EthereumClientProvider, InvalidERC20Info, InvalidERC721Info
 from gnosis.eth.django.models import EthereumAddressV2Field
@@ -113,7 +113,7 @@ class TokenManager(models.Manager):
                 # Make sure ERC721 is not indexed as an ERC20 for a node misbehaving
                 try:
                     decimals = ethereum_client.erc20.get_decimals(token_address)
-                except (ValueError, DecodingError, BadFunctionCallOutput):
+                except (Web3Exception, DecodingError, ValueError):
                     decimals = None
             except InvalidERC721Info:
                 logger.debug(

--- a/safe_transaction_service/utils/serializers.py
+++ b/safe_transaction_service/utils/serializers.py
@@ -2,7 +2,7 @@ from typing import List
 
 from eth_typing import ChecksumAddress
 from rest_framework.exceptions import ValidationError
-from web3.exceptions import BadFunctionCallOutput
+from web3.exceptions import Web3Exception
 
 from gnosis.eth import EthereumClientProvider
 from gnosis.safe import Safe
@@ -18,7 +18,7 @@ def get_safe_owners(safe_address: ChecksumAddress) -> List[ChecksumAddress]:
     safe = Safe(safe_address, ethereum_client)
     try:
         return safe.retrieve_owners(block_identifier="latest")
-    except BadFunctionCallOutput as e:
+    except Web3Exception as e:
         raise ValidationError(
             f"Could not get Safe {safe_address} owners from blockchain, check contract exists on network "
             f"{ethereum_client.get_network().name}"
@@ -40,7 +40,7 @@ def get_safe_version(safe_address: ChecksumAddress) -> str:
     safe = Safe(safe_address, ethereum_client)
     try:
         return safe.retrieve_version()
-    except BadFunctionCallOutput as e:
+    except Web3Exception as e:
         raise ValidationError(
             f"Could not get Safe {safe_address} version from blockchain, check contract exists on network "
             f"{ethereum_client.get_network().name}"


### PR DESCRIPTION
- Bump safe-eth-py and modify the required tests for Web3 v6
- Take a look at https://web3py.readthedocs.io/en/stable/v6_migration.html#migrating-v5-to-v6
