### PR TITLE
Fix transfer_id validator

### DIFF
--- a/safe_transaction_service/history/helpers.py
+++ b/safe_transaction_service/history/helpers.py
@@ -56,12 +56,18 @@ class DelegateSignatureHelper:
 
 def is_valid_unique_transfer_id(unique_transfer_id: str) -> bool:
     """
-    Check if transfer_id starts with 'e' or 'i' followed by keccak256 and appended by optional digits separated by commas
+    Check if transfer_id starts with 'e' or 'i' followed by keccak256 and ended by digits or digits separated by commas
 
     :param unique_transfer_id:
-    :return: True in case valide unique_transfer_id or False in other case
+    :return: ``True`` for a valid ``unique_transfer_id``, ``False`` otherwise
     """
-    return re.match(r"^(e|i)[a-fA-F0-9]{64}(\d+(,\d+)*)?$", unique_transfer_id)
+    token_transfer_id_pattern = r"^(e)([a-fA-F0-9]{64})(\d+)"
+    internal_transfer_id_pattern = r"^(i)([a-fA-F0-9]{64})(\d+)(,\d+)*"
+
+    return bool(
+        re.fullmatch(token_transfer_id_pattern, unique_transfer_id)
+        or re.fullmatch(internal_transfer_id_pattern, unique_transfer_id)
+    )
 
 
 def add_tokens_to_transfers(transfers: TransferDict) -> TransferDict:

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -480,7 +480,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         no_exist_module_transaction_id = (
-            "ief060441f0101ab83d62066b962f97e3a582686e0720157407c965c5946c2f7a"
+            "ief060441f0101ab83d62066b962f97e3a582686e0720157407c965c5946c2f7a0"
         )
         url = reverse(
             "v1:history:module-transaction", args=(no_exist_module_transaction_id,)
@@ -2759,7 +2759,38 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             self.assertNotEqual(result["type"], TransferType.ETHER_TRANSFER.name)
 
     def test_get_transfer_view(self):
+        # test wrong random transfer_id
         transfer_id = FuzzyText(length=6).fuzz()
+        response = self.client.get(
+            reverse("v1:history:transfer", args=(transfer_id,)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # test internal_tx transfer_id empty trace_address
+        transfer_id = (
+            "ief060441f0101ab83d62066b962f97e3a582686e0720157407c965c5946c2f7a"
+        )
+        response = self.client.get(
+            reverse("v1:history:transfer", args=(transfer_id,)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # test invalid erc20 transfer_id empty log_index
+        transfer_id = (
+            "e27e15ba8dea473d98c80a6b45d372c0f3c6f8c184177044c935c37eb419d7216"
+        )
+        response = self.client.get(
+            reverse("v1:history:transfer", args=(transfer_id,)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # test invalid erc20 transfer id wrong log index
+        transfer_id = (
+            "e27e15ba8dea473d98c80a6b45d372c0f3c6f8c184177044c935c37eb419d72161,1"
+        )
         response = self.client.get(
             reverse("v1:history:transfer", args=(transfer_id,)),
             format="json",

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -317,7 +317,7 @@ class ModuleTransactionView(RetrieveAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
                 data={
                     "code": 1,
-                    "message": "module_transaction_id is too short",
+                    "message": "module_transaction_id is not valid",
                     "arguments": [module_transaction_id],
                 },
             )


### PR DESCRIPTION
Closes #1455 
Closes #1454 

### What was wrong? 👾
Token transfer id should always finish with log_index value and internal_tx transfer_id should always finish with trace_address. 

### How was fixed? 
Improved `is_valid_unique_transfer_id` to check if `transfer_id` contains valid `log_index` when is token transfer or valid `trace_address` when is an internal_tx. 
 

