### PR TITLE
Use chain_id instead of network for building webhooks

### DIFF
--- a/safe_transaction_service/history/services/webhooks.py
+++ b/safe_transaction_service/history/services/webhooks.py
@@ -18,7 +18,7 @@ from safe_transaction_service.history.models import (
     TokenTransfer,
     WebHookType,
 )
-from safe_transaction_service.utils.ethereum import get_ethereum_network
+from safe_transaction_service.utils.ethereum import get_chain_id
 
 
 def build_webhook_payload(
@@ -107,7 +107,7 @@ def build_webhook_payload(
 
     # Add chainId to every payload
     for payload in payloads:
-        payload["chainId"] = str(get_ethereum_network().value)
+        payload["chainId"] = str(get_chain_id())
 
     return payloads
 

--- a/safe_transaction_service/notifications/tasks.py
+++ b/safe_transaction_service/notifications/tasks.py
@@ -11,7 +11,7 @@ from safe_transaction_service.history.models import (
     SafeLastStatus,
     WebHookType,
 )
-from safe_transaction_service.utils.ethereum import get_ethereum_network
+from safe_transaction_service.utils.ethereum import get_chain_id
 from safe_transaction_service.utils.redis import get_redis
 from safe_transaction_service.utils.utils import close_gevent_db_connection_decorator
 
@@ -217,7 +217,7 @@ def send_notification_owner_task(address: str, safe_tx_hash: str) -> Tuple[int, 
         "type": WebHookType.CONFIRMATION_REQUEST.name,
         "address": address,
         "safeTxHash": safe_tx_hash,
-        "chainId": str(get_ethereum_network().value),
+        "chainId": str(get_chain_id()),
     }
     # Make sure notification has not been sent before
     duplicate_notification = DuplicateNotification(address, payload)


### PR DESCRIPTION
- Fix issues with webhooks not working for networks not present in `EthereumNetwork`
