### PR TITLE
Add signal to trigger message webhook

### DIFF
--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -2001,6 +2001,8 @@ class WebHookType(Enum):
     MODULE_TRANSACTION = 7
     OUTGOING_ETHER = 8
     OUTGOING_TOKEN = 9
+    MESSAGE_CREATED = 10
+    MESSAGE_CONFIRMATION = 11
 
 
 class WebHookQuerySet(models.QuerySet):

--- a/safe_transaction_service/history/services/webhooks.py
+++ b/safe_transaction_service/history/services/webhooks.py
@@ -18,6 +18,10 @@ from safe_transaction_service.history.models import (
     TokenTransfer,
     WebHookType,
 )
+from safe_transaction_service.safe_messages.models import (
+    SafeMessage,
+    SafeMessageConfirmation,
+)
 from safe_transaction_service.utils.ethereum import get_chain_id
 
 
@@ -102,6 +106,22 @@ def build_webhook_payload(
                 "type": WebHookType.MODULE_TRANSACTION.name,
                 "module": instance.module,
                 "txHash": HexBytes(instance.internal_tx.ethereum_tx_id).hex(),
+            }
+        ]
+    elif sender == SafeMessage:
+        payloads = [
+            {
+                "address": instance.safe,
+                "type": WebHookType.MESSAGE_CREATED.name,
+                "messageHash": instance.message_hash,
+            }
+        ]
+    elif sender == SafeMessageConfirmation:
+        payloads = [
+            {
+                "address": instance.safe_message.safe,  # This could make a db call
+                "type": WebHookType.MESSAGE_CONFIRMATION.name,
+                "messageHash": instance.safe_message.message_hash,
             }
         ]
 

--- a/safe_transaction_service/safe_messages/signals.py
+++ b/safe_transaction_service/safe_messages/signals.py
@@ -1,3 +1,55 @@
 import logging
+from typing import Type, Union
+
+from django.db.models import Model
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from safe_transaction_service.events.tasks import send_event_to_queue_task
+from safe_transaction_service.history.services.webhooks import build_webhook_payload
+from safe_transaction_service.history.tasks import send_webhook_task
+from safe_transaction_service.safe_messages.models import (
+    SafeMessage,
+    SafeMessageConfirmation,
+)
 
 logger = logging.getLogger(__name__)
+
+
+@receiver(post_save, sender=SafeMessage, dispatch_uid="safe_message.process_webhook")
+@receiver(
+    post_save,
+    sender=SafeMessageConfirmation,
+    dispatch_uid="safe_message_confirmation.process_webhook",
+)
+def process_webhook(
+    sender: Type[Model],
+    instance: Union[
+        SafeMessage,
+        SafeMessageConfirmation,
+    ],
+    created: bool,
+    **kwargs,
+) -> None:
+    logger.debug("Start building payloads for created=%s object=%s", created, instance)
+    payloads = build_webhook_payload(sender, instance)
+    logger.debug(
+        "End building payloads %s for created=%s object=%s", payloads, created, instance
+    )
+    for payload in payloads:
+        if address := payload.get("address"):
+            logger.debug(
+                "Triggering send_webhook and send_notification tasks for created=%s object=%s",
+                created,
+                instance,
+            )
+            send_webhook_task.apply_async(
+                args=(address, payload), priority=2  # Almost lowest priority
+            )  # Almost the lowest priority
+            send_event_to_queue_task.delay(payload)
+        else:
+            logger.debug(
+                "Notification will not be sent for created=%s object=%s",
+                created,
+                instance,
+            )

