### PR TITLE
Fix admin search slow

### DIFF
--- a/safe_transaction_service/contracts/admin.py
+++ b/safe_transaction_service/contracts/admin.py
@@ -1,15 +1,16 @@
 from django.contrib import admin
 
-from gnosis.eth.django.admin import BinarySearchAdmin
-
-from safe_transaction_service.utils.admin import HasLogoFilterAdmin
+from safe_transaction_service.utils.admin import (
+    AdvancedAdminSearchMixin,
+    HasLogoFilterAdmin,
+)
 
 from .models import Contract, ContractAbi
 from .tasks import create_or_update_contract_with_metadata_task
 
 
 @admin.register(ContractAbi)
-class ContractAbiAdmin(BinarySearchAdmin):
+class ContractAbiAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     list_display = ("pk", "relevance", "description", "abi_functions")
     list_filter = ("relevance",)
     ordering = ["relevance"]
@@ -40,7 +41,7 @@ class HasAbiFilter(admin.SimpleListFilter):
 
 
 @admin.register(Contract)
-class ContractAdmin(BinarySearchAdmin):
+class ContractAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     actions = ["find_abi"]
     list_display = (
         "address",
@@ -57,7 +58,7 @@ class ContractAdmin(BinarySearchAdmin):
     ordering = ["address"]
     raw_id_fields = ("contract_abi",)
     search_fields = [
-        "=address",
+        "==address",
         "name",
         "contract_abi__abi",
         "contract_abi__description",

--- a/safe_transaction_service/history/admin.py
+++ b/safe_transaction_service/history/admin.py
@@ -11,8 +11,9 @@ from hexbytes import HexBytes
 from rest_framework.authtoken.admin import TokenAdmin
 
 from gnosis.eth import EthereumClientProvider
-from gnosis.eth.django.admin import BinarySearchAdmin
 from gnosis.safe import SafeTx
+
+from safe_transaction_service.utils.admin import AdvancedAdminSearchMixin
 
 from .models import (
     Chain,
@@ -90,6 +91,9 @@ class SafeContractDelegateInline(admin.TabularInline):
 # Admin models ------------------------------
 @admin.register(IndexingStatus)
 class IndexingStatusAdmin(admin.ModelAdmin):
+    class Meta:
+        verbose_name_plural = "Indexing Status"
+
     list_display = (
         "indexing_type",
         "block_number",
@@ -107,7 +111,7 @@ class ChainAdmin(admin.ModelAdmin):
 
 
 @admin.register(EthereumBlock)
-class EthereumBlockAdmin(admin.ModelAdmin):
+class EthereumBlockAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     date_hierarchy = "timestamp"
     inlines = (EthereumTxInline,)
     list_display = (
@@ -120,13 +124,13 @@ class EthereumBlockAdmin(admin.ModelAdmin):
     )
     list_filter = ("confirmed",)
     search_fields = [
-        "number",
-        "=block_hash",
+        "==number",
+        "==block_hash",
     ]
     ordering = ["-number"]
 
 
-class TokenTransferAdmin(BinarySearchAdmin):
+class TokenTransferAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     date_hierarchy = "timestamp"
     list_display = (
         "timestamp",
@@ -140,7 +144,7 @@ class TokenTransferAdmin(BinarySearchAdmin):
     )
     list_select_related = ("ethereum_tx",)
     ordering = ["-timestamp"]
-    search_fields = ["=_from", "=to", "=address", "=ethereum_tx__tx_hash"]
+    search_fields = ["==_from", "==to", "==address", "==ethereum_tx__tx_hash"]
     raw_id_fields = ("ethereum_tx",)
 
 
@@ -169,7 +173,7 @@ class ERC721TransferAdmin(TokenTransferAdmin):
 
 
 @admin.register(EthereumTx)
-class EthereumTxAdmin(BinarySearchAdmin):
+class EthereumTxAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     inlines = (
         ERC20TransferInline,
         ERC721TransferInline,
@@ -179,13 +183,13 @@ class EthereumTxAdmin(BinarySearchAdmin):
     )
     list_display = ("block_id", "tx_hash", "nonce", "_from", "to")
     list_filter = ("status", "type")
-    search_fields = ["=tx_hash", "=_from", "=to"]
+    search_fields = ["==block_id", "==tx_hash", "==_from", "==to"]
     ordering = ["-block_id"]
     raw_id_fields = ("block",)
 
 
 @admin.register(InternalTx)
-class InternalTxAdmin(BinarySearchAdmin):
+class InternalTxAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     date_hierarchy = "timestamp"
     inlines = (InternalTxDecodedInline,)
     list_display = (
@@ -207,11 +211,11 @@ class InternalTxAdmin(BinarySearchAdmin):
     ]
     raw_id_fields = ("ethereum_tx",)
     search_fields = [
-        "block_number",
-        "=_from",
-        "=to",
-        "=ethereum_tx__tx_hash",
-        "=contract_address",
+        "==block_number",
+        "==_from",
+        "==to",
+        "==ethereum_tx__tx_hash",
+        "==contract_address",
     ]
 
 
@@ -237,7 +241,7 @@ class InternalTxDecodedOfficialListFilter(admin.SimpleListFilter):
 
 
 @admin.register(InternalTxDecoded)
-class InternalTxDecodedAdmin(BinarySearchAdmin):
+class InternalTxDecodedAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     actions = ["process_again"]
     list_display = (
         "block_number",
@@ -257,11 +261,11 @@ class InternalTxDecodedAdmin(BinarySearchAdmin):
     ]
     raw_id_fields = ("internal_tx",)
     search_fields = [
-        "=function_name",
-        "=internal_tx__to",
-        "=internal_tx___from",
-        "=internal_tx__ethereum_tx__tx_hash",
-        "=internal_tx__block_number",
+        "==function_name",
+        "==internal_tx__to",
+        "==internal_tx___from",
+        "==internal_tx__ethereum_tx__tx_hash",
+        "==internal_tx__block_number",
     ]
 
     @admin.action(description="Process internal tx again")
@@ -287,7 +291,7 @@ class MultisigConfirmationListFilter(admin.SimpleListFilter):
 
 
 @admin.register(MultisigConfirmation)
-class MultisigConfirmationAdmin(BinarySearchAdmin):
+class MultisigConfirmationAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     list_display = (
         "block_number",
         "multisig_transaction_hash",
@@ -301,10 +305,10 @@ class MultisigConfirmationAdmin(BinarySearchAdmin):
     ordering = ["-created"]
     raw_id_fields = ("ethereum_tx", "multisig_transaction")
     search_fields = [
-        "=multisig_transaction__safe",
-        "=ethereum_tx__tx_hash",
-        "=multisig_transaction_hash",
-        "=owner",
+        "==multisig_transaction__safe",
+        "==ethereum_tx__tx_hash",
+        "==multisig_transaction_hash",
+        "==owner",
     ]
 
     @admin.display()
@@ -356,7 +360,7 @@ class MultisigTransactionAdminForm(forms.ModelForm):
 
 
 @admin.register(MultisigTransaction)
-class MultisigTransactionAdmin(BinarySearchAdmin):
+class MultisigTransactionAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     date_hierarchy = "created"
     form = MultisigTransactionAdminForm
     inlines = (MultisigConfirmationInline,)
@@ -382,7 +386,7 @@ class MultisigTransactionAdmin(BinarySearchAdmin):
     ordering = ["-created"]
     raw_id_fields = ("ethereum_tx",)
     readonly_fields = ("safe_tx_hash",)
-    search_fields = ["=ethereum_tx__tx_hash", "=safe", "=to", "=safe_tx_hash"]
+    search_fields = ["==ethereum_tx__tx_hash", "==safe", "==to", "==safe_tx_hash"]
 
     @admin.display(boolean=True)
     def executed(self, obj: MultisigTransaction):
@@ -423,7 +427,7 @@ class MultisigTransactionAdmin(BinarySearchAdmin):
 
 
 @admin.register(ModuleTransaction)
-class ModuleTransactionAdmin(BinarySearchAdmin):
+class ModuleTransactionAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     date_hierarchy = "created"
     list_display = (
         "created",
@@ -440,7 +444,7 @@ class ModuleTransactionAdmin(BinarySearchAdmin):
     list_select_related = ("internal_tx",)
     ordering = ["-created"]
     raw_id_fields = ("internal_tx",)
-    search_fields = ["=safe", "=module", "=to"]
+    search_fields = ["==safe", "==module", "==to"]
 
     def data_hex(self, o: ModuleTransaction):
         return HexBytes(o.data.tobytes()).hex() if o.data else None
@@ -449,10 +453,10 @@ class ModuleTransactionAdmin(BinarySearchAdmin):
         return o.internal_tx.ethereum_tx_id
 
 
-class MonitoredAddressAdmin(BinarySearchAdmin):
+class MonitoredAddressAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     actions = ["reindex", "reindex_last_day", "reindex_last_week", "reindex_last_month"]
     list_display = ("address", "initial_block_number", "tx_block_number")
-    search_fields = ["=address"]
+    search_fields = ["==address"]
 
     @admin.action(description="Reindex from initial block")
     def reindex(self, request, queryset):
@@ -525,7 +529,7 @@ class SafeContractERC20ListFilter(admin.SimpleListFilter):
 
 
 @admin.register(SafeContract)
-class SafeContractAdmin(BinarySearchAdmin):
+class SafeContractAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     inlines = (SafeContractDelegateInline,)
     list_display = (
         "created_block_number",
@@ -536,16 +540,20 @@ class SafeContractAdmin(BinarySearchAdmin):
     list_select_related = ("ethereum_tx",)
     ordering = ["-ethereum_tx__block_id"]
     raw_id_fields = ("ethereum_tx",)
-    search_fields = ["=address", "=ethereum_tx__tx_hash"]
+    search_fields = [
+        "==address",
+        "==ethereum_tx__tx_hash",
+        "==ethereum_tx__block_id",
+    ]
 
 
 @admin.register(SafeContractDelegate)
-class SafeContractDelegateAdmin(BinarySearchAdmin):
+class SafeContractDelegateAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     list_display = ("safe_contract", "read", "write", "delegate", "delegator")
     list_filter = ("read", "write")
     ordering = ["safe_contract_id"]
     raw_id_fields = ("safe_contract",)
-    search_fields = ["=safe_contract__address", "=delegate", "=delegator"]
+    search_fields = ["==safe_contract__address", "==delegate", "==delegator"]
 
 
 class SafeStatusModulesListFilter(admin.SimpleListFilter):
@@ -567,7 +575,7 @@ class SafeStatusModulesListFilter(admin.SimpleListFilter):
 
 
 @admin.register(SafeLastStatus)
-class SafeLastStatusAdmin(BinarySearchAdmin):
+class SafeLastStatusAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     actions = ["remove_and_index"]
     fields = (
         "internal_tx",
@@ -606,9 +614,9 @@ class SafeLastStatusAdmin(BinarySearchAdmin):
     ordering = ["-internal_tx__ethereum_tx__block_id", "-internal_tx_id"]
     raw_id_fields = ("internal_tx",)
     search_fields = [
-        "=address",
+        "==address",
         "owners__icontains",
-        "=internal_tx__ethereum_tx__tx_hash",
+        "==internal_tx__ethereum_tx__tx_hash",
         "enabled_modules__icontains",
     ]
 
@@ -633,7 +641,7 @@ class SafeStatusAdmin(SafeLastStatusAdmin):
 
 
 @admin.register(WebHook)
-class WebHookAdmin(BinarySearchAdmin):
+class WebHookAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     list_display = (
         "pk",
         "url",
@@ -657,4 +665,4 @@ class WebHookAdmin(BinarySearchAdmin):
         "new_outgoing_transaction",
     )
     ordering = ["-pk"]
-    search_fields = ["=address", "url"]
+    search_fields = ["==address", "==url"]

--- a/safe_transaction_service/notifications/admin.py
+++ b/safe_transaction_service/notifications/admin.py
@@ -2,13 +2,13 @@ from typing import List
 
 from django.contrib import admin
 
-from gnosis.eth.django.admin import BinarySearchAdmin
+from safe_transaction_service.utils.admin import AdvancedAdminSearchMixin
 
 from .models import FirebaseDevice, FirebaseDeviceOwner
 
 
 @admin.register(FirebaseDevice)
-class FirebaseDeviceAdmin(BinarySearchAdmin):
+class FirebaseDeviceAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     list_display = (
         "uuid",
         "cloud_messaging_token",
@@ -20,7 +20,7 @@ class FirebaseDeviceAdmin(BinarySearchAdmin):
     ordering = ["uuid"]
     raw_id_fields = ("safes",)
     readonly_fields = ("owners",)
-    search_fields = ["uuid", "cloud_messaging_token", "=safes__address"]
+    search_fields = ["==uuid", "==cloud_messaging_token", "==safes__address"]
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
@@ -34,7 +34,10 @@ class FirebaseDeviceAdmin(BinarySearchAdmin):
 
 
 @admin.register(FirebaseDeviceOwner)
-class FirebaseDeviceOwnerAdmin(BinarySearchAdmin):
+class FirebaseDeviceOwnerAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     list_display = ("firebase_device_id", "owner")
     ordering = ["firebase_device_id"]
-    search_fields = ["firebase_device_id__uuid", "=owner"]
+    search_fields = [
+        "==firebase_device_id__uuid",
+        "==owner",
+    ]

--- a/safe_transaction_service/safe_messages/admin.py
+++ b/safe_transaction_service/safe_messages/admin.py
@@ -1,21 +1,21 @@
 from django.contrib import admin
 
-from gnosis.eth.django.admin import BinarySearchAdmin
+from safe_transaction_service.utils.admin import AdvancedAdminSearchMixin
 
 from .models import SafeMessage, SafeMessageConfirmation
 
 
 @admin.register(SafeMessage)
-class SafeMessageAdmin(BinarySearchAdmin):
+class SafeMessageAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     date_hierarchy = "created"
     list_display = ("safe", "message_hash", "proposed_by", "message")
     ordering = ["-created"]
     readonly_fields = ("message_hash",)
-    search_fields = ["=safe", "=message_hash", "=proposed_by", "message"]
+    search_fields = ["==safe", "==message_hash", "==proposed_by", "message"]
 
 
 @admin.register(SafeMessageConfirmation)
-class SafeMessageConfirmationAdmin(BinarySearchAdmin):
+class SafeMessageConfirmationAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     date_hierarchy = "created"
     list_display = (
         "safe_message",
@@ -26,7 +26,6 @@ class SafeMessageConfirmationAdmin(BinarySearchAdmin):
     list_select_related = ("safe_message",)
     ordering = ["-created"]
     search_fields = [
-        "=safe_message__safe",
-        "=owner",
-        "safe_message__description",
+        "==safe_message__safe",
+        "==owner",
     ]

--- a/safe_transaction_service/tokens/admin.py
+++ b/safe_transaction_service/tokens/admin.py
@@ -1,14 +1,15 @@
 from django.contrib import admin
 
-from gnosis.eth.django.admin import BinarySearchAdmin
-
-from safe_transaction_service.utils.admin import HasLogoFilterAdmin
+from safe_transaction_service.utils.admin import (
+    AdvancedAdminSearchMixin,
+    HasLogoFilterAdmin,
+)
 
 from .models import Token, TokenList
 
 
 @admin.register(Token)
-class TokenAdmin(BinarySearchAdmin):
+class TokenAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     list_display = (
         "address",
         "trusted",
@@ -21,7 +22,7 @@ class TokenAdmin(BinarySearchAdmin):
     )
     list_filter = ("trusted", "spam", "events_bugged", "decimals", HasLogoFilterAdmin)
     ordering = ("address",)
-    search_fields = ["=address", "symbol", "name", "=copy_price"]
+    search_fields = ["==address", "symbol", "name", "==copy_price"]
 
 
 @admin.register(TokenList)
@@ -32,4 +33,4 @@ class TokenListAdmin(admin.ModelAdmin):
         "description",
     )
     ordering = ("pk",)
-    search_fields = ["description"]
+    search_fields = ["url", "description"]

--- a/safe_transaction_service/utils/admin.py
+++ b/safe_transaction_service/utils/admin.py
@@ -1,4 +1,9 @@
 from django.contrib import admin
+from django.contrib.admin.utils import lookup_spawns_duplicates
+from django.core.exceptions import FieldDoesNotExist, ValidationError
+from django.db import models
+from django.db.models.constants import LOOKUP_SEP
+from django.utils.text import smart_split, unescape_string_literal
 
 
 class HasLogoFilterAdmin(admin.SimpleListFilter):
@@ -18,3 +23,85 @@ class HasLogoFilterAdmin(admin.SimpleListFilter):
             return queryset.with_logo()
         else:
             return queryset
+
+
+class AdvancedAdminSearchMixin:
+    """
+    Use database indexes when using exact search instead
+    of converting everything to text before searching
+    """
+
+    def get_search_results(self, request, queryset, search_term):
+        """
+        Return a tuple containing a queryset to implement the search
+        and a boolean indicating if the results may contain duplicates.
+
+        This function was modified from Django original get_search_results
+        to allow `exact` search that uses database indexes
+        """
+
+        # Apply keyword searches.
+        print("HOLA")
+
+        def construct_search(field_name):
+            if field_name.startswith("^"):
+                return "%s__istartswith" % field_name[1:]
+            elif field_name.startswith("=="):
+                return "%s__exact" % field_name[2:]
+            elif field_name.startswith("="):
+                return "%s__iexact" % field_name[1:]
+            elif field_name.startswith("@"):
+                return "%s__search" % field_name[1:]
+            # Use field_name if it includes a lookup.
+            opts = queryset.model._meta
+            lookup_fields = field_name.split(LOOKUP_SEP)
+            # Go through the fields, following all relations.
+            prev_field = None
+            for path_part in lookup_fields:
+                if path_part == "pk":
+                    path_part = opts.pk.name
+                try:
+                    field = opts.get_field(path_part)
+                except FieldDoesNotExist:
+                    # Use valid query lookups.
+                    if prev_field and prev_field.get_lookup(path_part):
+                        return field_name
+                else:
+                    prev_field = field
+                    if hasattr(field, "path_infos"):
+                        # Update opts to follow the relation.
+                        opts = field.path_infos[-1].to_opts
+            # Otherwise, use the field with icontains.
+            return "%s__icontains" % field_name
+
+        may_have_duplicates = False
+        search_fields = self.get_search_fields(request)
+        if search_fields and search_term:
+            orm_lookups = [
+                construct_search(str(search_field)) for search_field in search_fields
+            ]
+            term_queries = []
+            for bit in smart_split(search_term):
+                if bit.startswith(('"', "'")) and bit[0] == bit[-1]:
+                    bit = unescape_string_literal(bit)
+
+                valid_queries = []
+                for orm_lookup in orm_lookups:
+                    try:
+                        # Check if query is valid (for example, not a number provided for an integer exact query)
+                        # This is the main difference comparing to Django official implementation
+                        queryset.filter(**{orm_lookup: bit})
+                        valid_queries.append((orm_lookup, bit))
+                    except (ValueError, ValidationError):
+                        pass
+                or_queries = models.Q.create(
+                    [valid_query for valid_query in valid_queries],
+                    connector=models.Q.OR,
+                )
+                term_queries.append(or_queries)
+            queryset = queryset.filter(models.Q.create(term_queries))
+            may_have_duplicates |= any(
+                lookup_spawns_duplicates(self.opts, search_spec)
+                for search_spec in orm_lookups
+            )
+        return queryset, may_have_duplicates

--- a/safe_transaction_service/utils/admin.py
+++ b/safe_transaction_service/utils/admin.py
@@ -25,6 +25,7 @@ class HasLogoFilterAdmin(admin.SimpleListFilter):
             return queryset
 
 
+# TODO Use the class in safe-eth-py
 class AdvancedAdminSearchMixin:
     """
     Use database indexes when using exact search instead
@@ -39,9 +40,6 @@ class AdvancedAdminSearchMixin:
         This function was modified from Django original get_search_results
         to allow `exact` search that uses database indexes
         """
-
-        # Apply keyword searches.
-        print("HOLA")
 
         def construct_search(field_name):
             if field_name.startswith("^"):


### PR DESCRIPTION
- Implement new AdvancedAdminSearchMixin
- Don't convert every value to text for search, so DB indexes can be used
- Change admin search from `iexact (=)`  to `exact (==)`
- Closes #1710 