### PR TITLE
Bump safe-eth-py to 5.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ psycogreen==1.0.2
 psycopg2==2.9.6
 redis==4.5.5
 requests==2.31.0
-safe-eth-py[django]==5.5.0
+safe-eth-py[django]==5.6.0
 web3==6.5.0


### PR DESCRIPTION
Update safe-eth-py to 5.6.0 https://github.com/safe-global/safe-eth-py/releases/tag/v5.6.0
