### PR TITLE
4337: Add endpoint to return UserOperations

### DIFF
--- a/safe_transaction_service/account_abstraction/serializers.py
+++ b/safe_transaction_service/account_abstraction/serializers.py
@@ -394,3 +394,22 @@ class SafeOperationResponseSerializer(serializers.Serializer):
         """
         signature = HexBytes(obj.build_signature())
         return signature.hex() if signature else None
+
+
+class UserOperationResponseSerializer(serializers.Serializer):
+    ethereum_tx_hash = eth_serializers.HexadecimalField(source="ethereum_tx_id")
+
+    sender = eth_serializers.EthereumAddressField()
+    user_operation_hash = eth_serializers.HexadecimalField(source="hash")
+    nonce = serializers.IntegerField(min_value=0)
+    init_code = eth_serializers.HexadecimalField(allow_null=True)
+    call_data = eth_serializers.HexadecimalField(allow_null=True)
+    call_data_gas_limit = serializers.IntegerField(min_value=0)
+    verification_gas_limit = serializers.IntegerField(min_value=0)
+    pre_verification_gas = serializers.IntegerField(min_value=0)
+    max_fee_per_gas = serializers.IntegerField(min_value=0)
+    max_priority_fee_per_gas = serializers.IntegerField(min_value=0)
+    paymaster = eth_serializers.EthereumAddressField(allow_null=True)
+    paymaster_data = eth_serializers.HexadecimalField(allow_null=True)
+    signature = eth_serializers.HexadecimalField()
+    entry_point = eth_serializers.EthereumAddressField()

--- a/safe_transaction_service/account_abstraction/services/aa_processor_service.py
+++ b/safe_transaction_service/account_abstraction/services/aa_processor_service.py
@@ -168,6 +168,8 @@ class AaProcessorService:
                     user_operation_model.sender,
                     user_operation.user_operation_hash.hex(),
                 )
+            # As `module_address` cannot be detected there's not enough data to index the SafeOperation
+            return None
 
         # Build SafeOperation from UserOperation
         safe_operation = SafeOperation.from_user_operation(user_operation)

--- a/safe_transaction_service/account_abstraction/urls.py
+++ b/safe_transaction_service/account_abstraction/urls.py
@@ -15,4 +15,14 @@ urlpatterns = [
         views.SafeOperationsView.as_view(),
         name="safe-operations",
     ),
+    path(
+        "user-operations/<str:user_operation_hash>/",
+        views.UserOperationView.as_view(),
+        name="user-operation",
+    ),
+    path(
+        "safes/<str:address>/user-operations/",
+        views.UserOperationsView.as_view(),
+        name="user-operations",
+    ),
 ]


### PR DESCRIPTION
- Sometimes SafeOperation is reverted and the only existing information is the UserOperation
- Related to #2035
