### PR TITLE
Add trusted field to token serialiser

### DIFF
--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -313,6 +313,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
                 "symbol": token.symbol,
                 "decimals": token.decimals,
                 "logo_uri": token.get_full_logo_uri(),
+                "trusted": token.trusted,
             },
         )
         transfers_not_empty = [
@@ -2325,6 +2326,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
                         "symbol": token.symbol,
                         "decimals": token.decimals,
                         "logoUri": token.get_full_logo_uri(),
+                        "trusted": token.trusted,
                     },
                 },
                 {
@@ -2400,6 +2402,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
                         "symbol": token.symbol,
                         "decimals": token.decimals,
                         "logoUri": token.get_full_logo_uri(),
+                        "trusted": token.trusted,
                     },
                 },
                 {
@@ -2569,6 +2572,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
                     "symbol": token.symbol,
                     "decimals": token.decimals,
                     "logoUri": token.get_full_logo_uri(),
+                    "trusted": token.trusted,
                 },
             },
             {
@@ -2856,6 +2860,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
                 "symbol": token.symbol,
                 "decimals": token.decimals,
                 "logoUri": token.get_full_logo_uri(),
+                "trusted": token.trusted,
             },
         }
         self.assertEqual(response.json(), expected_result)

--- a/safe_transaction_service/tokens/serializers.py
+++ b/safe_transaction_service/tokens/serializers.py
@@ -20,6 +20,7 @@ class TokenInfoResponseSerializer(serializers.Serializer):
     symbol = serializers.CharField()
     decimals = serializers.IntegerField()
     logo_uri = serializers.SerializerMethodField()
+    trusted = serializers.BooleanField()
 
     def get_type(self, obj: Token) -> str:
         if obj.is_erc20():

--- a/safe_transaction_service/tokens/tests/test_views.py
+++ b/safe_transaction_service/tokens/tests/test_views.py
@@ -44,6 +44,7 @@ class TestTokenViews(SafeTestCaseMixin, APITestCase):
                 "name": token.name,
                 "symbol": token.symbol,
                 "decimals": token.decimals,
+                "trusted": token.trusted,
             },
         )
 
@@ -59,6 +60,7 @@ class TestTokenViews(SafeTestCaseMixin, APITestCase):
                 "name": token.name,
                 "symbol": token.symbol,
                 "decimals": token.decimals,
+                "trusted": token.trusted,
             },
         )
 
@@ -95,6 +97,7 @@ class TestTokenViews(SafeTestCaseMixin, APITestCase):
                     "name": token.name,
                     "symbol": token.symbol,
                     "decimals": token.decimals,
+                    "trusted": token.trusted,
                 }
             ],
         )


### PR DESCRIPTION
Exposes the `trusted` field from the `Token` model entity. This field can be used for logic related to the reputation of a given token.
