### PR TITLE
Add address to filter condition

### DIFF
--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -1306,7 +1306,10 @@ class MultisigTransactionQuerySet(models.QuerySet):
         :return: queryset with `confirmations_required: int` field
         """
         threshold_safe_status_query = (
-            SafeStatus.objects.filter(internal_tx__ethereum_tx=OuterRef("ethereum_tx"))
+            SafeStatus.objects.filter(
+                address=OuterRef("safe"),
+                internal_tx__ethereum_tx=OuterRef("ethereum_tx"),
+            )
             .sorted_reverse_by_mined()
             .values("threshold")
         )

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -1391,7 +1391,9 @@ class TestMultisigTransactions(TestCase):
         )
 
         # SafeStatus not matching the EthereumTx
-        safe_status = SafeStatusFactory(nonce=1, threshold=8)
+        safe_status = SafeStatusFactory(
+            address=multisig_transaction.safe, nonce=1, threshold=8
+        )
         self.assertIsNone(
             MultisigTransaction.objects.with_confirmations_required()
             .first()


### PR DESCRIPTION
# What changes? 
`address`  field in `safeStatus` table is an index, adding this field to condition is reducing heavily the cost of the resultant query. 
The old query explain was as follows:
        
```
Gather Merge  (cost=1094612.73..1095395.38 rows=6708 width=46)
  Workers Planned: 2
  ->  Sort  (cost=1093612.70..1093621.09 rows=3354 width=46)
        Sort Key: history_safestatus.address, history_safestatus.nonce DESC, history_internaltx.block_number DESC, history_ethereumtx.transaction_index DESC, history_safestatus.internal_tx_id DESC
        ->  Hash Join  (cost=1019129.86..1093416.30 rows=3354 width=46)
              Hash Cond: (history_safestatus.internal_tx_id = history_internaltx.id)
              ->  Parallel Seq Scan on history_safestatus  (cost=0.00..59969.29 rows=670829 width=38)
              ->  Hash  (cost=1014551.76..1014551.76 rows=263368 width=16)
                    ->  Nested Loop  (cost=1.12..1014551.76 rows=263368 width=16)
                          ->  Index Scan using history_ethereumtx_pkey on history_ethereumtx  (cost=0.56..8.58 rows=1 width=37)
                                Index Cond: (tx_hash = 'any_tx_hash'::bytea)
                          ->  Index Scan using history_internaltx_ethereum_tx_id_e6ac35ab on history_internaltx  (cost=0.56..1011909.51 rows=263368 width=44)
                                Index Cond: (ethereum_tx_id = 'any_tx_hash'::bytea)
```
The first action that was planned was scan all the table to find the transaction hash that is not a field on `SafeStatus`.
`SafeStatus` table have the `address` field defined as index, adding this field to filter first is going to improve the execution. 
```
Gather Merge  (cost=23778.85..23779.77 rows=8 width=46)
  Workers Planned: 1
  ->  Sort  (cost=22778.84..22778.86 rows=8 width=46)
        Sort Key: history_safestatus.nonce DESC, history_internaltx.block_number DESC, history_ethereumtx.transaction_index DESC, history_safestatus.internal_tx_id DESC
        ->  Nested Loop  (cost=46.76..22778.72 rows=8 width=46)
              ->  Nested Loop  (cost=46.20..22710.02 rows=8 width=74)
                    ->  Parallel Bitmap Heap Scan on history_safestatus  (cost=45.64..8949.35 rows=1610 width=38)
                          Recheck Cond: (address = 'any_address'::bytea)
                          ->  Bitmap Index Scan on history_safestatus_address_68cd154d  (cost=0.00..44.95 rows=2737 width=0)
                                Index Cond: (address = 'any_address'::bytea)
                    ->  Index Scan using history_internaltx_pkey on history_internaltx  (cost=0.56..8.55 rows=1 width=44)
                          Index Cond: (id = history_safestatus.internal_tx_id)
                          Filter: (ethereum_tx_id = '\\any_tx_hash'::bytea)
              ->  Index Scan using history_ethereumtx_pkey on history_ethereumtx  (cost=0.56..8.58 rows=1 width=37)
                    Index Cond: (tx_hash = '\\any_tx_hash'::bytea)
```
In the last explain we can see that the cost was reduced and the first action is to search by the address index, reducing the number of rows to search later by transaction hash.


