### PR TITLE
Increase Celery concurrency to be able to handle PING

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -234,6 +234,10 @@ CELERY_BROKER_CONNECTION_MAX_RETRIES = env.int(
 CELERY_BROKER_CHANNEL_ERROR_RETRY = env.bool(
     "CELERY_BROKER_CHANNEL_ERROR_RETRY", default=True
 )
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-connection-retry-on-startup
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = env.bool(
+    "CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP", default=True
+)
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend
 CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND", default="redis://")
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-accept_content

--- a/docker/web/celery/worker/run.sh
+++ b/docker/web/celery/worker/run.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 MAX_MEMORY_PER_CHILD="${WORKER_MAX_MEMORY_PER_CHILD:-2097152}"
 MAX_TASKS_PER_CHILD="${MAX_TASKS_PER_CHILD:-1000000}"
-TASK_CONCURRENCY="${CELERYD_CONCURRENCY:-1000}"
+TASK_CONCURRENCY="${CELERYD_CONCURRENCY:-50000}"
 
 # DEBUG set in .env_docker_compose
 if [ ${DEBUG:-0} = 1 ]; then
@@ -34,4 +34,4 @@ exec celery -C -A config.celery_app worker \
      --max-memory-per-child=${MAX_MEMORY_PER_CHILD} \
      --max-tasks-per-child=${MAX_TASKS_PER_CHILD} \
      --without-heartbeat --without-gossip \
-     --without-mingle -Q "$WORKER_QUEUES"
+     --without-mingle -E -Q "$WORKER_QUEUES"


### PR DESCRIPTION
- Liveness is not working if all the workers are busy
- Enable Celery events so we can monitor what's going on
