### PR TITLE
Delete delegates from safe and owner when owner is removed

### DIFF
--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -1809,11 +1809,15 @@ class SafeContractDelegateManager(models.Manager):
     def remove_delegates_for_owner_in_safe(
         self, safe_address: ChecksumAddress, owner_address: ChecksumAddress
     ) -> int:
-        return (
-            self.filter(Q(safe_contract_id=safe_address))
-            .filter(delegator=owner_address)
-            .delete()[0]
-        )
+        """
+        This method deletes delegated users only if the safe address and the owner address match.
+        Used when an owner is removed from the Safe.
+
+        :return: number of delegated users deleted
+        """
+        return self.filter(
+            safe_contract_id=safe_address, delegator=owner_address
+        ).delete()[0]
 
 
 class SafeContractDelegate(models.Model):

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -1806,6 +1806,15 @@ class SafeContractDelegateManager(models.Manager):
             .distinct()
         )
 
+    def remove_delegates_for_owner_in_safe(
+        self, safe_address: ChecksumAddress, owner_address: ChecksumAddress
+    ) -> int:
+        return (
+            self.filter(Q(safe_contract_id=safe_address))
+            .filter(delegator=owner_address)
+            .delete()[0]
+        )
+
 
 class SafeContractDelegate(models.Model):
     """

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -1272,6 +1272,45 @@ class TestSafeContractDelegate(TestCase):
             set(),
         )
 
+    def test_remove_delegates_for_owner_in_safe(self):
+        safe_address = Account.create().address
+        owner = Account.create().address
+        self.assertCountEqual(
+            SafeContractDelegate.objects.get_for_safe(None, [owner]), []
+        )
+
+        safe_contract_delegate = SafeContractDelegateFactory(
+            delegator=owner, safe_contract=None
+        )
+        self.assertEqual(
+            SafeContractDelegate.objects.get_delegates_for_safe_and_owners(
+                Account.create().address, [owner]
+            ),
+            {safe_contract_delegate.delegate},
+        )
+
+        safe_specific_delegate = SafeContractDelegateFactory(
+            delegator=owner, safe_contract__address=safe_address
+        )
+
+        self.assertEqual(
+            SafeContractDelegate.objects.get_delegates_for_safe_and_owners(
+                safe_address, [owner]
+            ),
+            {safe_contract_delegate.delegate, safe_specific_delegate.delegate},
+        )
+
+        SafeContractDelegate.objects.remove_delegates_for_owner_in_safe(
+            safe_address, owner
+        )
+
+        self.assertEqual(
+            SafeContractDelegate.objects.get_delegates_for_safe_and_owners(
+                safe_address, [owner]
+            ),
+            {safe_contract_delegate.delegate},
+        )
+
 
 class TestMultisigConfirmations(TestCase):
     def test_remove_unused_confirmations(self):

--- a/safe_transaction_service/history/tests/test_tx_processor.py
+++ b/safe_transaction_service/history/tests/test_tx_processor.py
@@ -24,6 +24,7 @@ from ..models import (
     MultisigConfirmation,
     MultisigTransaction,
     SafeContract,
+    SafeContractDelegate,
     SafeLastStatus,
     SafeStatus,
 )
@@ -32,6 +33,7 @@ from .factories import (
     InternalTxDecodedFactory,
     MultisigConfirmationFactory,
     MultisigTransactionFactory,
+    SafeContractDelegateFactory,
     SafeLastStatusFactory,
     SafeMasterCopyFactory,
 )
@@ -101,6 +103,17 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         self.assertEqual(safe_status.nonce, 1)
         self.assertEqual(safe_status.threshold, threshold)
 
+        safe_contract = SafeContract.objects.get(address=safe_address)
+        safe_contract_delegate = SafeContractDelegateFactory(
+            delegator=owner, safe_contract=safe_contract
+        )
+        self.assertEqual(
+            SafeContractDelegate.objects.get_delegates_for_safe_and_owners(
+                safe_address, [owner]
+            ),
+            {safe_contract_delegate.delegate},
+        )
+
         another_owner = Account.create().address
         tx_processor.process_decoded_transactions(
             [
@@ -120,6 +133,12 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         safe_last_status = SafeLastStatus.objects.get(address=safe_address)
         self.assertEqual(safe_status, SafeStatus.from_status_instance(safe_last_status))
         self.assertEqual(safe_status.owners, [new_owner, another_owner])
+        self.assertEqual(
+            SafeContractDelegate.objects.get_delegates_for_safe_and_owners(
+                safe_address, [owner]
+            ),
+            set(),
+        )
         self.assertEqual(safe_status.nonce, 2)
         self.assertEqual(safe_status.threshold, threshold)
 
@@ -143,6 +162,15 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         )
         self.assertEqual(SafeMessageConfirmation.objects.count(), 2)
         number_confirmations = MultisigConfirmation.objects.count()
+        safe_contract_delegate_another_owner = SafeContractDelegateFactory(
+            delegator=another_owner, safe_contract=safe_contract
+        )
+        self.assertEqual(
+            SafeContractDelegate.objects.get_delegates_for_safe_and_owners(
+                safe_address, [another_owner]
+            ),
+            {safe_contract_delegate_another_owner.delegate},
+        )
         tx_processor.process_decoded_transactions(
             [
                 InternalTxDecodedFactory(
@@ -172,6 +200,12 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         safe_last_status = SafeLastStatus.objects.get(address=safe_address)
         self.assertEqual(safe_status, SafeStatus.from_status_instance(safe_last_status))
         self.assertEqual(safe_status.owners, [new_owner])
+        self.assertEqual(
+            SafeContractDelegate.objects.get_delegates_for_safe_and_owners(
+                safe_address, [another_owner]
+            ),
+            set(),
+        )
         self.assertEqual(safe_status.nonce, 3)
         self.assertEqual(safe_status.threshold, threshold)
 

--- a/safe_transaction_service/history/tests/test_tx_processor.py
+++ b/safe_transaction_service/history/tests/test_tx_processor.py
@@ -103,9 +103,8 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         self.assertEqual(safe_status.nonce, 1)
         self.assertEqual(safe_status.threshold, threshold)
 
-        safe_contract = SafeContract.objects.get(address=safe_address)
         safe_contract_delegate = SafeContractDelegateFactory(
-            delegator=owner, safe_contract=safe_contract
+            delegator=owner, safe_contract_id=safe_address
         )
         self.assertEqual(
             SafeContractDelegate.objects.get_delegates_for_safe_and_owners(
@@ -163,7 +162,7 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         self.assertEqual(SafeMessageConfirmation.objects.count(), 2)
         number_confirmations = MultisigConfirmation.objects.count()
         safe_contract_delegate_another_owner = SafeContractDelegateFactory(
-            delegator=another_owner, safe_contract=safe_contract
+            delegator=another_owner, safe_contract_id=safe_address
         )
         self.assertEqual(
             SafeContractDelegate.objects.get_delegates_for_safe_and_owners(


### PR DESCRIPTION
Closes #1850

The delegate should only be removed if it is specifically from the safe and the owner. If it is a general delegate for a user, it should not be deleted.