### PR TITLE
4337: Index failed user operations

### DIFF
--- a/safe_transaction_service/account_abstraction/serializers.py
+++ b/safe_transaction_service/account_abstraction/serializers.py
@@ -146,7 +146,7 @@ class SafeOperationSerializer(serializers.Serializer):
         self, valid_until: Optional[datetime.datetime]
     ) -> Optional[datetime.datetime]:
         """
-        Make sure ``valid_until`` is not previous to the current timestamp, so it will be valid for some time
+        Make sure ``valid_until`` is not previous to the current timestamp
 
         :param valid_until:
         :return: `valid_until`

--- a/safe_transaction_service/account_abstraction/services/aa_processor_service.py
+++ b/safe_transaction_service/account_abstraction/services/aa_processor_service.py
@@ -35,10 +35,6 @@ class AaProcessorServiceException(Exception):
     pass
 
 
-class UserOperationFailed(AaProcessorServiceException):
-    pass
-
-
 class ExecutionFromSafeModuleNotDetected(AaProcessorServiceException):
     pass
 
@@ -213,8 +209,11 @@ class AaProcessorService:
             user_operation_hash
         )
         if not user_operation_receipt.success:
-            raise UserOperationFailed(
-                f"UserOperation with user-operation-hash={user_operation_hash} failed"
+            logger.info(
+                "[%s] UserOperation user-operation-hash=%s on tx-hash=%s failed, indexing either way",
+                safe_address,
+                user_operation_hash,
+                tx_hash,
             )
 
         # Use event `Deposited (index_topic_1 address account, uint256 totalDeposit)`


### PR DESCRIPTION
As a first step we disabled indexing of failed user operations, but they should be indexed too. Also a user operation can deploy a Safe and then fail
