### PR TITLE
Handle logging exception in ethereum_indexer.py

### DIFF
--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -451,7 +451,7 @@ class EthereumIndexer(ABC):
                     "%s: Processed %d elements for almost updated addresses. From-block-number=%d to-block-number=%d",
                     self.__class__.__name__,
                     number_processed_elements,
-                    from_block_number,
+                    from_block_number or 0,
                     to_block_number,
                 )
                 total_number_processed_elements += number_processed_elements


### PR DESCRIPTION
### Make sure these boxes are checked! 📦✅

- [ ] You ran `./run_tests.sh`
- [x] You ran `pre-commit run -a`

### What was wrong? 👾

Indexing was failing because of an exception in a logging message.

```
indexer_worker_mordor_1                  | 2023-06-02 08:39:00,773 [INFO] [3ad5fb4c/index_erc20_events_task] Erc20EventsIndexer: Processing 46 almost updated addresses
indexer_worker_mordor_1                  | --- Logging error ---
indexer_worker_mordor_1                  | Traceback (most recent call last):
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/logging/__init__.py", line 1100, in emit
indexer_worker_mordor_1                  |     msg = self.format(record)
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/logging/__init__.py", line 943, in format
indexer_worker_mordor_1                  |     return fmt.format(record)
indexer_worker_mordor_1                  |   File "/app/safe_transaction_service/utils/celery.py", line 32, in format
indexer_worker_mordor_1                  |     return super().format(record)
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/celery/utils/log.py", line 146, in format
indexer_worker_mordor_1                  |     msg = super().format(record)
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/logging/__init__.py", line 678, in format
indexer_worker_mordor_1                  |     record.message = record.getMessage()
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/logging/__init__.py", line 368, in getMessage
indexer_worker_mordor_1                  |     msg = msg % self.args
indexer_worker_mordor_1                  | TypeError: %d format: a real number is required, not NoneType
indexer_worker_mordor_1                  | Call stack:
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/celery/concurrency/gevent.py", line 26, in apply_timeout
indexer_worker_mordor_1                  |     return apply_target(target, args, kwargs, callback,
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/celery/concurrency/base.py", line 29, in apply_target
indexer_worker_mordor_1                  |     ret = target(*args, **kwargs)
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 649, in fast_trace_task
indexer_worker_mordor_1                  |     R, I, T, Rstr = tasks[task].__trace__(
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 451, in trace_task
indexer_worker_mordor_1                  |     R = retval = fun(*args, **kwargs)
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 734, in __protected_call__
indexer_worker_mordor_1                  |     return self.run(*args, **kwargs)
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/celery/app/autoretry.py", line 34, in run
indexer_worker_mordor_1                  |     return task._orig_run(*args, **kwargs)
indexer_worker_mordor_1                  |   File "/app/safe_transaction_service/history/tasks.py", line 106, in index_erc20_events_task
indexer_worker_mordor_1                  |     ) = Erc20EventsIndexerProvider().start()
indexer_worker_mordor_1                  |   File "/app/safe_transaction_service/history/indexers/ethereum_indexer.py", line 450, in start
indexer_worker_mordor_1                  |     logger.debug(
indexer_worker_mordor_1                  | Message: '%s: Processed %d elements for almost updated addresses. From-block-number=%d to-block-number=%d'
indexer_worker_mordor_1                  | Arguments: ('Erc20EventsIndexer', 0, None, 8873638)
```

