### PR TITLE
4337: Add `safeOperation` inside of `userOperation` serializer

### DIFF
--- a/safe_transaction_service/account_abstraction/serializers.py
+++ b/safe_transaction_service/account_abstraction/serializers.py
@@ -344,7 +344,6 @@ class UserOperationResponseSerializer(serializers.Serializer):
 class SafeOperationResponseSerializer(serializers.Serializer):
     created = serializers.DateTimeField()
     modified = serializers.DateTimeField()
-    user_operation = UserOperationResponseSerializer(many=False, read_only=True)
     safe_operation_hash = eth_serializers.HexadecimalField(source="hash")
 
     valid_after = serializers.DateTimeField()
@@ -376,20 +375,11 @@ class SafeOperationResponseSerializer(serializers.Serializer):
         return signature.hex() if signature else None
 
 
-class UserOperationResponseSerializer(serializers.Serializer):
-    ethereum_tx_hash = eth_serializers.HexadecimalField(source="ethereum_tx_id")
+class SafeOperationWithUserOperationResponseSerializer(SafeOperationResponseSerializer):
+    user_operation = UserOperationResponseSerializer(many=False, read_only=True)
 
-    sender = eth_serializers.EthereumAddressField()
-    user_operation_hash = eth_serializers.HexadecimalField(source="hash")
-    nonce = serializers.IntegerField(min_value=0)
-    init_code = eth_serializers.HexadecimalField(allow_null=True)
-    call_data = eth_serializers.HexadecimalField(allow_null=True)
-    call_data_gas_limit = serializers.IntegerField(min_value=0)
-    verification_gas_limit = serializers.IntegerField(min_value=0)
-    pre_verification_gas = serializers.IntegerField(min_value=0)
-    max_fee_per_gas = serializers.IntegerField(min_value=0)
-    max_priority_fee_per_gas = serializers.IntegerField(min_value=0)
-    paymaster = eth_serializers.EthereumAddressField(allow_null=True)
-    paymaster_data = eth_serializers.HexadecimalField(allow_null=True)
-    signature = eth_serializers.HexadecimalField()
-    entry_point = eth_serializers.EthereumAddressField()
+
+class UserOperationWithSafeOperationResponseSerializer(UserOperationResponseSerializer):
+    safe_operation = SafeOperationResponseSerializer(
+        many=False, read_only=True, allow_null=True
+    )

--- a/safe_transaction_service/account_abstraction/tests/test_views.py
+++ b/safe_transaction_service/account_abstraction/tests/test_views.py
@@ -681,6 +681,16 @@ class TestAccountAbstractionViews(SafeTestCaseMixin, APITestCase):
             "paymasterData": "0x",
             "signature": "0x",
             "entryPoint": safe_operation.user_operation.entry_point,
+            "safeOperation": {
+                "created": datetime_to_str(safe_operation.created),
+                "modified": datetime_to_str(safe_operation.modified),
+                "safeOperationHash": safe_operation.hash,
+                "validAfter": datetime_to_str(safe_operation.valid_after),
+                "validUntil": datetime_to_str(safe_operation.valid_until),
+                "moduleAddress": safe_operation.module_address,
+                "confirmations": [],
+                "preparedSignature": None,
+            },
         }
         self.assertDictEqual(
             response.json(),
@@ -723,6 +733,16 @@ class TestAccountAbstractionViews(SafeTestCaseMixin, APITestCase):
             "paymasterData": "0x",
             "signature": "0x",
             "entryPoint": safe_operation.user_operation.entry_point,
+            "safeOperation": {
+                "created": datetime_to_str(safe_operation.created),
+                "modified": datetime_to_str(safe_operation.modified),
+                "safeOperationHash": safe_operation.hash,
+                "validAfter": datetime_to_str(safe_operation.valid_after),
+                "validUntil": datetime_to_str(safe_operation.valid_until),
+                "moduleAddress": safe_operation.module_address,
+                "confirmations": [],
+                "preparedSignature": None,
+            },
         }
         self.assertDictEqual(
             response.json(),

--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -757,7 +757,9 @@ class SafeCreationInfoResponseSerializer(serializers.Serializer):
     master_copy = EthereumAddressField(allow_null=True)
     setup_data = HexadecimalField(allow_null=True)
     data_decoded = serializers.SerializerMethodField()
-    safe_operation = aa_serializers.SafeOperationResponseSerializer(allow_null=True)
+    user_operation = aa_serializers.UserOperationWithSafeOperationResponseSerializer(
+        allow_null=True
+    )
 
     def get_data_decoded(self, obj: SafeCreationInfo) -> Dict[str, Any]:
         return get_data_decoded_from_data(obj.setup_data or b"")

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -3210,7 +3210,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
                 "setup_data": None,
                 "data_decoded": None,
                 "transaction_hash": internal_tx.ethereum_tx_id,
-                "safe_operation": None,
+                "user_operation": None,
             }
             self.assertDictEqual(response.data, expected)
 
