### PR TITLE
Deprecate price endpoint

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.28.0"
+__version__ = "4.28.1"
 __version_info__ = tuple(
     int(num) if num.isdigit() else num
     for num in __version__.replace("-", ".", 1).split(".")

--- a/safe_transaction_service/tokens/views.py
+++ b/safe_transaction_service/tokens/views.py
@@ -64,7 +64,7 @@ class TokenPriceView(RetrieveAPIView):
 
     @swagger_auto_schema(
         deprecated=True,
-        operation_description="Price service will be removed at 30/11/2024",
+        operation_description="Eth/token pricing features will be removed at 30/11/2024",
     )
     @method_decorator(cache_page(60 * 10))  # Cache 10 minutes
     def get(self, request, *args, **kwargs):

--- a/safe_transaction_service/tokens/views.py
+++ b/safe_transaction_service/tokens/views.py
@@ -3,6 +3,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 
 import django_filters.rest_framework
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import response, status
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.generics import ListAPIView, RetrieveAPIView
@@ -61,6 +62,10 @@ class TokenPriceView(RetrieveAPIView):
     lookup_field = "address"
     queryset = Token.objects.all()
 
+    @swagger_auto_schema(
+        deprecated=True,
+        operation_description="Price service will be removed at 30/11/2024",
+    )
     @method_decorator(cache_page(60 * 10))  # Cache 10 minutes
     def get(self, request, *args, **kwargs):
         address = self.kwargs["address"]


### PR DESCRIPTION
# Description
Price endpoint will be removed at `30/11/2024`. 
This PR marks price token endpoint as deprecated. 

# Related issues
#1758 

