### PR TITLE
Support checking every chain

### DIFF
--- a/safe_transaction_service/history/management/commands/check_chainid_matches.py
+++ b/safe_transaction_service/history/management/commands/check_chainid_matches.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 
-from safe_transaction_service.utils.ethereum import get_ethereum_network
+from safe_transaction_service.utils.ethereum import get_chain_id
 
 from ...models import Chain
 
@@ -9,20 +9,18 @@ class Command(BaseCommand):
     help = "Check current connected Ethereum RPC chainId matches the one previously configured"
 
     def handle(self, *args, **options):
-        ethereum_network = get_ethereum_network()
+        chain_id = get_chain_id()
 
         try:
             chain = Chain.objects.get()  # Only one element in the table
         except Chain.DoesNotExist:
-            chain = Chain.objects.create(chain_id=ethereum_network.value)
+            chain = Chain.objects.create(chain_id=chain_id)
 
-        if chain.chain_id == ethereum_network.value:
+        if chain.chain_id == chain_id:
             self.stdout.write(
-                self.style.SUCCESS(
-                    f"EthereumRPC chainId {ethereum_network.value} looks good"
-                )
+                self.style.SUCCESS(f"EthereumRPC chainId {chain_id} looks good")
             )
         else:
             raise CommandError(
-                f"EthereumRPC chainId {ethereum_network.value} does not match previously used chainId {chain.chain_id}"
+                f"EthereumRPC chainId {chain_id} does not match previously used chainId {chain.chain_id}"
             )

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -418,19 +418,19 @@ class TestCommands(TestCase):
             self.assertIn("Start exporting of 1", buf.getvalue())
 
     @mock.patch(
-        "safe_transaction_service.history.management.commands.check_chainid_matches.get_ethereum_network"
+        "safe_transaction_service.history.management.commands.check_chainid_matches.get_chain_id"
     )
-    def test_check_chainid_matches(self, get_ethereum_network_mock: MagicMock):
+    def test_check_chainid_matches(self, get_chain_id_mock: MagicMock):
         command = "check_chainid_matches"
 
         # Create ChainId model
-        get_ethereum_network_mock.return_value = EthereumNetwork.MAINNET
+        get_chain_id_mock.return_value = EthereumNetwork.MAINNET.value
         buf = StringIO()
         call_command(command, stdout=buf)
         self.assertIn("EthereumRPC chainId 1 looks good", buf.getvalue())
 
         # Use different chainId
-        get_ethereum_network_mock.return_value = EthereumNetwork.GNOSIS
+        get_chain_id_mock.return_value = EthereumNetwork.GNOSIS.value
         with self.assertRaisesMessage(
             CommandError,
             "EthereumRPC chainId 100 does not match previously used chainId 1",
@@ -438,7 +438,7 @@ class TestCommands(TestCase):
             call_command(command)
 
         # Check again with the initial chainId
-        get_ethereum_network_mock.return_value = EthereumNetwork.MAINNET
+        get_chain_id_mock.return_value = EthereumNetwork.MAINNET.value
         buf = StringIO()
         call_command(command, stdout=buf)
         self.assertIn("EthereumRPC chainId 1 looks good", buf.getvalue())

--- a/safe_transaction_service/utils/ethereum.py
+++ b/safe_transaction_service/utils/ethereum.py
@@ -4,5 +4,9 @@ from gnosis.eth import EthereumClientProvider, EthereumNetwork
 
 
 @cache
+def get_chain_id() -> int:
+    return EthereumClientProvider().get_chain_id()
+
+
 def get_ethereum_network() -> EthereumNetwork:
-    return EthereumClientProvider().get_network()
+    return EthereumNetwork(get_chain_id())


### PR DESCRIPTION
- Use `get_chain_id` instead of `get_network` so networks not present on `EthereumNetwork` enum are supported
- Closes #1459
