### PR TITLE
Fix missing rabbitmq testing variable

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -11,3 +11,4 @@ ETHEREUM_NODE_URL=http://localhost:8545
 ETHEREUM_TRACING_NODE_URL=http://localhost:8545
 ETH_HASH_BACKEND=pysha3
 ENABLE_ANALYTICS=True
+EVENTS_QUEUE_URL=amqp://guest:guest@rabbitmq/


### PR DESCRIPTION
Local tests doesn't work because rabbitmq host was not defined.
