### PR TITLE
fix: wrong link to supported networks docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Aside from using standard HTTP requests:
 - [Safe CLI](https://github.com/5afe/safe-cli): It has a `tx-service` mode to gather offchain signatures.
 
 ### What chains do you officially support?
-https://docs.safe.global/safe-core-api/available-services
+https://docs.safe.global/api-supported-networks
 
 ### What means banned field in SafeContract model?
 The `banned` field in the `SafeContract` model is used to prevent indexing of certain Safes that have an unsupported `MasterCopy` or unverified proxies that have issues during indexing. This field does not remove the banned Safe and indexing can be resumed once the issue has been resolved.


### PR DESCRIPTION
### Make sure these boxes are checked! 📦✅

- [ ] You ran `./run_tests.sh`
- [ ] You ran `pre-commit run -a`
- [ ] If you want to add your network to `setup_service.py`, provide a link to your
    [safe-deployments PR](https://github.com/safe-global/safe-deployments/pulls) and check network name
    exists in [safe-eth-py](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py)

### What was wrong? 👾

Closes #

### How was it fixed? 🎯
