### PR TITLE
Add default celery configurations

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -212,8 +212,18 @@ INSTALLED_APPS += [
 CELERY_BROKER_URL = env("CELERY_BROKER_URL", default="django://")
 # https://docs.celeryproject.org/en/stable/userguide/optimizing.html#broker-connection-pools
 # https://docs.celeryq.dev/en/latest/userguide/optimizing.html#broker-connection-pools
-CELERY_BROKER_POOL_LIMIT = env(
-    "CELERY_BROKER_POOL_LIMIT", default=env("CELERYD_CONCURRENCY", default=1000)
+# Configured to 0 due to connection issues https://github.com/celery/celery/issues/4355
+CELERY_BROKER_POOL_LIMIT = env.int("CELERY_BROKER_POOL_LIMIT", default=0)
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-heartbeat
+CELERY_BROKER_HEARTBEAT = env.int("CELERY_BROKER_HEARTBEAT", default=0)
+
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-broker_connection_max_retries
+CELERY_BROKER_CONNECTION_MAX_RETRIES = env.int(
+    "CELERY_BROKER_CONNECTION_MAX_RETRIES", default=0
+)
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-channel-error-retry
+CELERY_BROKER_CHANNEL_ERROR_RETRY = env.bool(
+    "CELERY_BROKER_CHANNEL_ERROR_RETRY", default=True
 )
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend
 CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND", default="redis://")
@@ -234,6 +244,7 @@ CELERY_TASK_DEFAULT_PRIORITY = 5
 CELERY_TASK_QUEUE_MAX_PRIORITY = 10
 # https://docs.celeryproject.org/en/latest/userguide/configuration.html#broker-transport-options
 CELERY_BROKER_TRANSPORT_OPTIONS = {}
+
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_routes
 CELERY_ROUTES = (
     [

--- a/docker/web/celery/scheduler/run.sh
+++ b/docker/web/celery/scheduler/run.sh
@@ -13,4 +13,6 @@ fi
 sleep 10
 
 echo "==> $(date +%H:%M:%S) ==> Running Celery beat <=="
-exec celery -C -A config.celery_app beat -S django_celery_beat.schedulers:DatabaseScheduler --loglevel $log_level
+exec celery -C -A config.celery_app beat \
+     -S django_celery_beat.schedulers:DatabaseScheduler \
+     --loglevel $log_level

--- a/docker/web/celery/worker/run.sh
+++ b/docker/web/celery/worker/run.sh
@@ -33,4 +33,5 @@ exec celery -C -A config.celery_app worker \
      --concurrency=${TASK_CONCURRENCY} \
      --max-memory-per-child=${MAX_MEMORY_PER_CHILD} \
      --max-tasks-per-child=${MAX_TASKS_PER_CHILD} \
-     -Q "$WORKER_QUEUES"
+     --without-heartbeat --without-gossip \
+     --without-mingle -Q "$WORKER_QUEUES"


### PR DESCRIPTION
# Description 
Several issues are appearing on `rabbitMq` connections, ("connection reset by peer", "missing heartbeat"...) 
One possible reason could be due the high number of messages that celery are sending to keep the heartbeat, mingle and gossip. 
The following links explains a little bit more about it:
https://www.cloudamqp.com/docs/celery.html#commandline-arguments  
https://github.com/celery/celery/issues/4980

Also we change some default parameter that can be related: 
- pool connection to 0  https://github.com/celery/celery/issues/4355
- connection max retries to 0 (unlimited re-connection retries) 
- broker channel error to True, that enable retries when there is an issue with the channel connection. 

# Issues related
#1566 
