### PR TITLE
Refactor reindexing

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -415,7 +415,7 @@ ETH_INTERNAL_TXS_BLOCK_PROCESS_LIMIT = env.int(
     "ETH_INTERNAL_TXS_BLOCK_PROCESS_LIMIT", default=10_000
 )
 ETH_INTERNAL_TXS_BLOCKS_TO_REINDEX_AGAIN = env.int(
-    "ETH_INTERNAL_TXS_BLOCKS_TO_REINDEX_AGAIN", default=6
+    "ETH_INTERNAL_TXS_BLOCKS_TO_REINDEX_AGAIN", default=10
 )
 ETH_INTERNAL_TXS_NUMBER_TRACE_BLOCKS = env.int(
     "ETH_INTERNAL_TXS_NUMBER_TRACE_BLOCKS", default=10
@@ -442,7 +442,7 @@ ETH_EVENTS_BLOCK_PROCESS_LIMIT_MAX = env.int(
     "ETH_EVENTS_BLOCK_PROCESS_LIMIT_MAX", default=0
 )  # Maximum number of blocks to process together when searching for events. 0 == no limit.
 ETH_EVENTS_BLOCKS_TO_REINDEX_AGAIN = env.int(
-    "ETH_EVENTS_BLOCKS_TO_REINDEX_AGAIN", default=10
+    "ETH_EVENTS_BLOCKS_TO_REINDEX_AGAIN", default=20
 )  # Blocks to reindex again every indexer run when service is synced. Useful for RPCs not reliable
 ETH_EVENTS_GET_LOGS_CONCURRENCY = env.int(
     "ETH_EVENTS_GET_LOGS_CONCURRENCY", default=20
@@ -454,7 +454,7 @@ ETH_EVENTS_UPDATED_BLOCK_BEHIND = env.int(
     "ETH_EVENTS_UPDATED_BLOCK_BEHIND", default=24 * 60 * 60 // 15
 )  # Number of blocks to consider an address 'almost updated'.
 ETH_REORG_BLOCKS = env.int(
-    "ETH_REORG_BLOCKS", default=100 if ETH_L2_NETWORK else 10
+    "ETH_REORG_BLOCKS", default=150 if ETH_L2_NETWORK else 10
 )  # Number of blocks from the current block number needed to consider a block valid/stable
 
 # Tokens
@@ -495,10 +495,6 @@ if NOTIFICATIONS_FIREBASE_CREDENTIALS_PATH:
             "firebase-credentials.json"
         )
     )
-
-ALERT_OUT_OF_SYNC_EVENTS_THRESHOLD = env.float(
-    "ALERT_OUT_OF_SYNC_EVENTS_THRESHOLD", default=0.1
-)  # Percentage of Safes allowed to be out of sync without alerting. By default 10%
 
 # Events
 # ------------------------------------------------------------------------------

--- a/safe_transaction_service/history/services/index_service.py
+++ b/safe_transaction_service/history/services/index_service.py
@@ -67,7 +67,6 @@ class IndexServiceProvider:
                 EthereumClientProvider(),
                 settings.ETH_REORG_BLOCKS,
                 settings.ETH_L2_NETWORK,
-                settings.ALERT_OUT_OF_SYNC_EVENTS_THRESHOLD,
             )
         return cls.instance
 
@@ -84,12 +83,10 @@ class IndexService:
         ethereum_client: EthereumClient,
         eth_reorg_blocks: int,
         eth_l2_network: bool,
-        alert_out_of_sync_events_threshold: float,
     ):
         self.ethereum_client = ethereum_client
         self.eth_reorg_blocks = eth_reorg_blocks
         self.eth_l2_network = eth_l2_network
-        self.alert_out_of_sync_events_threshold = alert_out_of_sync_events_threshold
 
     def block_get_or_create_from_block_hash(self, block_hash: int):
         try:
@@ -405,7 +402,11 @@ class IndexService:
         if not addresses:
             logger.warning("No addresses to process")
         else:
-            logger.info("Start reindexing addresses %s", addresses)
+            # Don't log all the addresses
+            addresses_str = (
+                str(addresses) if len(addresses) < 10 else f"{addresses[:10]}..."
+            )
+            logger.info("Start reindexing addresses %s", addresses_str)
             current_block_number = self.ethereum_client.current_block_number
             stop_block_number = (
                 min(current_block_number, to_block_number)

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -131,8 +131,8 @@ def index_erc20_events_out_of_sync_task(
 
     current_block_number = erc20_events_indexer.ethereum_client.current_block_number
     addresses = addresses or [
-        x.address
-        for x in erc20_events_indexer.get_almost_updated_addresses(
+        almost_updated_address.address
+        for almost_updated_address in erc20_events_indexer.get_almost_updated_addresses(
             current_block_number
         )[:number_of_addresses]
     ]


### PR DESCRIPTION
- Increase default `ETH_REORG_BLOCKS` from `100` -> `150`
- Don't log all addresses when reindexing
- Remove not used anymore ALERT_OUT_OF_SYNC_EVENTS_THRESHOLD
