### PR TITLE
Catch ValueError for RPC Indexer errors

### DIFF
--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -399,6 +399,7 @@ class EthereumIndexer(ABC):
             FindRelevantElementsException,
             SoftTimeLimitExceeded,
             Timeout,
+            ValueError,
         ) as e:
             self.block_process_limit = 1  # Set back to the very minimum
             logger.info(


### PR DESCRIPTION
### What was wrong? 👾
Some RPC node return 200 ok result and some random messages indicating an issue like for example "Block range too wide" that should indicate us that the block_process_limit configured have higher values than the RPC node accepts. 
To avoid stuck the indexer in this cases, a strategy could be reduce the indexer `block_process_limit` to one if this error happens. 
This PR add `ValueError` exception to  catch and reduce the block_process_limit to 1 as is done with other exceptions.

