### PR TITLE
Fix duplicate notifications

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -472,6 +472,10 @@ SLACK_API_WEBHOOK = env("SLACK_API_WEBHOOK", default=None)
 NOTIFICATIONS_FIREBASE_CREDENTIALS_PATH = env(
     "NOTIFICATIONS_FIREBASE_CREDENTIALS_PATH", default=None
 )
+NOTIFICATIONS_DUPLICATED_EXPIRATION_TIME_SECONDS = env.int(
+    "NOTIFICATIONS_DUPLICATED_EXPIRATION_TIME_SECONDS", default=60 * 60 * 2  # 2 hours
+)  # Don't allow the same notification to be sent during the expiration time due to reorgs and reindexing
+
 if NOTIFICATIONS_FIREBASE_CREDENTIALS_PATH:
     import json
 

--- a/safe_transaction_service/history/tests/test_transaction_service.py
+++ b/safe_transaction_service/history/tests/test_transaction_service.py
@@ -236,15 +236,15 @@ class TestTransactionService(TestCase):
         )
         all_tx_hashes = [q["safe_tx_hash"] for q in queryset]
 
-        self.assertEqual(len(self.transaction_service.redis.keys("*")), 0)
+        self.assertEqual(len(self.transaction_service.redis.keys("tx-service:*")), 0)
         all_txs = transaction_service.get_all_txs_from_identifiers(
             safe_address, all_tx_hashes
         )
-        self.assertEqual(len(self.transaction_service.redis.keys("*")), 1)
+        self.assertEqual(len(self.transaction_service.redis.keys("tx-service:*")), 1)
         all_txs = transaction_service.get_all_txs_from_identifiers(
             safe_address, all_tx_hashes
         )  # Force caching
