### PR TITLE
Revert "Bump drf-yasg[validation] from 1.21.5 to 1.21.6"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-timezone-field==5.1
 djangorestframework==3.14.0
 djangorestframework-camel-case==1.4.2
 docutils==0.20.1
-drf-yasg[validation]==1.21.6
+drf-yasg[validation]==1.21.5
 firebase-admin==6.2.0
 flower==1.2.0
 gunicorn[gevent]==20.1.0


### PR DESCRIPTION
- Reverts safe-global/safe-transaction-service#1526
- Wait for https://github.com/axnsan12/drf-yasg/issues/856 to be released