### PR TITLE
Optimize load of addresses in indexer

### DIFF
--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -72,7 +72,7 @@ class Erc20EventsIndexer(EventsIndexer):
 
     @property
     def database_queryset(self) -> QuerySet:
-        return SafeContract.objects
+        return SafeContract.objects.all()
 
     def _do_node_query(
         self,

--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -71,7 +71,7 @@ class Erc20EventsIndexer(EventsIndexer):
         return "erc20_block_number"
 
     @property
-    def database_queryset(self):
+    def database_queryset(self) -> QuerySet:
         return SafeContract.objects.all()
 
     def _do_node_query(
@@ -201,7 +201,7 @@ class Erc20EventsIndexer(EventsIndexer):
 
     def get_almost_updated_addresses(
         self, current_block_number: int
-    ) -> QuerySet[MonitoredAddress]:
+    ) -> QuerySet[SafeContract]:
         """
 
         :param current_block_number:

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -134,6 +134,10 @@ def index_erc20_events_out_of_sync_task(
         list(erc20_events_indexer.get_almost_updated_addresses(current_block_number))[
             :number_of_addresses
         ]
+    addresses = set(addresses) if addresses else  set(
+        list(erc20_events_indexer.get_almost_updated_addresses(current_block_number))[
+            :number_of_addresses
+        ]
     )
 
     if not addresses:

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -130,14 +130,14 @@ def index_erc20_events_out_of_sync_task(
         erc20_events_indexer.block_process_limit_max = block_process_limit_max
 
     current_block_number = erc20_events_indexer.ethereum_client.current_block_number
-    addresses = (set(addresses) if addresses else None) or set(
-        list(erc20_events_indexer.get_almost_updated_addresses(current_block_number))[
-            :number_of_addresses
-        ]
-    addresses = set(addresses) if addresses else  set(
-        list(erc20_events_indexer.get_almost_updated_addresses(current_block_number))[
-            :number_of_addresses
-        ]
+    addresses = (
+        set(addresses)
+        if addresses
+        else set(
+            list(
+                erc20_events_indexer.get_almost_updated_addresses(current_block_number)
+            )[:number_of_addresses]
+        )
     )
 
     if not addresses:

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -115,7 +115,7 @@ def index_erc20_events_task(self) -> Optional[Tuple[int, int]]:
 def index_erc20_events_out_of_sync_task(
     block_process_limit: Optional[int] = None,
     block_process_limit_max: Optional[int] = None,
-    addresses: Optional[ChecksumAddress] = None,
+    addresses: Optional[list[ChecksumAddress]] = None,
     number_of_addresses: Optional[int] = 100,
 ) -> Optional[int]:
     """
@@ -130,12 +130,11 @@ def index_erc20_events_out_of_sync_task(
         erc20_events_indexer.block_process_limit_max = block_process_limit_max
 
     current_block_number = erc20_events_indexer.ethereum_client.current_block_number
-    addresses = addresses or [
-        almost_updated_address.address
-        for almost_updated_address in erc20_events_indexer.get_almost_updated_addresses(
-            current_block_number
-        )[:number_of_addresses]
-    ]
+    addresses = (set(addresses) if addresses else None) or set(
+        list(erc20_events_indexer.get_almost_updated_addresses(current_block_number))[
+            :number_of_addresses
+        ]
+    )
 
     if not addresses:
         logger.info("No addresses to process")

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -126,10 +126,11 @@ class TestCommands(SafeTestCaseMixin, TestCase):
 
         with self.assertLogs(logger=task_logger) as cm:
             safe_contract = SafeContractFactory()
+            addresses = {safe_contract.address}
             buf = StringIO()
             call_command(command, stdout=buf)
             self.assertIn(
-                f"Start indexing of erc20/721 events for out of sync addresses {[safe_contract.address]}",
+                f"Start indexing of erc20/721 events for out of sync addresses {addresses}",
                 cm.output[0],
             )
             self.assertIn(
@@ -139,10 +140,11 @@ class TestCommands(SafeTestCaseMixin, TestCase):
 
         with self.assertLogs(logger=task_logger) as cm:
             safe_contract_2 = SafeContractFactory()
+            addresses = {safe_contract_2.address}
             buf = StringIO()
             call_command(command, f"--addresses={safe_contract_2.address}", stdout=buf)
             self.assertIn(
-                f"Start indexing of erc20/721 events for out of sync addresses {[safe_contract_2.address]}",
+                f"Start indexing of erc20/721 events for out of sync addresses {addresses}",
                 cm.output[0],
             )
             self.assertIn(
@@ -153,12 +155,13 @@ class TestCommands(SafeTestCaseMixin, TestCase):
         # Test sync task call
         with self.assertLogs(logger=task_logger) as cm:
             safe_contract_2 = SafeContractFactory()
+            addresses = {safe_contract_2.address}
             buf = StringIO()
             call_command(
                 command, f"--addresses={safe_contract_2.address}", "--sync", stdout=buf
             )
             self.assertIn(
-                f"Start indexing of erc20/721 events for out of sync addresses {[safe_contract_2.address]}",
+                f"Start indexing of erc20/721 events for out of sync addresses {addresses}",
                 cm.output[0],
             )
             self.assertIn(

--- a/safe_transaction_service/history/tests/test_internal_tx_indexer.py
+++ b/safe_transaction_service/history/tests/test_internal_tx_indexer.py
@@ -203,9 +203,9 @@ class TestInternalTxIndexer(TestCase):
     ):
         current_block_number = current_block_number_mock.return_value
         internal_tx_indexer = self.internal_tx_indexer
-        addresses = ["0x5aC255889882aCd3da2aA939679E3f3d4cea221e"]
+        addresses = {"0x5aC255889882aCd3da2aA939679E3f3d4cea221e"}
         trace_filter_transactions = OrderedDict(
-            (trace["transactionHash"], []) for trace in trace_filter_mock.return_value
+            (trace["transactionHash"], None) for trace in trace_filter_mock.return_value
         )
         trace_block_transactions = OrderedDict(
             (
@@ -221,12 +221,12 @@ class TestInternalTxIndexer(TestCase):
         elements = internal_tx_indexer.find_relevant_elements(
             addresses, 1, current_block_number - 50
         )
-        self.assertEqual(trace_filter_transactions, elements)
+        self.assertDictEqual(trace_filter_transactions, elements)
         trace_filter_mock.assert_called_once_with(
             internal_tx_indexer.ethereum_client.tracing,
             from_block=1,
             to_block=current_block_number - 50,
-            to_address=addresses,
+            to_address=list(addresses),
         )
         trace_block_mock.assert_not_called()
         trace_filter_mock.reset_mock()
@@ -235,12 +235,14 @@ class TestInternalTxIndexer(TestCase):
         elements = internal_tx_indexer.find_relevant_elements(
             addresses, current_block_number - 50, current_block_number
         )
-        self.assertEqual(trace_filter_transactions | trace_block_transactions, elements)
+        self.assertDictEqual(
+            trace_filter_transactions | trace_block_transactions, elements
+        )
         trace_filter_mock.assert_called_once_with(
             internal_tx_indexer.ethereum_client.tracing,
             from_block=current_block_number - 50,
             to_block=current_block_number - internal_tx_indexer.number_trace_blocks,
-            to_address=addresses,
+            to_address=list(addresses),
         )
 
         trace_block_mock.assert_called_with(

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -67,8 +67,9 @@ class TestTasks(TestCase):
         with self.assertLogs(logger=task_logger) as cm:
             safe_contract = SafeContractFactory()
             index_erc20_events_out_of_sync_task.delay()
+            addresses = {safe_contract.address}
             self.assertIn(
-                f"Start indexing of erc20/721 events for out of sync addresses {[safe_contract.address]}",
+                f"Start indexing of erc20/721 events for out of sync addresses {addresses}",
                 cm.output[0],
             )
             self.assertIn(


### PR DESCRIPTION
Make indexers use `sets` instead of db instances

- Previously, `MonitoredAddress` instances were used.
- Currently, only `address` is retrieved from database, and transformed into a set
- This approach is:
    - More optimal both on CPU/RAM, as it does not have to use a `list` and then convert to a `set`
    - Easier to cache (in a following PR)
    - Easiert to extend and implement new indexers
- Tests and indexers were refactored
- Typing was checked and fixed