-        self.assertEqual(len(self.transaction_service.redis.keys("*")), 1)
+        self.assertEqual(len(self.transaction_service.redis.keys("tx-service:*")), 1)
         self.assertEqual(len(all_txs), 6)
         tx_types = [
             MultisigTransaction,

--- a/safe_transaction_service/notifications/tasks.py
+++ b/safe_transaction_service/notifications/tasks.py
@@ -1,4 +1,3 @@
-import pickle
 from typing import Any, Dict, Optional, Tuple
 
 from celery import app
@@ -12,37 +11,13 @@ from safe_transaction_service.history.models import (
     WebHookType,
 )
 from safe_transaction_service.utils.ethereum import get_chain_id
-from safe_transaction_service.utils.redis import get_redis
 from safe_transaction_service.utils.utils import close_gevent_db_connection_decorator
 
 from .clients.firebase_client import FirebaseClientPool
 from .models import FirebaseDevice, FirebaseDeviceOwner
+from .utils import mark_notification_as_processed
 
 logger = get_task_logger(__name__)
-
-
-class DuplicateNotification:
-    def __init__(self, address: Optional[str], payload: Dict[str, Any]):
-        self.redis = get_redis()
-        self.address = address
-        self.payload = payload
-        self.redis_payload = self._get_redis_payload(address, payload)
-
-    def _get_redis_payload(self, address: Optional[str], payload: Dict[str, Any]):
-        return f"notifications:{address}:".encode() + pickle.dumps(payload)
-
-    def is_duplicated(self) -> bool:
-        """
-        :return: True if payload was already notified, False otherwise
-        """
-        return bool(self.redis.get(self.redis_payload))
-
-    def set_duplicated(self) -> bool:
-        """
-        Stores notification with an expiration time of 5 minutes
-        :return:
-        """
-        return self.redis.set(self.redis_payload, 1, ex=5 * 60)
 
 
 def filter_notification(payload: Dict[str, Any]) -> bool:
@@ -115,8 +90,8 @@ def send_notification_task(
         return 0, 0
 
     # Make sure notification has not been sent before
-    duplicate_notification = DuplicateNotification(address, payload)
-    if duplicate_notification.is_duplicated():
+    if not mark_notification_as_processed(address, payload):
+        # Notification was processed already
         logger.info(
             "Duplicated notification about Safe=%s with payload=%s to tokens=%s",
             address,
@@ -124,8 +99,6 @@ def send_notification_task(
             tokens,
         )
         return 0, 0
-
-    duplicate_notification.set_duplicated()
 
     with FirebaseClientPool() as firebase_client:
         logger.info(
@@ -220,8 +193,8 @@ def send_notification_owner_task(address: str, safe_tx_hash: str) -> Tuple[int, 
         "chainId": str(get_chain_id()),
     }
     # Make sure notification has not been sent before
-    duplicate_notification = DuplicateNotification(address, payload)
-    if duplicate_notification.is_duplicated():
+    if not mark_notification_as_processed(address, payload):
+        # Notification was processed already
         logger.info(
             "Duplicated notification about Safe=%s with payload=%s to tokens=%s",
             address,
@@ -229,8 +202,6 @@ def send_notification_owner_task(address: str, safe_tx_hash: str) -> Tuple[int, 
             tokens,
         )
         return 0, 0
-
-    duplicate_notification.set_duplicated()
 
     with FirebaseClientPool() as firebase_client:
         logger.info(

--- a/safe_transaction_service/notifications/tests/test_utils.py
+++ b/safe_transaction_service/notifications/tests/test_utils.py
@@ -7,11 +7,12 @@ from ..utils import SafeNotification, mark_notification_as_processed
 
 class TestUtils(TestCase):
     @classmethod
-    def setUpClass(cls) -> None:
+    def setUpClass(cls):
+        super().setUpClass()
         get_redis().flushall()
 
-    @classmethod
-    def tearDownClass(cls) -> None:
+    def tearDown(self):
+        super().tearDown()
         get_redis().flushall()
 
     def test_mark_notification_as_processed(self):

--- a/safe_transaction_service/notifications/tests/test_utils.py
+++ b/safe_transaction_service/notifications/tests/test_utils.py
@@ -1,0 +1,54 @@
+from unittest import TestCase
+
+from safe_transaction_service.utils.redis import get_redis
+
+from ..utils import SafeNotification, mark_notification_as_processed
+
+
+class TestUtils(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        get_redis().flushall()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        get_redis().flushall()
+
+    def test_mark_notification_as_processed(self):
+        address = "0x1230B3d59858296A31053C1b8562Ecf89A2f888b"
+        payloads = [
+            {
+                "address": "0x1230B3d59858296A31053C1b8562Ecf89A2f888b",
+                "type": "INCOMING_TOKEN",
+                "tokenAddress": "0x63704B63Ac04f3a173Dfe677C7e3D330c347CD88",
+                "txHash": "0xd8cf5db08e4f3d43660975c8be02a079139a69c42c0ccdd157618aec9bb91b28",
+                "value": "50000000000000",
+            },
+            {
+                "address": "0x1230B3d59858296A31053C1b8562Ecf89A2f888b",
+                "type": "OUTGOING_TOKEN",
+                "tokenAddress": "0x63704B63Ac04f3a173Dfe677C7e3D330c347CD88",
+                "txHash": "0xd8cf5db08e4f3d43660975c8be02a079139a69c42c0ccdd157618aec9bb91b28",
+                "value": "50000000000000",
+            },
+        ]
+
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                self.assertTrue(mark_notification_as_processed(None, payload))
+                self.assertFalse(mark_notification_as_processed(None, payload))
+                self.assertTrue(mark_notification_as_processed(address, payload))
+                self.assertFalse(mark_notification_as_processed(address, payload))
+
+                self.assertTrue(SafeNotification(None, payload).is_duplicated())
+                self.assertTrue(SafeNotification(address, payload).is_duplicated())
+
+        # Change order for fields in `payloads[0]`
+        payload_0_changed = {
+            "value": "50000000000000",
+            "tokenAddress": "0x63704B63Ac04f3a173Dfe677C7e3D330c347CD88",
+            "txHash": "0xd8cf5db08e4f3d43660975c8be02a079139a69c42c0ccdd157618aec9bb91b28",
+            "address": "0x1230B3d59858296A31053C1b8562Ecf89A2f888b",
+            "type": "INCOMING_TOKEN",
+        }
+        self.assertFalse(mark_notification_as_processed(None, payload_0_changed))

--- a/safe_transaction_service/notifications/utils.py
+++ b/safe_transaction_service/notifications/utils.py
@@ -1,9 +1,57 @@
-from typing import Sequence
+import hashlib
+import json
+from typing import Any, Dict, Optional, Sequence
 from uuid import UUID
 
 from hexbytes import HexBytes
 
 from gnosis.eth.utils import fast_keccak
+
+from safe_transaction_service.utils.redis import get_redis
+
+
+class SafeNotification:
+    def __init__(self, address: Optional[str], payload: Dict[str, Any]):
+        self.redis = get_redis()
+        self.address = address
+        self.payload = payload
+        self.redis_key = self._get_redis_key(address, payload)
+
+    def _get_redis_key(self, address: Optional[str], payload: Dict[str, Any]) -> str:
+        """
+        :param address:
+        :param payload:
+        :return: Key built from ``address`` and MD5 hashing the ``payload``
+        """
+        payload_hash = json.dumps(payload, sort_keys=True)
+        # Use MD5 as it's fast and should be enough for this use case
+        hex_hash = hashlib.md5(payload_hash.encode()).hexdigest()
+        return f"notifications:{address}:{hex_hash}"
+
+    def is_duplicated(self) -> bool:
+        """
+        :return: ``True`` if payload was already notified, ``False`` otherwise
+        """
+        return bool(self.redis.get(self.redis_key))
+
+    def set_duplicated(self) -> bool:
+        """
+        Stores key with an expiration time of 2 hours (if not set)
+
+        :return: ``True`` if key was not set before, ``False`` otherwise
+        """
+        return bool(self.redis.set(self.redis_key, 1, ex=60 * 60 * 2, nx=True))
+
+
+def mark_notification_as_processed(
+    address: Optional[str], payload: Dict[str, Any]
+) -> bool:
+    """
+    :param address:
+    :param payload:
+    :return: ``True`` if key was not used and was set, ``False`` otherwise
+    """
+    return SafeNotification(address, payload).set_duplicated()
 
 
 def calculate_device_registration_hash(


### PR DESCRIPTION

- Use md5 hash of the payload instead of the payload
- Increase cache expiration time from 5 minutes to 2 hours
- Optimize redis check, so only one query is needed (by using SETNX)
- Refactor classes and tests
