### PR TITLE
Optimize reorg handling

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -475,6 +475,9 @@ ETH_EVENTS_QUERY_CHUNK_SIZE = env.int(
 ETH_EVENTS_UPDATED_BLOCK_BEHIND = env.int(
     "ETH_EVENTS_UPDATED_BLOCK_BEHIND", default=24 * 60 * 60 // 15
 )  # Number of blocks to consider an address 'almost updated'.
+ETH_REORG_BLOCKS_BATCH = env.int(
+    "ETH_REORG_BLOCKS_BATCH", default=250
+)  # Number of blocks to be checked in the same batch for reorgs
 ETH_REORG_BLOCKS = env.int(
     "ETH_REORG_BLOCKS", default=200 if ETH_L2_NETWORK else 10
 )  # Number of blocks from the current block number needed to consider a block valid/stable

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -272,15 +272,19 @@ class EthereumBlockQuerySet(models.QuerySet):
             timestamp__lte=timezone.now() - datetime.timedelta(seconds=seconds)
         ).order_by("-timestamp")
 
-    def not_confirmed(self, to_block_number: Optional[int] = None):
+    def not_confirmed(self):
         """
         :param to_block_number:
         :return: Block not confirmed until ``to_block_number``, if provided
         """
         queryset = self.filter(confirmed=False)
-        if to_block_number is not None:
-            queryset = queryset.filter(number__lte=to_block_number)
         return queryset
+
+    def since_block(self, block_number: int):
+        return self.filter(number__gte=block_number)
+
+    def until_block(self, block_number: int):
+        return self.filter(number__lte=block_number)
 
 
 class EthereumBlock(models.Model):


### PR DESCRIPTION
- Until now, reorg handling was only checking "safe" blocks (with the required number of confirmations). That made the service really slow reacting to reorgs
- With this PR, all `not confirmed` blocks are checked, but only marking as confirmed the ones with the required number of confirmations
- `Previous block hash` check was removed, as it should be enough by checking the current returned block by the node
- Pagination is used to prevent having a lot of blocks of memory in the case of a service that went out of sync
- Pagination parameter was fixed to 250 by default as it's half of the value we use to index txs/blocks (using new configuration variable `ETH_REORG_BLOCKS_BATCH`)
- Closes #1554
