### PR TITLE
Fix reorg strategy

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -454,7 +454,7 @@ ETH_EVENTS_UPDATED_BLOCK_BEHIND = env.int(
     "ETH_EVENTS_UPDATED_BLOCK_BEHIND", default=24 * 60 * 60 // 15
 )  # Number of blocks to consider an address 'almost updated'.
 ETH_REORG_BLOCKS = env.int(
-    "ETH_REORG_BLOCKS", default=150 if ETH_L2_NETWORK else 10
+    "ETH_REORG_BLOCKS", default=200 if ETH_L2_NETWORK else 10
 )  # Number of blocks from the current block number needed to consider a block valid/stable
 
 # Tokens

--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -230,6 +230,16 @@ class Erc20EventsIndexer(EventsIndexer):
     def update_monitored_address(
         self, addresses: Sequence[str], from_block_number: int, to_block_number: int
     ) -> int:
-        return int(
-            IndexingStatus.objects.set_erc20_721_indexing_status(to_block_number + 1)
+        # Keep indexing going on the next block
+        new_to_block_number = to_block_number + 1
+        result = IndexingStatus.objects.set_erc20_721_indexing_status(
+            new_to_block_number, from_block_number=from_block_number
         )
+        if not result:
+            logger.warning(
+                "%s: Possible reorg - Cannot update erc20_721 indexing status from-block-number=%d to-block-number=%d",
+                self.__class__.__name__,
+                from_block_number,
+                to_block_number,
+            )
+        return int(result)

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -278,8 +278,7 @@ class EthereumIndexer(ABC):
             **{
                 "address__in": addresses,
                 self.database_field
-                + "__gte": from_block_number
-                - 1,  # Protect in case of reorg
+                + "__gte": from_block_number,  # Protect in case of reorg
                 self.database_field
                 + "__lt": new_to_block_number,  # Don't update to a lower block number
             }

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -166,12 +166,20 @@ class IndexingStatusManager(models.Manager):
     def get_erc20_721_indexing_status(self) -> "IndexingStatus":
         return self.get(indexing_type=IndexingStatusType.ERC20_721_EVENTS.value)
 
-    def set_erc20_721_indexing_status(self, block_number: int) -> bool:
-        return bool(
-            self.filter(indexing_type=IndexingStatusType.ERC20_721_EVENTS.value).update(
-                block_number=block_number
-            )
-        )
+    def set_erc20_721_indexing_status(
+        self, block_number: int, from_block_number: Optional[int] = None
+    ) -> bool:
+        """
+
+        :param block_number:
+        :param from_block_number: If provided, only update the field if bigger than `from_block_number`, to protect
+                                  from reorgs
+        :return:
+        """
+        queryset = self.filter(indexing_type=IndexingStatusType.ERC20_721_EVENTS.value)
+        if from_block_number is not None:
+            queryset = queryset.filter(block_number__gte=from_block_number)
+        return bool(queryset.update(block_number=block_number))
 
 
 class IndexingStatus(models.Model):

--- a/safe_transaction_service/history/services/reorg_service.py
+++ b/safe_transaction_service/history/services/reorg_service.py
@@ -40,7 +40,7 @@ class ReorgService:
         self,
         ethereum_client: EthereumClient,
         eth_reorg_blocks: int,
-        eth_reorg_rewind_blocks: Optional[int] = 250,
+        eth_reorg_rewind_blocks: Optional[int] = 10,
     ):
         """
         :param ethereum_client:
@@ -83,6 +83,7 @@ class ReorgService:
             EthereumBlock.objects.not_confirmed(to_block_number=to_block)
             .only("number", "block_hash", "confirmed")
             .order_by("number")
+            .iterator()
         ):
             blockchain_block, blockchain_next_block = self.ethereum_client.get_blocks(
                 [database_block.number, database_block.number + 1],
@@ -93,8 +94,19 @@ class ReorgService:
                 == HexBytes(blockchain_next_block["parentHash"])
                 == HexBytes(database_block.block_hash)
             ):
+                logger.debug(
+                    "Block with number=%d and hash=%s is matching blockchain one, setting as confirmed",
+                    database_block.number,
+                    HexBytes(blockchain_block["hash"]).hex(),
+                )
                 database_block.set_confirmed()
             else:
+                logger.warning(
+                    "Block with number=%d and hash=%s is not matching blockchain hash=%s, reorg found",
+                    database_block.number,
+                    HexBytes(database_block.block_hash).hex(),
+                    HexBytes(blockchain_block["hash"]).hex(),
+                )
                 return database_block.number
 
     @transaction.atomic
@@ -129,10 +141,14 @@ class ReorgService:
         )
 
         updated = self.reset_all_to_block(safe_reorg_block_number)
-        EthereumBlock.objects.filter(number__gte=reorg_block_number).delete()
+        number_deleted_blocks, _ = EthereumBlock.objects.filter(
+            number__gte=reorg_block_number
+        ).delete()
         logger.warning(
-            "Reorg of block-number=%d fixed, %d elements updated",
+            "Reorg of block-number=%d fixed, indexing was reset to safe block=%d, %d elements updated and %d blocks deleted",
             reorg_block_number,
+            safe_reorg_block_number,
             updated,
+            number_deleted_blocks,
         )
         return updated

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -152,6 +152,35 @@ class TestIndexingStatus(TestCase):
             # IndexingStatus should be inserted with a migration and `indexing_type` is unique
             IndexingStatusFactory(indexing_type=0)
 
+    def test_set_erc20_721_indexing_status(self):
+        self.assertTrue(IndexingStatus.objects.set_erc20_721_indexing_status(5))
+        self.assertEqual(
+            IndexingStatus.objects.get_erc20_721_indexing_status().block_number, 5
+        )
+
+        self.assertTrue(IndexingStatus.objects.set_erc20_721_indexing_status(2))
+        self.assertEqual(
+            IndexingStatus.objects.get_erc20_721_indexing_status().block_number, 2
+        )
+
+        self.assertTrue(
+            IndexingStatus.objects.set_erc20_721_indexing_status(
+                10, from_block_number=2
+            )
+        )
+        self.assertEqual(
+            IndexingStatus.objects.get_erc20_721_indexing_status().block_number, 10
+        )
+
+        self.assertFalse(
+            IndexingStatus.objects.set_erc20_721_indexing_status(
+                20, from_block_number=11
+            )
+        )
+        self.assertEqual(
+            IndexingStatus.objects.get_erc20_721_indexing_status().block_number, 10
+        )
+
 
 class TestMultisigTransaction(TestCase):
     def test_data_should_be_decoded(self):


### PR DESCRIPTION
- I don't know why service was resetting to `250 blocks` before the reorg when finding a reorg. That's a lot and I guess is a typo. It was reduced to 10. Even leaving it to 0 should be alright.
- Erc20/721 indexing has no protection for reorgs. If a reorg happened it will keep indexing as it nothing happened, not reindexing the reorged blocks. Now if database block was reduced indexed status will not updated.
- Increase ETH_REORG_BLOCKS to 200 for every chain but mainnet. Looks like a safe assumption for all networks
- Add more logging to `ReorgService`
