### PR TITLE
Don't mark txs as processed before processing

### DIFF
--- a/safe_transaction_service/history/indexers/element_already_processed_checker.py
+++ b/safe_transaction_service/history/indexers/element_already_processed_checker.py
@@ -9,6 +9,10 @@ logger = getLogger(__name__)
 
 
 class ElementAlreadyProcessedChecker:
+    """
+    Keeps a cache of already processed transactions and events
+    """
+
     def __init__(self):
         self._processed_element_cache = FixedSizeDict(maxlen=40_000)  # Around 3MiB
 
@@ -24,12 +28,26 @@ class ElementAlreadyProcessedChecker:
     def is_processed(
         self, tx_hash: HexBytes, block_hash: Optional[HexBytes], index: int = 0
     ) -> bool:
+        """
+        :param tx_hash:
+        :param block_hash:
+        :param index: Only for events
+        :return: ``True`` if element was processed, ``False`` otherwise
+        """
         tx_id = self.get_key(tx_hash, block_hash, index)
         return tx_id in self._processed_element_cache
 
     def mark_as_processed(
         self, tx_hash: HexBytes, block_hash: Optional[HexBytes], index: int = 0
     ) -> bool:
+        """
+        Mark element as processed if it is not already marked
+
+        :param tx_hash:
+        :param block_hash:
+        :param index: Only for events
+        :return: ``True`` if element was marked as processed, ``False`` if it was marked already
+        """
         tx_id = self.get_key(tx_hash, block_hash, index)
 
         if tx_id in self._processed_element_cache:

--- a/safe_transaction_service/history/indexers/element_already_processed_checker.py
+++ b/safe_transaction_service/history/indexers/element_already_processed_checker.py
@@ -1,0 +1,51 @@
+from logging import getLogger
+from typing import Optional
+
+from hexbytes import HexBytes
+
+from safe_transaction_service.utils.utils import FixedSizeDict
+
+logger = getLogger(__name__)
+
+
+class ElementAlreadyProcessedChecker:
+    def __init__(self):
+        self._processed_element_cache = FixedSizeDict(maxlen=40_000)  # Around 3MiB
+
+    def clear(self) -> None:
+        return self._processed_element_cache.clear()
+
+    def get_key(self, tx_hash: HexBytes, block_hash: HexBytes, index: int) -> HexBytes:
+        tx_hash = HexBytes(tx_hash)
+        block_hash = HexBytes(block_hash or 0)
+        index = HexBytes(index)
+        return tx_hash + block_hash + index
+
+    def is_processed(
+        self, tx_hash: HexBytes, block_hash: Optional[HexBytes], index: int = 0
+    ) -> bool:
+        tx_id = self.get_key(tx_hash, block_hash, index)
+        return tx_id in self._processed_element_cache
+
+    def mark_as_processed(
+        self, tx_hash: HexBytes, block_hash: Optional[HexBytes], index: int = 0
+    ) -> bool:
+        tx_id = self.get_key(tx_hash, block_hash, index)
+
+        if tx_id in self._processed_element_cache:
+            logger.debug(
+                "Element with tx-hash=%s on block=%s with index=%d was already processed",
+                tx_hash.hex(),
+                block_hash.hex(),
+                index,
+            )
+            return False
+        else:
+            logger.debug(
+                "Marking element with tx-hash=%s on block=%s with index=%d as processed",
+                tx_hash.hex(),
+                block_hash.hex(),
+                index,
+            )
+            self._processed_element_cache[tx_id] = None
+            return True

--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -170,7 +170,11 @@ class Erc20EventsIndexer(EventsIndexer):
             not_processed_log_receipts = [
                 log_receipt
                 for log_receipt in log_receipts
-                if self.mark_as_processed(log_receipt)
+                if not self.element_already_processed_checker.is_processed(
+                    log_receipt["transactionHash"],
+                    log_receipt["blockHash"],
+                    log_receipt["logIndex"],
+                )
             ]
             result_erc20 = ERC20Transfer.objects.bulk_create_from_generator(
                 self.events_to_erc20_transfer(not_processed_log_receipts),
@@ -181,6 +185,14 @@ class Erc20EventsIndexer(EventsIndexer):
                 ignore_conflicts=True,
             )
             logger.debug("Stored TokenTransfer objects")
+            logger.debug("Marking events as processed")
+            for log_receipt in log_receipts:
+                self.element_already_processed_checker.mark_as_processed(
+                    log_receipt["transactionHash"],
+                    log_receipt["blockHash"],
+                    log_receipt["logIndex"],
+                )
+            logger.debug("Marked events as processed")
             return range(
                 result_erc20 + result_erc721
             )  # TODO Hack to prevent returning `TokenTransfer` and using too much RAM

--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -186,7 +186,7 @@ class Erc20EventsIndexer(EventsIndexer):
             )
             logger.debug("Stored TokenTransfer objects")
             logger.debug("Marking events as processed")
