### PR TITLE
Refactor all-transactions endpoint

### DIFF
--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -235,12 +235,28 @@ class AllTransactionsListView(ListAPIView):
         transaction_service = TransactionServiceProvider()
         safe = self.kwargs["address"]
         executed, queued, trusted = self.get_parameters()
+        logger.debug(
+            "%s: Getting all tx identifiers for Safe=%s executed=%s queued=%s trusted=%s",
+            self.__class__.__name__,
+            safe,
+            executed,
+            queued,
+            trusted,
+        )
         queryset = self.filter_queryset(
             transaction_service.get_all_tx_identifiers(
                 safe, executed=executed, queued=queued, trusted=trusted
             )
         )
         page = self.paginate_queryset(queryset)
+        logger.debug(
+            "%s: Got all tx identifiers for Safe=%s executed=%s queued=%s trusted=%s",
+            self.__class__.__name__,
+            safe,
+            executed,
+            queued,
+            trusted,
+        )
 
         if not page:
             return self.get_paginated_response([])
@@ -251,7 +267,23 @@ class AllTransactionsListView(ListAPIView):
         all_txs = transaction_service.get_all_txs_from_identifiers(
             safe, all_tx_identifiers
         )
+        logger.debug(
+            "%s: Got all txs from identifiers for Safe=%s executed=%s queued=%s trusted=%s",
+            self.__class__.__name__,
+            safe,
+            executed,
+            queued,
+            trusted,
+        )
         all_txs_serialized = transaction_service.serialize_all_txs(all_txs)
+        logger.debug(
+            "%s: All txs from identifiers for Safe=%s executed=%s queued=%s trusted=%s were serialized",
+            self.__class__.__name__,
+            safe,
+            executed,
+            queued,
+            trusted,
+        )
         return self.get_paginated_response(all_txs_serialized)
 
     @swagger_auto_schema(

--- a/safe_transaction_service/utils/tasks.py
+++ b/safe_transaction_service/utils/tasks.py
@@ -57,7 +57,7 @@ def only_one_running_task(
     task: CeleryTask,
     lock_name_suffix: Optional[str] = None,
     lock_timeout: Optional[int] = LOCK_TIMEOUT,
-    gevent: bool = True,
+    gevent_enabled: bool = True,
 ):
     """
     Ensures one running task at the same, using `task` name as a unique key
@@ -67,7 +67,7 @@ def only_one_running_task(
     when it has different arguments
     :param lock_timeout: How long the lock will be stored, in case worker is halted so key is not stored forever
     in Redis
-    :param gevent: If `True`, `close_gevent_db_connection` will be called at the end
+    :param gevent_enabled: If `True`, `close_gevent_db_connection` will be called at the end
     :return: Instance of redis `Lock`
     :raises: LockError if lock cannot be acquired
     """
@@ -83,6 +83,6 @@ def only_one_running_task(
             yield lock
             ACTIVE_LOCKS.remove(lock_name)
         finally:
-            if gevent:
+            if gevent_enabled:
                 # Needed for django-db-geventpool
                 close_gevent_db_connection()


### PR DESCRIPTION
- Remove distinct from `ModuleTransaction`, as every `ModuleTransaction` is showed separated even if they share the same `ethereum txHash`
- Clean transaction_service, adding comments, renaming variables and refactoring typing
- Add logging to service and view
- Rename gevent variable for task locks (not very descriptive)
