### PR TITLE
Fix random issues on events queue tests

### DIFF
--- a/safe_transaction_service/events/tests/test_queue_service.py
+++ b/safe_transaction_service/events/tests/test_queue_service.py
@@ -18,6 +18,8 @@ class TestQueueService(TestCase):
         self.queue_service._channel.queue_bind(
             self.queue, self.queue_service.exchange_name
         )
+        # Clean queue to avoid old messages
+        self.queue_service._channel.queue_purge(self.queue)
 
     def test_send_unsent_messages(self):
         queue_service = QueueServiceProvider()


### PR DESCRIPTION
When `RabbitMQ` keeps running, messages are not removed from the queue, which can cause issues during tests expecting different results.
The issue was fixed cleaning on setup the events queue. 
