### PR TITLE
4337: Add SafeOperation to creation endpoint

### DIFF
--- a/safe_transaction_service/account_abstraction/serializers.py
+++ b/safe_transaction_service/account_abstraction/serializers.py
@@ -236,31 +236,53 @@ class SafeOperationConfirmationResponseSerializer(serializers.Serializer):
 
 
 class SafeOperationResponseSerializer(serializers.Serializer):
-    created = serializers.DateTimeField(source="safe_operation.created")
-    modified = serializers.DateTimeField(source="safe_operation.modified")
-
-    sender = eth_serializers.EthereumAddressField()
-    user_operation_hash = eth_serializers.HexadecimalField(source="hash")
-    safe_operation_hash = eth_serializers.HexadecimalField(source="safe_operation.hash")
-    ethereum_tx_hash = eth_serializers.HexadecimalField(source="ethereum_tx_id")
-    nonce = serializers.IntegerField(min_value=0)
-    init_code = eth_serializers.HexadecimalField(allow_null=True)
-    call_data = eth_serializers.HexadecimalField(allow_null=True)
-    call_data_gas_limit = serializers.IntegerField(min_value=0)
-    verification_gas_limit = serializers.IntegerField(min_value=0)
-    pre_verification_gas = serializers.IntegerField(min_value=0)
-    max_fee_per_gas = serializers.IntegerField(min_value=0)
-    max_priority_fee_per_gas = serializers.IntegerField(min_value=0)
-    paymaster = eth_serializers.EthereumAddressField(allow_null=True)
-    paymaster_data = eth_serializers.HexadecimalField(allow_null=True)
-    signature = eth_serializers.HexadecimalField()
-    entry_point = eth_serializers.EthereumAddressField()
-    # Safe Operation fields
-    valid_after = serializers.DateTimeField(source="safe_operation.valid_after")
-    valid_until = serializers.DateTimeField(source="safe_operation.valid_until")
-    module_address = eth_serializers.EthereumAddressField(
-        source="safe_operation.module_address"
+    created = serializers.DateTimeField()
+    modified = serializers.DateTimeField()
+    ethereum_tx_hash = eth_serializers.HexadecimalField(
+        source="user_operation.ethereum_tx_id"
     )
+
+    # User Operation fields
+    sender = eth_serializers.EthereumAddressField(source="user_operation.sender")
+    user_operation_hash = eth_serializers.HexadecimalField(source="user_operation.hash")
+    safe_operation_hash = eth_serializers.HexadecimalField(source="hash")
+    nonce = serializers.IntegerField(min_value=0, source="user_operation.nonce")
+    init_code = eth_serializers.HexadecimalField(
+        allow_null=True, source="user_operation.init_code"
+    )
+    call_data = eth_serializers.HexadecimalField(
+        allow_null=True, source="user_operation.call_data"
+    )
+    call_data_gas_limit = serializers.IntegerField(
+        min_value=0, source="user_operation.call_data_gas_limit"
+    )
+    verification_gas_limit = serializers.IntegerField(
+        min_value=0, source="user_operation.verification_gas_limit"
+    )
+    pre_verification_gas = serializers.IntegerField(
+        min_value=0, source="user_operation.pre_verification_gas"
+    )
+    max_fee_per_gas = serializers.IntegerField(
+        min_value=0, source="user_operation.max_fee_per_gas"
+    )
+    max_priority_fee_per_gas = serializers.IntegerField(
+        min_value=0, source="user_operation.max_priority_fee_per_gas"
+    )
+    paymaster = eth_serializers.EthereumAddressField(
+        allow_null=True, source="user_operation.paymaster"
+    )
+    paymaster_data = eth_serializers.HexadecimalField(
+        allow_null=True, source="user_operation.paymaster_data"
+    )
+    signature = eth_serializers.HexadecimalField(source="user_operation.signature")
+    entry_point = eth_serializers.EthereumAddressField(
+        source="user_operation.entry_point"
+    )
+
+    # Safe Operation fields
+    valid_after = serializers.DateTimeField()
+    valid_until = serializers.DateTimeField()
+    module_address = eth_serializers.EthereumAddressField()
 
     confirmations = serializers.SerializerMethodField()
     prepared_signature = serializers.SerializerMethodField()
@@ -273,7 +295,7 @@ class SafeOperationResponseSerializer(serializers.Serializer):
         :return: Serialized queryset
         """
         return SafeOperationConfirmationResponseSerializer(
-            obj.safe_operation.confirmations, many=True
+            obj.confirmations, many=True
         ).data
 
     def get_prepared_signature(self, obj: SafeOperation) -> Optional[HexStr]:
@@ -283,5 +305,5 @@ class SafeOperationResponseSerializer(serializers.Serializer):
         :param obj: SafeOperation instance
         :return: Serialized queryset
         """
-        signature = HexBytes(obj.safe_operation.build_signature())
+        signature = HexBytes(obj.build_signature())
         return signature.hex() if signature else None

--- a/safe_transaction_service/account_abstraction/tests/test_views.py
+++ b/safe_transaction_service/account_abstraction/tests/test_views.py
@@ -45,7 +45,7 @@ class TestAccountAbstractionViews(SafeTestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(
-            response.json(), {"detail": "No UserOperation matches the given query."}
+            response.json(), {"detail": "No SafeOperation matches the given query."}
         )
         safe_address = Account.create().address
         safe_operation = factories.SafeOperationFactory(
@@ -107,7 +107,6 @@ class TestAccountAbstractionViews(SafeTestCaseMixin, APITestCase):
                 "signatureType": "EOA",
             }
         ]
-        self.maxDiff = None
         self.assertDictEqual(response.json(), expected)
 
     def test_safe_operations_view(self):

--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -22,6 +22,7 @@ from gnosis.safe import Safe
 from gnosis.safe.safe_signature import SafeSignature, SafeSignatureType
 from gnosis.safe.serializers import SafeMultisigTxSerializerV1
 
+from safe_transaction_service.account_abstraction import serializers as aa_serializers
 from safe_transaction_service.contracts.tx_decoder import (
     TxDecoderException,
     get_db_tx_decoder,
@@ -776,6 +777,7 @@ class SafeCreationInfoResponseSerializer(serializers.Serializer):
     master_copy = EthereumAddressField(allow_null=True)
     setup_data = HexadecimalField(allow_null=True)
     data_decoded = serializers.SerializerMethodField()
+    safe_operation = aa_serializers.SafeOperationResponseSerializer(allow_null=True)
 
     def get_data_decoded(self, obj: SafeCreationInfo) -> Dict[str, Any]:
         return get_data_decoded_from_data(obj.setup_data or b"")

--- a/safe_transaction_service/history/services/safe_service.py
+++ b/safe_transaction_service/history/services/safe_service.py
@@ -137,9 +137,14 @@ class SafeService:
         except IOError as exc:
             raise NodeConnectionException from exc
 
-        safe_operation = aa_models.SafeOperation.objects.filter(
-            user_operation__ethereum_tx=creation_ethereum_tx
-        ).first()
+        safe_operation = (
+            aa_models.SafeOperation.objects.filter(
+                user_operation__ethereum_tx=creation_ethereum_tx,
+                user_operation__sender=safe_address,
+            )
+            .exclude(user_operation__init_code=None)
+            .first()
+        )
         return SafeCreationInfo(
             created_time,
             creator,

--- a/safe_transaction_service/history/services/safe_service.py
+++ b/safe_transaction_service/history/services/safe_service.py
@@ -16,6 +16,8 @@ from gnosis.safe import Safe
 from gnosis.safe.exceptions import CannotRetrieveSafeInfoException
 from gnosis.safe.safe import SafeInfo
 
+from safe_transaction_service.account_abstraction import models as aa_models
+
 from ..exceptions import NodeConnectionException
 from ..models import InternalTx, SafeLastStatus, SafeMasterCopy
 
@@ -45,6 +47,7 @@ class SafeCreationInfo:
     master_copy: Optional[EthereumAddress]
     setup_data: Optional[bytes]
     transaction_hash: str
+    safe_operation: Optional[aa_models.SafeOperation]
 
 
 class SafeServiceProvider:
@@ -134,6 +137,9 @@ class SafeService:
         except IOError as exc:
             raise NodeConnectionException from exc
 
+        safe_operation = aa_models.SafeOperation.objects.filter(
+            user_operation__ethereum_tx=creation_ethereum_tx
+        ).first()
         return SafeCreationInfo(
             created_time,
             creator,
@@ -141,6 +147,7 @@ class SafeService:
             master_copy,
             setup_data,
             creation_internal_tx.ethereum_tx_id,
+            safe_operation,
         )
 
     def get_safe_info(self, safe_address: ChecksumAddress) -> SafeInfo:


### PR DESCRIPTION
- Refactor `SafeOperationResponseSerializer`, previously it was using a `UserOperation` to render the fields, now it uses a `SafeOperation`
- Refactor tests
