### PR TITLE
Remove all-transaction sorting options except execution_date

### DIFF
--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -181,7 +181,9 @@ class AllTransactionsListView(ListAPIView):
         OrderingFilter,
     )
     ordering_fields = ["execution_date"]
-    allowed_ordering_fields = ["execution_date", "-execution_date"]
+    allowed_ordering_fields = ordering_fields + [
+        f"-{ordering_field}" for ordering_field in ordering_fields
+    ]
     pagination_class = pagination.SmallPagination
     serializer_class = (
         serializers.AllTransactionsSchemaSerializer
@@ -435,7 +437,7 @@ class AllTransactionsListView(ListAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
                 data={
                     "code": 1,
-                    "message": "Ordering field is not valid, execution_date is only allowed",
+                    "message": "Ordering field is not valid, only `execution_date` is allowed",
                     "arguments": [ordering],
                 },
             )

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -180,7 +180,8 @@ class AllTransactionsListView(ListAPIView):
         django_filters.rest_framework.DjangoFilterBackend,
         OrderingFilter,
     )
-    ordering_fields = ["execution_date", "safe_nonce", "block", "created"]
+    ordering_fields = ["execution_date"]
+    allowed_ordering_fields = ["execution_date", "-execution_date"]
     pagination_class = pagination.SmallPagination
     serializer_class = (
         serializers.AllTransactionsSchemaSerializer
@@ -416,7 +417,7 @@ class AllTransactionsListView(ListAPIView):
         by a delegate). If you need that behaviour to be disabled set the query parameter `trusted=False`
         - Module Transactions for a Safe. `tx_type=MODULE_TRANSACTION`
         - Incoming Transfers of Ether/ERC20 Tokens/ERC721 Tokens. `tx_type=ETHEREUM_TRANSACTION`
-        Ordering_fields: ["execution_date", "safe_nonce", "block", "created"] eg: `created` or `-created`
+        Ordering_fields: ["execution_date"] eg: `execution_date` or `-execution_date`
         """
         address = kwargs["address"]
         if not fast_is_checksum_address(address):
@@ -426,6 +427,16 @@ class AllTransactionsListView(ListAPIView):
                     "code": 1,
                     "message": "Checksum address validation failed",
                     "arguments": [address],
+                },
+            )
+        ordering = self.get_ordering_parameter()
+        if ordering and ordering not in self.allowed_ordering_fields:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "code": 1,
+                    "message": "Ordering field is not valid, execution_date is only allowed",
+                    "arguments": [ordering],
                 },
             )
 


### PR DESCRIPTION
Closes #1614 
- Remove all sorting options except `execution_date`
- Check if correct sorting option was chosen 
- Add ordering test
- Add get all transactions view test

