### PR TITLE
Refactor gunicorn configuration

### DIFF
--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -1,0 +1,8 @@
+"""
+Store gunicorn variables in this file, so they can be read by Django
+"""
+import os
+
+gunicorn_request_timeout = os.environ.get("WEB_WORKER_TIMEOUT", 60)
+gunicorn_worker_connections = os.environ.get("WEB_WORKER_CONNECTIONS", 1000)
+gunicorn_workers = os.environ.get("WEB_CONCURRENCY", 2)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -7,6 +7,12 @@ from pathlib import Path
 import environ
 from corsheaders.defaults import default_headers as default_cors_headers
 
+from ..gunicorn import (
+    gunicorn_request_timeout,
+    gunicorn_worker_connections,
+    gunicorn_workers,
+)
+
 ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 APPS_DIR = ROOT_DIR / "safe_transaction_service"
 
@@ -46,6 +52,11 @@ SSO_ENABLED = False
 
 # Enable analytics endpoints
 ENABLE_ANALYTICS = env("ENABLE_ANALYTICS", default=False)
+
+# GUNICORN
+GUNICORN_REQUEST_TIMEOUT = gunicorn_request_timeout
+GUNICORN_WORKER_CONNECTIONS = gunicorn_worker_connections
+GUNICORN_WORKERS = gunicorn_workers
 
 # DATABASES
 # ------------------------------------------------------------------------------

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,4 +1,8 @@
-import os
+from config.gunicorn import (
+    gunicorn_request_timeout,
+    gunicorn_worker_connections,
+    gunicorn_workers,
+)
 
 access_logfile = "-"
 error_logfile = "-"
@@ -13,19 +17,8 @@ log_level = "info"
 logger_class = "safe_transaction_service.utils.loggers.CustomGunicornLogger"
 preload_app = False  # Load application code before the worker processes are forked (problems with gevent patching)
 # For timeout to work with gevent, a custom GeventWorker needs to be used
-timeout = os.environ.get("WEB_WORKER_TIMEOUT", 60)
+timeout = gunicorn_request_timeout
 
 worker_class = "gunicorn_custom_workers.MyGeventWorker"  # "gevent"
-worker_connections = os.environ.get("WEB_WORKER_CONNECTIONS", 1000)
-workers = os.environ.get("WEB_CONCURRENCY", 2)
-
-
-def post_fork(server, worker):
-    try:
-        from psycogreen.gevent import patch_psycopg
-
-        worker.log.info("Making Psycopg2 Green")
-        patch_psycopg()
-        worker.log.info("Made Psycopg2 Green")
-    except ImportError:
-        worker.log.info("Psycopg2 not patched")
+worker_connections = gunicorn_worker_connections
+workers = gunicorn_workers

--- a/gunicorn_custom_workers.py
+++ b/gunicorn_custom_workers.py
@@ -1,8 +1,18 @@
 import gevent
 from gunicorn.workers.ggevent import GeventWorker
+from psycogreen.gevent import patch_psycopg
 
 
 class MyGeventWorker(GeventWorker):
+    def patch_psycopg2(self):
+        patch_psycopg()
+        self.log.info("Patched Psycopg2 for gevent")
+
+    def patch(self):
+        super().patch()
+        self.log.info("Patched all for gevent")
+        self.patch_psycopg2()
+
     def handle_request(self, listener_name, req, sock, addr):
         try:
             with gevent.Timeout(self.cfg.timeout):

--- a/safe_transaction_service/utils/utils.py
+++ b/safe_transaction_service/utils/utils.py
@@ -1,3 +1,4 @@
+import socket
 from functools import wraps
 from itertools import islice
 from typing import Any, Iterable, List, Union
@@ -5,7 +6,7 @@ from typing import Any, Iterable, List, Union
 from django.core.signals import request_finished
 from django.db import connection
 
-import gevent.monkey
+import gevent.socket
 
 
 class FixedSizeDict(dict):
@@ -53,7 +54,7 @@ def chunks_iterable(iterable: Iterable[Any], n: int) -> Iterable[Iterable[Any]]:
 
 
 def running_on_gevent() -> bool:
-    return "sys" in gevent.monkey.saved
+    return socket.socket is gevent.socket.socket
 
 
 def close_gevent_db_connection() -> None:


### PR DESCRIPTION
- Store some gunicorn configuration in `/config`, so it can be used by Django
- Make sure psycopg is patched after the rest, and refactor it to the gunicorn worker
- Fix `running_on_gevent`, checking `socket` should be more accurate