### PR TITLE
Fix connection is NoneType

### DIFF
--- a/safe_transaction_service/events/services/queue_service.py
+++ b/safe_transaction_service/events/services/queue_service.py
@@ -140,7 +140,7 @@ class AsyncQueueService(QueueService):
             self._connection_parameters.host,
             err,
         )
-        self._connection.ioloop.call_later(5, self.connect)
+        connection.ioloop.call_later(5, self.connect)
 
     def on_connection_closed(self, connection: GeventConnection, reason: Exception):
         """
@@ -158,7 +158,7 @@ class AsyncQueueService(QueueService):
             self._connection_parameters.host,
             reason,
         )
-        self._connection.ioloop.call_later(5, self.connect)
+        connection.ioloop.call_later(5, self.connect)
 
     def open_channel(self):
         """


### PR DESCRIPTION
# Description
If an issue during the first attempt connection happens, connection is not assigned properly that is ok, in this case we should use the connection passed as parameter on `on_connection_open_error` callback to retry the connection after 5 seconds. 
# Logs related
```
  File "/app/safe_transaction_service/events/services/queue_service.py", line 143, in on_connection_open_error
    self._connection.ioloop.call_later(5, self.connect)
AttributeError: 'NoneType' object has no attribute 'ioloop'
```