### PR TITLE
Reduce number of blocks to reindex again

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -438,7 +438,7 @@ ETH_INTERNAL_TXS_BLOCK_PROCESS_LIMIT = env.int(
     "ETH_INTERNAL_TXS_BLOCK_PROCESS_LIMIT", default=10_000
 )
 ETH_INTERNAL_TXS_BLOCKS_TO_REINDEX_AGAIN = env.int(
-    "ETH_INTERNAL_TXS_BLOCKS_TO_REINDEX_AGAIN", default=10
+    "ETH_INTERNAL_TXS_BLOCKS_TO_REINDEX_AGAIN", default=1
 )
 ETH_INTERNAL_TXS_NUMBER_TRACE_BLOCKS = env.int(
     "ETH_INTERNAL_TXS_NUMBER_TRACE_BLOCKS", default=10
@@ -465,7 +465,7 @@ ETH_EVENTS_BLOCK_PROCESS_LIMIT_MAX = env.int(
     "ETH_EVENTS_BLOCK_PROCESS_LIMIT_MAX", default=0
 )  # Maximum number of blocks to process together when searching for events. 0 == no limit.
 ETH_EVENTS_BLOCKS_TO_REINDEX_AGAIN = env.int(
-    "ETH_EVENTS_BLOCKS_TO_REINDEX_AGAIN", default=20
+    "ETH_EVENTS_BLOCKS_TO_REINDEX_AGAIN", default=2
 )  # Blocks to reindex again every indexer run when service is synced. Useful for RPCs not reliable
 ETH_EVENTS_GET_LOGS_CONCURRENCY = env.int(
     "ETH_EVENTS_GET_LOGS_CONCURRENCY", default=20

--- a/safe_transaction_service/history/tests/test_proxy_factory_indexer.py
+++ b/safe_transaction_service/history/tests/test_proxy_factory_indexer.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.test import TestCase
 
 from gnosis.safe.tests.safe_test_case import SafeTestCaseMixin
@@ -21,10 +22,12 @@ class TestProxyFactoryIndexer(SafeTestCaseMixin, TestCase):
         )
         safe_contract_address = ethereum_tx_sent.contract_address
         self.w3.eth.wait_for_transaction_receipt(ethereum_tx_sent.tx_hash)
-        # We expect 1 event and 21 blocks 20 by reindexing and 1 from safe creation
+
+        blocks_to_reindex_again = settings.ETH_EVENTS_BLOCKS_TO_REINDEX_AGAIN
+        # We expect 1 event (Safe Creation) and `1 + blocks_to_reindex_again` blocks
         self.assertEqual(
             proxy_factory_indexer.start(),
-            (1, 21),
+            (1, 1 + blocks_to_reindex_again),
         )
         # Test if only 1 Safe was created
         self.assertEqual(SafeContract.objects.count(), 1 + safe_contracts_count)


### PR DESCRIPTION
As indexer it's running quite well, we shouldn't require to reindex so many blocks
