### PR TITLE
Messages webhok send bytes instead string

### DIFF
--- a/safe_transaction_service/history/services/webhooks.py
+++ b/safe_transaction_service/history/services/webhooks.py
@@ -113,7 +113,7 @@ def build_webhook_payload(
             {
                 "address": instance.safe,
                 "type": WebHookType.MESSAGE_CREATED.name,
-                "messageHash": instance.message_hash,
+                "messageHash": HexBytes(instance.message_hash).hex(),
             }
         ]
     elif sender == SafeMessageConfirmation:
@@ -121,7 +121,7 @@ def build_webhook_payload(
             {
                 "address": instance.safe_message.safe,  # This could make a db call
                 "type": WebHookType.MESSAGE_CONFIRMATION.name,
-                "messageHash": instance.safe_message.message_hash,
+                "messageHash": HexBytes(instance.safe_message.message_hash).hex(),
             }
         ]
 

--- a/safe_transaction_service/safe_messages/models.py
+++ b/safe_transaction_service/safe_messages/models.py
@@ -33,11 +33,7 @@ class SafeMessage(TimeStampedModel):
         message = message_str[:message_size]
         if len(message_str) > message_size:
             message += "..."
-        message_hash = (
-            self.message_hash.hex()
-            if isinstance(self.message_hash, bytes)
-            else self.message_hash
-        )
+        message_hash = HexBytes(self.message_hash).hex()
         return f"Safe Message {message_hash} - {message}"
 
     def build_signature(self) -> bytes:


### PR DESCRIPTION
### What was wrong? 👾
We shouldn't return message_hash as bytes format, only string format. 
`{'address': '0x0EDc6697427E9e9d62A1eE1A2951AfA7bE9e75B7', 'type': 'MESSAGE_CONFIRMATION', 'messageHash': b'W\xa5W\xd6$12\xbaV\x13\xb4\x15\xe6\x80\xea\x7f\tXN\xe5%L|\xe3\x92Z\x14\\\xc5\xd6\xb9\x1c', 'chainId': '5'}`

### How was it fixed? 🎯
Converting the value from database to a hexadecimal string representation.