### PR TITLE
Bump safe-eth-py to v6.0.0b27

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@ psycogreen==1.0.2
 psycopg2==2.9.9
 redis==5.0.4
 requests==2.31.0
-safe-eth-py[django]==6.0.0b26
+safe-eth-py[django]==6.0.0b27
 web3==6.17.0


### PR DESCRIPTION
Updates safe-eth-py to v6.0.0b7
