### PR TITLE
4337: Fix `valid_after` and `valid_until` parsing

### DIFF
--- a/safe_transaction_service/account_abstraction/serializers.py
+++ b/safe_transaction_service/account_abstraction/serializers.py
@@ -118,6 +118,7 @@ class SafeOperationSerializer(serializers.Serializer):
     def validate_valid_until(self, valid_until: Optional[int]) -> Optional[int]:
         """
         Make sure ``valid_until`` is not previous to the current timestamp, so it will be valid for some time
+
         :param valid_until:
         :return: `valid_until`
         """
@@ -138,8 +139,10 @@ class SafeOperationSerializer(serializers.Serializer):
                 f"valid values are {settings.ETHEREUM_4337_SUPPORTED_SAFE_MODULES}"
             )
 
-        valid_after = attrs["valid_after"] or 0
-        valid_until = attrs["valid_until"] or 0
+        valid_after, valid_until = [
+            int(attrs[key].timestamp()) if attrs[key] else 0
+            for key in ("valid_after", "valid_until")
+        ]
         if valid_after and valid_until and valid_after > valid_until:
             raise ValidationError("`valid_after` cannot be higher than `valid_until`")
 

--- a/safe_transaction_service/account_abstraction/tests/test_views.py
+++ b/safe_transaction_service/account_abstraction/tests/test_views.py
@@ -441,7 +441,7 @@ class TestAccountAbstractionViews(SafeTestCaseMixin, APITestCase):
             },
         )
 
-        # Fix `valid_until`, set it in the future
+        # Set valid_until in the future
         valid_until = timezone.now() + datetime.timedelta(minutes=90)
         data["valid_until"] = datetime_to_str(valid_until)
         new_safe_operation = dataclasses.replace(

--- a/safe_transaction_service/account_abstraction/tests/test_views.py
+++ b/safe_transaction_service/account_abstraction/tests/test_views.py
@@ -1,3 +1,5 @@
+import dataclasses
+import datetime
 import logging
 from unittest import mock
 from unittest.mock import MagicMock
@@ -376,10 +378,11 @@ class TestAccountAbstractionViews(SafeTestCaseMixin, APITestCase):
         self, get_chain_id_mock: MagicMock, get_owners_mock: MagicMock
     ):
         """
-        Don't allow `valid_until` previous to the current timestamp
+        Make sure `valid_until` checks are working
         """
 
         account = Account.create()
+        get_owners_mock.return_value = [account.address]
         safe_address = safe_4337_address
         user_operation_hash = safe_4337_user_operation_hash_mock
 
@@ -398,7 +401,6 @@ class TestAccountAbstractionViews(SafeTestCaseMixin, APITestCase):
         )
 
         signature = account.signHash(safe_operation_hash)["signature"].hex()
-        get_owners_mock.return_value = []
         data = {
             "nonce": safe_operation.nonce,
             "init_code": user_operation.init_code.hex(),
@@ -438,3 +440,20 @@ class TestAccountAbstractionViews(SafeTestCaseMixin, APITestCase):
                 ]
             },
         )
+
+        # Fix `valid_until`, set it in the future
+        valid_until = timezone.now() + datetime.timedelta(minutes=90)
+        data["valid_until"] = datetime_to_str(valid_until)
+        new_safe_operation = dataclasses.replace(
+            safe_operation, valid_until=int(valid_until.timestamp())
+        )
+        safe_operation_hash = new_safe_operation.get_safe_operation_hash(
+            safe_4337_chain_id_mock, safe_4337_module_address_mock
+        )
+        data["signature"] = account.signHash(safe_operation_hash)["signature"].hex()
+        response = self.client.post(
+            reverse("v1:account_abstraction:safe-operations", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)


### PR DESCRIPTION
- Fix `valid_after` and `valid_until` parsing
-  Fix `valid_until` check
