### PR TITLE
Update Celery configuration

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -238,7 +238,7 @@ CELERY_BROKER_CHANNEL_ERROR_RETRY = env.bool(
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = env.bool(
     "CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP", default=True
 )
-# http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend
+# https://docs.celeryq.dev/en/latest/userguide/configuration.html#task-result-backend-settings
 CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND", default=None)
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-accept_content
 CELERY_ACCEPT_CONTENT = ["json"]

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -239,7 +239,7 @@ CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = env.bool(
     "CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP", default=True
 )
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend
-CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND", default="redis://")
+CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND", default=None)
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-accept_content
 CELERY_ACCEPT_CONTENT = ["json"]
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_serializer

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -50,7 +50,3 @@ DEBUG_TOOLBAR_CONFIG = {
 }
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#internal-ips
 INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
-
-# CELERY
-# ------------------------------------------------------------------------------
-CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND", default=REDIS_URL)

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -65,10 +65,6 @@ if SSO_ENABLED:
 # Django Admin URL regex.
 ADMIN_URL = env("DJANGO_ADMIN_URL", default="admin/")
 
-# CELERY
-# ------------------------------------------------------------------------------
-CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND", default=REDIS_URL)
-
 # Gunicorn
 # ------------------------------------------------------------------------------
 INSTALLED_APPS += ["gunicorn"]  # noqa F405

--- a/docker/web/celery/worker/run.sh
+++ b/docker/web/celery/worker/run.sh
@@ -2,9 +2,7 @@
 
 set -euo pipefail
 
-MAX_MEMORY_PER_CHILD="${WORKER_MAX_MEMORY_PER_CHILD:-2097152}"
-MAX_TASKS_PER_CHILD="${MAX_TASKS_PER_CHILD:-1000000}"
-TASK_CONCURRENCY="${CELERYD_CONCURRENCY:-15000}"
+TASK_CONCURRENCY=${CELERYD_CONCURRENCY:-15000}
 
 # DEBUG set in .env_docker_compose
 if [ ${DEBUG:-0} = 1 ]; then
@@ -27,11 +25,11 @@ fi
 echo "==> $(date +%H:%M:%S) ==> Check RPC connected matches previously used RPC... "
 python manage.py check_chainid_matches
 
-echo "==> $(date +%H:%M:%S) ==> Running Celery worker with a max_memory_per_child of ${MAX_MEMORY_PER_CHILD} <=="
-exec celery -C -A config.celery_app worker \
-     --loglevel $log_level --pool=gevent \
-     --concurrency=${TASK_CONCURRENCY} \
-     --max-memory-per-child=${MAX_MEMORY_PER_CHILD} \
-     --max-tasks-per-child=${MAX_TASKS_PER_CHILD} \
-     --without-heartbeat --without-gossip \
+echo "==> $(date +%H:%M:%S) ==> Running Celery worker for queues $WORKER_QUEUES with concurrency $TASK_CONCURRENCY <=="
+exec celery --no-color -A config.celery_app worker \
+     --pool=gevent \
+     --loglevel $log_level \
+     --concurrency="${TASK_CONCURRENCY}" \
+     --without-heartbeat \
+     --without-gossip \
      --without-mingle -E -Q "$WORKER_QUEUES"


### PR DESCRIPTION
- Stop storing results, as we are not using them.
- Remove `MAX_MEMORY_PER_CHILD` and `MAX_TASKS_PER_CHILD`, as they are not valid for `gevent` pool.
