### PR TITLE
Add safe deployments endpoint

### DIFF
--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -1204,3 +1204,13 @@ class DelegateDeleteSerializer(DelegateSignatureCheckerMixin, serializers.Serial
         raise ValidationError(
             f"Signature does not match provided delegate={delegate} or delegator={delegator}"
         )
+
+
+class SafeDeploymentContractSerializer(serializers.Serializer):
+    contract_name = serializers.CharField()
+    address = EthereumAddressField(allow_null=True)
+
+
+class SafeDeploymentSerializer(serializers.Serializer):
+    version = serializers.CharField(max_length=10)  # Example 1.3.0
+    contracts = SafeDeploymentContractSerializer(many=True)

--- a/safe_transaction_service/history/tests/mocks/deployments_mock.py
+++ b/safe_transaction_service/history/tests/mocks/deployments_mock.py
@@ -1,0 +1,149 @@
+mainnet_deployments_1_4_1_multisend = {
+    "contractName": "MultiSend",
+    "address": "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
+}
+
+mainnet_deployments_1_4_1_safe = {
+    "contractName": "Safe",
+    "address": "0x41675C099F32341bf84BFc5382aF534df5C7461a",
+}
+
+mainnet_deployments_1_4_1 = {
+    "version": "1.4.1",
+    "contracts": [
+        {
+            "contractName": "CompatibilityFallbackHandler",
+            "address": "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",
+        },
+        {
+            "contractName": "CreateCall",
+            "address": "0x9b35Af71d77eaf8d7e40252370304687390A1A52",
+        },
+        mainnet_deployments_1_4_1_multisend,
+        {
+            "contractName": "MultiSendCallOnly",
+            "address": "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",
+        },
+        mainnet_deployments_1_4_1_safe,
+        {
+            "contractName": "SafeL2",
+            "address": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
+        },
+        {
+            "contractName": "SafeProxyFactory",
+            "address": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
+        },
+        {
+            "contractName": "SignMessageLib",
+            "address": "0xd53cd0aB83D845Ac265BE939c57F53AD838012c9",
+        },
+        {
+            "contractName": "SimulateTxAccessor",
+            "address": "0x3d4BA2E0884aa488718476ca2FB8Efc291A46199",
+        },
+    ],
+}
+
+mainnet_deployments_1_3_0 = {
+    "version": "1.3.0",
+    "contracts": [
+        {
+            "contractName": "CompatibilityFallbackHandler",
+            "address": "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4",
+        },
+        {
+            "contractName": "CreateCall",
+            "address": "0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4",
+        },
+        {
+            "contractName": "GnosisSafe",
+            "address": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
+        },
+        {
+            "contractName": "GnosisSafeL2",
+            "address": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
+        },
+        {
+            "contractName": "MultiSend",
+            "address": "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
+        },
+        {
+            "contractName": "MultiSendCallOnly",
+            "address": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
+        },
+        {
+            "contractName": "GnosisSafeProxyFactory",
+            "address": "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",
+        },
+        {
+            "contractName": "SignMessageLib",
+            "address": "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",
+        },
+        {
+            "contractName": "SimulateTxAccessor",
+            "address": "0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da",
+        },
+    ],
+}
+
+mainnet_deployments_1_2_0 = {
+    "version": "1.2.0",
+    "contracts": [
+        {
+            "contractName": "GnosisSafe",
+            "address": "0x6851D6fDFAfD08c0295C392436245E5bc78B0185",
+        }
+    ],
+}
+
+mainnet_deployments_1_1_1 = {
+    "version": "1.1.1",
+    "contracts": [
+        {
+            "contractName": "CreateAndAddModules",
+            "address": "0xF61A721642B0c0C8b334bA3763BA1326F53798C0",
+        },
+        {
+            "contractName": "CreateCall",
+            "address": "0x8538fcbccba7f5303d2c679fa5d7a629a8c9bf4a",
+        },
+        {
+            "contractName": "DefaultCallbackHandler",
+            "address": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
+        },
+        {
+            "contractName": "GnosisSafe",
+            "address": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+        },
+        {
+            "contractName": "MultiSend",
+            "address": "0x8D29bE29923b68abfDD21e541b9374737B49cdAD",
+        },
+        {
+            "contractName": "ProxyFactory",
+            "address": "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B",
+        },
+    ],
+}
+
+mainnet_deployments_1_0_0 = {
+    "version": "1.0.0",
+    "contracts": [
+        {
+            "contractName": "GnosisSafe",
+            "address": "0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A",
+        },
+        {
+            "contractName": "ProxyFactory",
+            "address": "0x12302fE9c02ff50939BaAaaf415fc226C078613C",
+        },
+    ],
+}
+
+mainnet_deployments = [
+    mainnet_deployments_1_0_0,
+    mainnet_deployments_1_1_1,
+    mainnet_deployments_1_2_0,
+    mainnet_deployments_1_3_0,
+    mainnet_deployments_1_4_1,
+]

--- a/safe_transaction_service/history/tests/mocks/deployments_mock.py
+++ b/safe_transaction_service/history/tests/mocks/deployments_mock.py
@@ -105,7 +105,7 @@ mainnet_deployments_1_1_1 = {
         },
         {
             "contractName": "CreateCall",
-            "address": "0x8538fcbccba7f5303d2c679fa5d7a629a8c9bf4a",
+            "address": "0x8538FcBccba7f5303d2C679Fa5d7A629A8c9bf4A",
         },
         {
             "contractName": "DefaultCallbackHandler",

--- a/safe_transaction_service/history/urls.py
+++ b/safe_transaction_service/history/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     ),
     path(
         "about/deployments/",
-        views.SafeDeployments.as_view(),
+        views.SafeDeploymentsView.as_view(),
         name="deployments",
     ),
     path("data-decoder/", views.DataDecoderView.as_view(), name="data-decoder"),

--- a/safe_transaction_service/history/urls.py
+++ b/safe_transaction_service/history/urls.py
@@ -22,6 +22,11 @@ urlpatterns = [
         views.IndexingView.as_view(),
         name="indexing",
     ),
+    path(
+        "about/deployments/",
+        views.SafeDeployments.as_view(),
+        name="deployments",
+    ),
     path("data-decoder/", views.DataDecoderView.as_view(), name="data-decoder"),
     path("safes/<str:address>/", views.SafeInfoView.as_view(), name="safe-info"),
     path(

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -176,7 +176,7 @@ class SingletonsView(ListAPIView):
         return SafeMasterCopy.objects.relevant()
 
 
-class SafeDeployments(ListAPIView):
+class SafeDeploymentsView(ListAPIView):
     """
     Returns a list of safe deployments by version.
     """

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -29,6 +29,7 @@ from gnosis.eth import EthereumClient, EthereumClientProvider, EthereumNetwork
 from gnosis.eth.constants import NULL_ADDRESS
 from gnosis.eth.utils import fast_is_checksum_address
 from gnosis.safe import CannotEstimateGas
+from gnosis.safe.safe_deployments import safe_deployments
 
 from safe_transaction_service import __version__
 from safe_transaction_service.utils.ethereum import get_chain_id
@@ -173,6 +174,75 @@ class SingletonsView(ListAPIView):
 
     def get_queryset(self):
         return SafeMasterCopy.objects.relevant()
+
+
+class SafeDeployments(ListAPIView):
+    """
+    Returns a list of safe deployments by version.
+    """
+
+    serializer_class = serializers.SafeDeploymentSerializer
+    pagination_class = None  # Don't show limit/offset in swagger
+
+    _schema_version_param = openapi.Parameter(
+        "version",
+        openapi.IN_QUERY,
+        type=openapi.TYPE_STRING,
+        default=None,
+        description="Filter by Safe version",
+    )
+    _schema_contract_param = openapi.Parameter(
+        "contract",
+        openapi.IN_QUERY,
+        type=openapi.TYPE_STRING,
+        default=None,
+        description="Filter by Safe contract name",
+    )
+
+    @swagger_auto_schema(
+        responses={404: "Provided version does not exist"},
+        manual_parameters=[
+            _schema_version_param,
+            _schema_contract_param,
+        ],
+    )
+    @method_decorator(cache_page(60))  # 60 seconds
+    def get(self, request):
+        """
+        Get current indexing status for ERC20/721 events
+        """
+        filter_version = self.request.query_params.get("version")
+        filter_contract = self.request.query_params.get("contract")
+
+        if filter_version and filter_version not in safe_deployments.keys():
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        versions = [filter_version] if filter_version else list(safe_deployments.keys())
+        chain_id = get_chain_id()
+        data_response = []
+        for version in versions:
+            contracts = []
+            if not filter_contract:
+                for contract_name, addresses in safe_deployments[version].items():
+                    contracts.append(
+                        {
+                            "contract_name": contract_name,
+                            "address": addresses.get(str(chain_id)),
+                        }
+                    )
+            else:
+                # Filter by contract
+                if addresses := safe_deployments[version].get(filter_contract):
+                    contracts.append(
+                        {
+                            "contract_name": filter_contract,
+                            "address": addresses.get(str(chain_id)),
+                        }
+                    )
+
+            data_response.append({"version": version, "contracts": contracts})
+
+        return Response(status=status.HTTP_200_OK, data=data_response)
 
 
 class AllTransactionsListView(ListAPIView):

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -240,7 +240,7 @@ class SafeDeploymentsView(ListAPIView):
             data_response.append({"version": version, "contracts": contracts})
 
         serializer = self.serializer_class(data=data_response, many=True)
-        serializer.is_valid()
+        serializer.is_valid(raise_exception=True)
         return Response(status=status.HTTP_200_OK, data=serializer.data)
 
 


### PR DESCRIPTION
# Description
Add a new endpoint to return the Safe deployments from https://github.com/safe-global/safe-eth-py/blob/main/gnosis/safe/safe_deployments.py 
The new endpoint can be queried by version or/and contract name providing it by query parameter.
This PR also includes the swagger documentation for this new endpoint. 

Closes #1996 