--- a/safe_transaction_service/safe_messages/tests/test_signals.py
+++ b/safe_transaction_service/safe_messages/tests/test_signals.py
@@ -1,0 +1,95 @@
+from unittest import mock
+
+from django.db.models.signals import post_save
+from django.test import TestCase
+
+import factory
+
+from gnosis.eth import EthereumNetwork
+from gnosis.safe.tests.safe_test_case import SafeTestCaseMixin
+
+from safe_transaction_service.events.tasks import send_event_to_queue_task
+from safe_transaction_service.history.models import WebHookType
+from safe_transaction_service.history.tasks import send_webhook_task
+from safe_transaction_service.safe_messages.models import (
+    SafeMessage,
+    SafeMessageConfirmation,
+)
+from safe_transaction_service.safe_messages.signals import process_webhook
+from safe_transaction_service.safe_messages.tests.factories import (
+    SafeMessageConfirmationFactory,
+    SafeMessageFactory,
+)
+
+
+class TestSafeMessageSignals(SafeTestCaseMixin, TestCase):
+    @factory.django.mute_signals(post_save)
+    @mock.patch.object(send_webhook_task, "apply_async")
+    @mock.patch.object(send_event_to_queue_task, "delay")
+    def test_process_webhook(
+        self,
+        send_event_to_queue_task_mock,
+        webhook_task_mock,
+    ):
+        safe_address = self.deploy_test_safe().address
+        safe_message = SafeMessageFactory(safe=safe_address)
+        process_webhook(SafeMessage, safe_message, True)
+        message_created_payload = {
+            "address": safe_address,
+            "type": WebHookType.MESSAGE_CREATED.name,
+            "messageHash": safe_message.message_hash,
+            "chainId": str(EthereumNetwork.GANACHE.value),
+        }
+        webhook_task_mock.assert_called_with(
+            args=(safe_address, message_created_payload), priority=2
+        )
+        send_event_to_queue_task_mock.assert_called_with(message_created_payload)
+
+        message_confirmation_payload = {
+            "address": safe_address,
+            "type": WebHookType.MESSAGE_CONFIRMATION.name,
+            "messageHash": safe_message.message_hash,
+            "chainId": str(EthereumNetwork.GANACHE.value),
+        }
+        safe_message_confirmation = SafeMessageConfirmationFactory(
+            safe_message=safe_message
+        )
+        process_webhook(SafeMessageConfirmation, safe_message_confirmation, True)
+        webhook_task_mock.assert_called_with(
+            args=(safe_address, message_confirmation_payload), priority=2
+        )
+        send_event_to_queue_task_mock.assert_called_with(message_confirmation_payload)
+
+    @mock.patch.object(send_webhook_task, "apply_async")
+    @mock.patch.object(send_event_to_queue_task, "delay")
+    def test_signals_are_correctly_fired(
+        self,
+        send_event_to_queue_task_mock,
+        webhook_task_mock,
+    ):
+        safe_address = self.deploy_test_safe().address
+        # Create a confirmation should fire a signal and webhooks should be sended
+        safe_message = SafeMessageFactory(safe=safe_address)
+        message_created_payload = {
+            "address": safe_address,
+            "type": WebHookType.MESSAGE_CREATED.name,
+            "messageHash": safe_message.message_hash,
+            "chainId": str(EthereumNetwork.GANACHE.value),
+        }
+        webhook_task_mock.assert_called_with(
+            args=(safe_address, message_created_payload), priority=2
+        )
+        send_event_to_queue_task_mock.assert_called_with(message_created_payload)
+
+        message_confirmation_payload = {
+            "address": safe_address,
+            "type": WebHookType.MESSAGE_CONFIRMATION.name,
+            "messageHash": safe_message.message_hash,
+            "chainId": str(EthereumNetwork.GANACHE.value),
+        }
+        # Create a confirmation should fire a signal and webhooks should be sended
+        SafeMessageConfirmationFactory(safe_message=safe_message)
+        webhook_task_mock.assert_called_with(
+            args=(safe_address, message_confirmation_payload), priority=2
+        )
+        send_event_to_queue_task_mock.assert_called_with(message_confirmation_payload)


### PR DESCRIPTION
# Description
The goal of this PR is send webhooks when a message is created, updated or confirmed. 
`process_webhook` was included in signals file of `safe_messages` app with some differences of the history signals method: 
- in this case is not necessary check if the notification is still relevant because the safe message have not `created` field.
- don't send notification to firebase. 

Two new types or webhook were included: 
- MESSAGE_CREATED
- MESSAGE_CONFIRMATION  

Also modify `build_webhook_payload`  to include payloads for message creation and confirmation following this specs https://github.com/safe-global/safe-transaction-service/issues/1240#issuecomment-1683585133 


# Issues related
Closes #1240


