### PR TITLE
Bump safe-eth-py to v5.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ psycogreen==1.0.2
 psycopg2==2.9.7
 redis==4.6.0
 requests==2.31.0
-safe-eth-py[django]==5.6.0
+safe-eth-py[django]==5.7.0
 web3==6.8.0


### PR DESCRIPTION
Update safe-eth-version to v5.7.0 https://github.com/safe-global/safe-eth-py/releases/tag/v5.7.0
Most important change, gas increment for safe creation was removed. 
