### PR TITLE
Fix swagger doc

### DIFF
--- a/safe_transaction_service/safe_messages/views.py
+++ b/safe_transaction_service/safe_messages/views.py
@@ -43,6 +43,9 @@ class SafeMessageSignatureView(CreateAPIView):
         )
         return context
 
+    @swagger_auto_schema(
+        responses={201: "Created"},
+    )
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -89,7 +92,7 @@ class SafeMessagesView(ListCreateAPIView):
 
     @swagger_auto_schema(
         request_body=serializers.SafeMessageSerializer,
-        responses={201: serializers.SafeMessageResponseSerializer},
+        responses={201: "Created"},
     )
     def post(self, request, address, *args, **kwargs):
         if not fast_is_checksum_address(address):


### PR DESCRIPTION
### What was wrong? 👾
Swagger documentation  for `/v1/messages/{message_hash}/signatures/` and `/v1/safes/{address}/messages/` is indicating wrongly that the response includes a body.
Closes #1517 