-            for log_receipt in log_receipts:
+            for log_receipt in not_processed_log_receipts:
                 self.element_already_processed_checker.mark_as_processed(
                     log_receipt["transactionHash"],
                     log_receipt["blockHash"],

--- a/safe_transaction_service/history/indexers/events_indexer.py
+++ b/safe_transaction_service/history/indexers/events_indexer.py
@@ -14,8 +14,9 @@ from web3.contract.contract import ContractEvent
 from web3.exceptions import LogTopicError
 from web3.types import EventData, FilterParams, LogReceipt
 
-from safe_transaction_service.utils.utils import FixedSizeDict, chunks
+from safe_transaction_service.utils.utils import chunks
 
+from .element_already_processed_checker import ElementAlreadyProcessedChecker
 from .ethereum_indexer import EthereumIndexer, FindRelevantElementsException
 
 logger = getLogger(__name__)
@@ -51,42 +52,9 @@ class EventsIndexer(EthereumIndexer):
 
         # Number of concurrent requests to `getLogs`
         self.get_logs_concurrency = settings.ETH_EVENTS_GET_LOGS_CONCURRENCY
-        self._processed_element_cache = FixedSizeDict(maxlen=40_000)  # Around 3MiB
+        self.element_already_processed_checker = ElementAlreadyProcessedChecker()
 
         super().__init__(*args, **kwargs)
-
-    def mark_as_processed(self, log_receipt: LogReceipt) -> bool:
-        """
-        Mark event as processed by the indexer
-
-        :param log_receipt:
-        :return: `True` if `event` was marked as processed, `False` if it was already processed
-        """
-
-        # Calculate id, collision should be almost impossible
-        # Add blockHash to prevent reorg issues
-        block_hash = HexBytes(log_receipt["blockHash"])
-        tx_hash = HexBytes(log_receipt["transactionHash"])
-        log_index = log_receipt["logIndex"]
-        event_id = block_hash + tx_hash + HexBytes(log_index)
-
-        if event_id in self._processed_element_cache:
-            logger.debug(
-                "Event with tx-hash=%s log-index=%d on block=%s was already processed",
-                tx_hash.hex(),
-                log_index,
-                block_hash.hex(),
-            )
-            return False
-        else:
-            logger.debug(
-                "Marking event with tx-hash=%s log-index=%d on block=%s as processed",
-                tx_hash.hex(),
-                log_index,
-                block_hash.hex(),
-            )
-            self._processed_element_cache[event_id] = None
-            return True
 
     @property
     @abstractmethod
@@ -289,7 +257,11 @@ class EventsIndexer(EthereumIndexer):
         not_processed_log_receipts = [
             log_receipt
             for log_receipt in log_receipts
-            if self.mark_as_processed(log_receipt)
+            if not self.element_already_processed_checker.is_processed(
+                log_receipt["transactionHash"],
+                log_receipt["blockHash"],
+                log_receipt["logIndex"],
+            )
         ]
         decoded_elements: List[EventData] = self.decode_elements(
             not_processed_log_receipts
@@ -306,4 +278,14 @@ class EventsIndexer(EthereumIndexer):
             if processed_element := self._process_decoded_element(decoded_element):
                 processed_elements.append(processed_element)
         logger.debug("End processing %d decoded events", len(decoded_elements))
+
+        logger.debug("Marking events as processed")
+        for log_receipt in log_receipts:
+            self.element_already_processed_checker.mark_as_processed(
+                log_receipt["transactionHash"],
+                log_receipt["blockHash"],
+                log_receipt["logIndex"],
+            )
+        logger.debug("Marked events as processed")
+
         return processed_elements

--- a/safe_transaction_service/history/indexers/events_indexer.py
+++ b/safe_transaction_service/history/indexers/events_indexer.py
@@ -280,7 +280,7 @@ class EventsIndexer(EthereumIndexer):
         logger.debug("End processing %d decoded events", len(decoded_elements))
 
         logger.debug("Marking events as processed")
-        for log_receipt in log_receipts:
+        for log_receipt in not_processed_log_receipts:
             self.element_already_processed_checker.mark_as_processed(
                 log_receipt["transactionHash"],
                 log_receipt["blockHash"],

--- a/safe_transaction_service/history/indexers/internal_tx_indexer.py
+++ b/safe_transaction_service/history/indexers/internal_tx_indexer.py
@@ -294,7 +294,7 @@ class InternalTxIndexer(EthereumIndexer):
                 if not tx_hash_with_traces[tx_hash]:
                     tx_hashes_missing_traces.append(tx_hash)
             else:
-                # Trace was already processed
+                # Traces were already processed
                 del tx_hash_with_traces[tx_hash]
 
         ethereum_txs = self.index_service.txs_create_or_update_from_tx_hashes(tx_hashes)

--- a/safe_transaction_service/history/tests/test_erc20_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_erc20_events_indexer.py
@@ -66,7 +66,7 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
         )[0]
         self.assertIn("value", event["args"])
 
-    def test_mark_as_processed(self):
+    def test_element_already_processed_checker(self):
         # Create transaction in db so not fetching of transaction is needed
         for log_receipt in log_receipt_mock:
             tx_hash = log_receipt["transactionHash"]
@@ -74,11 +74,14 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
             EthereumTxFactory(tx_hash=tx_hash, block__block_hash=block_hash)
 
         # After the first processing transactions will be cached to prevent reprocessing
-        self.assertEqual(len(self.erc20_events_indexer._processed_element_cache), 0)
+        processed_element_cache = (
+            self.erc20_events_indexer.element_already_processed_checker._processed_element_cache
+        )
+        self.assertEqual(len(processed_element_cache), 0)
         self.assertEqual(
             len(self.erc20_events_indexer.process_elements(log_receipt_mock)), 1
         )
-        self.assertEqual(len(self.erc20_events_indexer._processed_element_cache), 1)
+        self.assertEqual(len(processed_element_cache), 1)
 
         # Transactions are cached and will not be reprocessed
         self.assertEqual(
@@ -89,7 +92,7 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
         )
 
         # Cleaning the cache will reprocess the transactions again
-        self.erc20_events_indexer._processed_element_cache.clear()
+        self.erc20_events_indexer.element_already_processed_checker.clear()
         self.assertEqual(
             len(self.erc20_events_indexer.process_elements(log_receipt_mock)), 1
         )

--- a/safe_transaction_service/history/tests/test_internal_tx_indexer.py
+++ b/safe_transaction_service/history/tests/test_internal_tx_indexer.py
@@ -322,7 +322,7 @@ class TestInternalTxIndexer(TestCase):
         results = tx_processor.process_decoded_transactions(internal_txs_decoded)
         self.assertEqual(results, [True, True])
 
-    def test_mark_as_processed(self):
+    def test_element_already_processed_checker(self):
         """
         Test not reprocessing of processed events
         """
@@ -336,11 +336,14 @@ class TestInternalTxIndexer(TestCase):
             EthereumTxFactory(tx_hash=tx_hash)
 
         # After the first processing transactions will be cached to prevent reprocessing
-        self.assertEqual(len(self.internal_tx_indexer._processed_element_cache), 0)
+        processed_element_cache = (
+            self.internal_tx_indexer.element_already_processed_checker._processed_element_cache
+        )
+        self.assertEqual(len(processed_element_cache), 0)
         self.assertEqual(
             len(self.internal_tx_indexer.process_elements(tx_hash_with_traces)), 2
         )
-        self.assertEqual(len(self.internal_tx_indexer._processed_element_cache), 2)
+        self.assertEqual(len(processed_element_cache), 2)
 
         # Transactions are cached and will not be reprocessed
         self.assertEqual(
@@ -351,7 +354,7 @@ class TestInternalTxIndexer(TestCase):
         )
 
         # Cleaning the cache will reprocess the transactions again
-        self.internal_tx_indexer._processed_element_cache.clear()
+        self.internal_tx_indexer.element_already_processed_checker.clear()
         self.assertEqual(
             len(self.internal_tx_indexer.process_elements(tx_hash_with_traces)), 2
         )

--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -611,7 +611,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
             InternalTxDecoded.objects.count(), expected_internal_txs_decoded
         )
 
-    def test_mark_as_processed(self):
+    def test_element_already_processed_checker(self):
         # SafeEventsIndexer does not use bulk saving into database,
         # so mark_as_processed is just a optimization but not critical
 
@@ -623,11 +623,14 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
                 EthereumTxFactory(tx_hash=tx_hash, block__block_hash=block_hash)
 
         # After the first processing transactions will be cached to prevent reprocessing
-        self.assertEqual(len(self.safe_events_indexer._processed_element_cache), 0)
+        processed_element_cache = (
+            self.safe_events_indexer.element_already_processed_checker._processed_element_cache
+        )
+        self.assertEqual(len(processed_element_cache), 0)
         self.assertEqual(
             len(self.safe_events_indexer.process_elements(safe_events_mock)), 28
         )
-        self.assertEqual(len(self.safe_events_indexer._processed_element_cache), 28)
+        self.assertEqual(len(processed_element_cache), 28)
 
         # Transactions are cached and will not be reprocessed
         self.assertEqual(
@@ -638,7 +641,7 @@ class TestSafeEventsIndexer(SafeTestCaseMixin, TestCase):
         )
 
         # Even if we empty the cache, events will not be reprocessed again
-        self.safe_events_indexer._processed_element_cache.clear()
+        self.safe_events_indexer.element_already_processed_checker.clear()
         self.assertEqual(
             len(self.safe_events_indexer.process_elements(safe_events_mock)), 0
         )


### PR DESCRIPTION
- Txs/events were marked as processed in a optimistic way
- When txs/events were not processed due to an exception in the middle of the process, txs/events cannot be processed again as they were marked as processed
- Mark txs/events as processed only after they are inserted
- Improve logging for storing blocks, txs and receipts on database
