### PR TITLE
Revert "Bump celery from 5.2.7 to 5.3.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.26.151
 cachetools==5.3.1
-celery==5.3.1
+celery==5.2.7
 django==4.2.3
 django-cache-memoize==0.1.10
 django-celery-beat==2.5.0


### PR DESCRIPTION
Reverts safe-global/safe-transaction-service#1550

# Reasons 
- Several connection issues were found with the last version of celery that didn't happened with 5.2.7.
- The connection issues are unrecoverable until worker restart https://github.com/safe-global/safe-transaction-service/issues/1566 
- Some issues related were opened on celery github https://github.com/celery/celery/issues?q=is%3Aissue+is%3Aopen+rabbit+

Closes #1566 