### PR TITLE
Set version to v4.27.1

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.27.0"
+__version__ = "4.27.1"
 __version_info__ = tuple(
     int(num) if num.isdigit() else num
     for num in __version__.replace("-", ".", 1).split(".")


### PR DESCRIPTION
Hotfix to include [Disable gas estimation in L2 networks](https://github.com/safe-global/safe-transaction-service/pull/1722) 