### PR TITLE
Add Print SQL limit configuration

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -551,3 +551,7 @@ SWAGGER_SETTINGS = {
         "api_key": {"type": "apiKey", "in": "header", "name": "Authorization"}
     },
 }
+
+# Shell Plus
+# ------------------------------------------------------------------------------
+SHELL_PLUS_PRINT_SQL_TRUNCATE = env.int("SHELL_PLUS_PRINT_SQL_TRUNCATE", default=10_000)


### PR DESCRIPTION
# Description
This PR is enabling the configuration of print sql limit for debug purposes. 
The default limit set by `--print-sql ` in shell_plus is not enough for larger SQL queries.