### PR TITLE
Reenable auto reindex of Safes when finding issues

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -11,4 +11,4 @@ ETHEREUM_NODE_URL=http://localhost:8545
 ETHEREUM_TRACING_NODE_URL=http://localhost:8545
 ETH_HASH_BACKEND=pysha3
 ENABLE_ANALYTICS=True
-EVENTS_QUEUE_URL=amqp://guest:guest@rabbitmq/
+EVENTS_QUEUE_URL=amqp://guest:guest@localhost:5672/

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -255,7 +255,7 @@ def process_decoded_internal_txs_task(self) -> Optional[int]:
                 if safe_to_process not in banned_safes:
                     count += 1
                     process_decoded_internal_txs_for_safe_task.delay(
-                        safe_to_process, reindex_master_copies=False
+                        safe_to_process, reindex_master_copies=True
                     )
                 else:
                     logger.info(
@@ -291,7 +291,9 @@ def reindex_mastercopies_last_hours_task(self, hours: float = 2.5) -> Optional[i
                         from_block_number,
                         to_block_number,
                     )
-                    reindex_master_copies_task.delay(from_block_number, to_block_number)
+                    reindex_master_copies_task.delay(
+                        from_block_number, to_block_number=to_block_number
+                    )
 
 
 @app.shared_task(bind=True, soft_time_limit=SOFT_TIMEOUT, time_limit=LOCK_TIMEOUT)
@@ -316,13 +318,17 @@ def reindex_erc20_erc721_last_hours_task(self, hours: float = 2.5) -> Optional[i
                         from_block_number,
                         to_block_number,
                     )
-                    # countdown of 30 minutes to execute this reindex after mastercopies reindex is finished
-                    reindex_erc20_events_task.delay(from_block_number, to_block_number)
+                    reindex_erc20_events_task.delay(
+                        from_block_number, to_block_number=to_block_number
+                    )
 
 
 @app.shared_task(bind=True, soft_time_limit=SOFT_TIMEOUT, time_limit=LOCK_TIMEOUT)
 def reindex_master_copies_task(
-    self, from_block_number: int, to_block_number: int
+    self,
+    from_block_number: int,
+    to_block_number: Optional[int] = None,
+    addresses: Optional[ChecksumAddress] = None,
 ) -> None:
     """
     Reindexes master copies
@@ -331,19 +337,22 @@ def reindex_master_copies_task(
         with only_one_running_task(self):
             index_service = IndexServiceProvider()
             logger.info(
-                "Reindexing master copies from-block=%d to-block=%d",
+                "Reindexing master copies from-block=%d to-block=%s addresses=%s",
                 from_block_number,
                 to_block_number,
+                addresses,
             )
             index_service.reindex_master_copies(
-                from_block_number=from_block_number,
-                to_block_number=to_block_number,
+                from_block_number, to_block_number=to_block_number, addresses=addresses
             )
 
 
 @app.shared_task(bind=True, soft_time_limit=SOFT_TIMEOUT, time_limit=LOCK_TIMEOUT)
 def reindex_erc20_events_task(
-    self, from_block_number: int, to_block_number: int
+    self,
+    from_block_number: int,
+    to_block_number: Optional[int] = None,
+    addresses: Optional[ChecksumAddress] = None,
 ) -> None:
     """
     Reindexes master copies
@@ -352,13 +361,13 @@ def reindex_erc20_events_task(
         with only_one_running_task(self):
             index_service = IndexServiceProvider()
             logger.info(
-                "Reindexing erc20/721 events from-block=%d to-block=%d",
+                "Reindexing erc20/721 events from-block=%d to-block=%s addresses=%s",
                 from_block_number,
                 to_block_number,
+                addresses,
             )
             index_service.reindex_erc20_events(
-                from_block_number=from_block_number,
-                to_block_number=to_block_number,
+                from_block_number, to_block_number=to_block_number, addresses=addresses
             )
 
 
@@ -421,8 +430,12 @@ def process_decoded_internal_txs_for_safe_task(
                                     block_number,
                                     to_block_number,
                                 )
+                                # Setting the safe address reindexing should be very fast
                                 reindex_master_copies_task.delay(
-                                    block_number, to_block_number
+                                    block_number,
+                                    # Reindex until current block
+                                    #  to_block_number=to_block_number,
+                                    addresses=[safe_address],
                                 )
                             logger.info(
                                 "Safe-address=%s Processing traces again after reindexing",

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -104,8 +104,9 @@ class TestTasks(TestCase):
 
         reindex_mastercopies_last_hours_task()
         reindex_master_copies_mock.assert_called_once_with(
-            from_block_number=ethereum_block_1.number,
+            ethereum_block_1.number,
             to_block_number=ethereum_block_3.number,
+            addresses=None,
         )
 
     @patch.object(IndexService, "reindex_erc20_events")
@@ -127,8 +128,9 @@ class TestTasks(TestCase):
 
         reindex_erc20_erc721_last_hours_task()
         reindex_erc20_events.assert_called_once_with(
-            from_block_number=ethereum_block_1.number,
+            ethereum_block_1.number,
             to_block_number=ethereum_block_3.number,
+            addresses=None,
         )
 
     @patch.object(EthereumClient, "get_network", return_value=EthereumNetwork.GANACHE)
@@ -211,8 +213,10 @@ class TestTasks(TestCase):
                     process_decoded_internal_txs_for_safe_task.delay(safe_address)
                     reprocess_mock.assert_called_with([safe_address])
                     reindex_mock.assert_called_with(
-                        from_block_number=safe_status_0.block_number,
-                        to_block_number=safe_status_5.block_number,
+                        safe_status_0.block_number,
+                        # to_block_number=safe_status_5.block_number,
+                        to_block_number=None,
+                        addresses=[safe_address],
                     )
                     self.assertIn(
                         f"Safe-address={safe_address} A problem was found in SafeStatus "
@@ -231,7 +235,7 @@ class TestTasks(TestCase):
                     )
                     self.assertIn(
                         f"Reindexing master copies from-block={safe_status_0.internal_tx.ethereum_tx.block_id} "
-                        f"to-block={safe_status_5.block_number}",
+                        f"to-block=None addresses={[safe_address]}",
                         cm.output[4],
                     )
                     self.assertIn(


### PR DESCRIPTION
- It was disabled due to it taking a lot of resources
- When setting one Safe address to reindex instead of a lot reindexing is really fast
