### PR TITLE
Fix get_token_eth_price_from_oracles

### DIFF
--- a/safe_transaction_service/tokens/services/price_service.py
+++ b/safe_transaction_service/tokens/services/price_service.py
@@ -350,7 +350,7 @@ class PriceService:
     def get_token_usd_price(self, token_address: ChecksumAddress) -> float:
         """
         :param token_address:
-        :return: usd value for a given `token_address` using Curve, if not use Coingecko as last resource
+        :return: usd value for a given `token_address` using Coingecko
         """
         if self.coingecko_client.supports_network(self.ethereum_network):
             try:
@@ -449,7 +449,8 @@ class PriceService:
         """
         return (
             self.get_token_eth_value(token_address)
-            or self.get_token_usd_price(token_address) / self.get_ether_usd_price()
+            or self.get_token_usd_price(token_address)
+            / self.get_native_coin_usd_price()
         )
 
     def get_token_eth_price_from_composed_oracles(

--- a/safe_transaction_service/tokens/tests/test_price_service.py
+++ b/safe_transaction_service/tokens/tests/test_price_service.py
@@ -274,3 +274,22 @@ class TestPriceService(TestCase):
         curve_price = "0xe7ce624c00381b4b7abb03e633fb4acac4537dd6"
         eth_price = price_service.get_token_eth_price_from_composed_oracles(curve_price)
         self.assertEqual(eth_price, 1.0)
+
+    def test_get_token_eth_price_from_oracles(self):
+        mainnet_node = just_test_if_mainnet_node()
+        price_service = PriceService(EthereumClient(mainnet_node), self.redis)
+        gno_token_address = "0x6810e776880C02933D47DB1b9fc05908e5386b96"
+        token_eth_value = price_service.get_token_eth_price_from_oracles(
+            gno_token_address
+        )
+        self.assertIsInstance(token_eth_value, float)
+        self.assertGreater(token_eth_value, 0)
+        with mock.patch.object(
+            PriceService, "get_token_eth_value", autospec=True, return_value=0
+        ):
+            token_eth_value_from_coingecko = (
+                price_service.get_token_eth_price_from_oracles(gno_token_address)
+            )
+            self.assertAlmostEqual(
+                token_eth_value, token_eth_value_from_coingecko, delta=0.1
+            )


### PR DESCRIPTION
### What was wrong? 👾
`get_token_eth_price_from_oracles` was returning ether value instead native token value when the price was returned from coingecko instead from oracles. 

Closes #1552 

 