### PR TITLE
Preload tx decoder when app starts

### DIFF
--- a/safe_transaction_service/contracts/tx_decoder.py
+++ b/safe_transaction_service/contracts/tx_decoder.py
@@ -119,6 +119,14 @@ class MultisendDecoded(TypedDict):
 
 @cache
 def get_db_tx_decoder() -> "DbTxDecoder":
+    """
+    :return: Tx decoder with every ABI in the database loaded and indexed by function opcode
+    .. note::
+        Be careful when calling this function in a concurrent way, as if cache is not generated it will compute
+        the ``DbTxDecoder`` multiple times, and depending on the number of Contracts in the database it could
+        take a lot.
+    """
+
     def _get_db_tx_decoder() -> "DbTxDecoder":
         return DbTxDecoder()
 

--- a/safe_transaction_service/history/apps.py
+++ b/safe_transaction_service/history/apps.py
@@ -1,3 +1,5 @@
+import sys
+
 from django.apps import AppConfig
 
 
@@ -7,3 +9,14 @@ class HistoryConfig(AppConfig):
 
     def ready(self):
         from . import signals  # noqa
+
+        for argument in sys.argv:
+            if "gunicorn" in argument:  # pragma: no cover
+                # Just run this on production
+                # TODO Find a better way
+                from safe_transaction_service.contracts.tx_decoder import (
+                    get_db_tx_decoder,
+                )
+
+                get_db_tx_decoder()  # Build tx decoder cache
+                break

--- a/safe_transaction_service/utils/redis.py
+++ b/safe_transaction_service/utils/redis.py
@@ -1,10 +1,14 @@
+import logging
 from functools import cache
 
 from django.conf import settings
 
 from redis import Redis
 
+logger = logging.getLogger(__name__)
+
 
 @cache
 def get_redis() -> Redis:
+    logger.info("Opening connection to Redis")
     return Redis.from_url(settings.REDIS_URL)

--- a/safe_transaction_service/utils/utils.py
+++ b/safe_transaction_service/utils/utils.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable, List, Union
 from django.core.signals import request_finished
 from django.db import connection
 
-from gevent.monkey import saved
+import gevent.monkey
 
 
 class FixedSizeDict(dict):
@@ -53,7 +53,7 @@ def chunks_iterable(iterable: Iterable[Any], n: int) -> Iterable[Iterable[Any]]:
 
 
 def running_on_gevent() -> bool:
-    return "sys" in saved
+    return "sys" in gevent.monkey.saved
 
 
 def close_gevent_db_connection() -> None:


### PR DESCRIPTION

- Tx decoder could take a few minutes to be loaded
- Before it was done by the first query that reached the tx service
- If there were multiple concurrent queries, tx service will be doing the computation multiple times, even if just one will be used for the cache
- Add logging to `get_redis` to find out if the same could be happening