@@ -3241,37 +3241,37 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        expected["safe_operation"] = {
-            "created": datetime_to_str(safe_operation.created),
-            "modified": datetime_to_str(safe_operation.created),
-            "safe_operation_hash": safe_operation.hash,
-            "user_operation": {
-                "ethereum_tx_hash": internal_tx.ethereum_tx_id,
-                "sender": safe_operation.user_operation.sender,
-                "user_operation_hash": safe_operation.user_operation.hash,
-                "nonce": safe_operation.user_operation.nonce,
-                "init_code": "0x1234",
-                "call_data": "0x",
-                "call_data_gas_limit": safe_operation.user_operation.call_data_gas_limit,
-                "verification_gas_limit": safe_operation.user_operation.verification_gas_limit,
-                "pre_verification_gas": safe_operation.user_operation.pre_verification_gas,
-                "max_fee_per_gas": safe_operation.user_operation.max_fee_per_gas,
-                "max_priority_fee_per_gas": safe_operation.user_operation.max_priority_fee_per_gas,
-                "paymaster": safe_operation.user_operation.paymaster,
-                "paymaster_data": "0x",
-                "signature": "0x",
-                "entry_point": safe_operation.user_operation.entry_point,
+        expected["user_operation"] = {
+            "sender": safe_operation.user_operation.sender,
+            "nonce": safe_operation.user_operation.nonce,
+            "user_operation_hash": safe_operation.user_operation.hash,
+            "ethereum_tx_hash": internal_tx.ethereum_tx_id,
+            "init_code": "0x1234",
+            "call_data": "0x",
+            "call_data_gas_limit": safe_operation.user_operation.call_data_gas_limit,
+            "verification_gas_limit": safe_operation.user_operation.verification_gas_limit,
+            "pre_verification_gas": safe_operation.user_operation.pre_verification_gas,
+            "max_fee_per_gas": safe_operation.user_operation.max_fee_per_gas,
+            "max_priority_fee_per_gas": safe_operation.user_operation.max_priority_fee_per_gas,
+            "paymaster": safe_operation.user_operation.paymaster,
+            "paymaster_data": "0x",
+            "signature": "0x",
+            "entry_point": safe_operation.user_operation.entry_point,
+            "safe_operation": {
+                "created": datetime_to_str(safe_operation.created),
+                "modified": datetime_to_str(safe_operation.created),
+                "safe_operation_hash": safe_operation.hash,
+                "valid_after": datetime_to_str(safe_operation.valid_after),
+                "valid_until": datetime_to_str(safe_operation.valid_until),
+                "module_address": safe_operation.module_address,
+                "confirmations": [],
+                "prepared_signature": None,
             },
-            "valid_after": datetime_to_str(safe_operation.valid_after),
-            "valid_until": datetime_to_str(safe_operation.valid_until),
-            "module_address": safe_operation.module_address,
-            "confirmations": [],
-            "prepared_signature": None,
         }
 
-        self.assertIsNotNone(response.data["safe_operation"])
+        self.assertIsNotNone(response.data["user_operation"])
         self.assertDictEqual(response.data, expected)
-        safe_operation.delete()
+        safe_operation.user_operation.delete()
 
         another_trace_2 = dict(call_trace)
         another_trace_2["traceAddress"] = [0]
@@ -3309,7 +3309,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
                             "master_copy": test_data["master_copy"],
                             "setup_data": test_data["setup_data"],
                             "data_decoded": data_decoded,
-                            "safe_operation": None,
+                            "user_operation": None,
                         },
                     )
 


### PR DESCRIPTION
- `user-operations` endpoints should return `safeOperation` if there's one for the `userOperation`
- Related to #2035 