### PR TITLE
Use address type for EIP712 payload

### DIFF
--- a/safe_transaction_service/history/helpers.py
+++ b/safe_transaction_service/history/helpers.py
@@ -106,7 +106,7 @@ class DelegateSignatureHelperV2(TemporarySignatureHelper):
                     {"name": "chainId", "type": "uint256"},
                 ],
                 "Delegate": [
-                    {"name": "delegateAddress", "type": "bytes32"},
+                    {"name": "delegateAddress", "type": "address"},
                     {"name": "totp", "type": "uint256"},
                 ],
             },

--- a/safe_transaction_service/history/tests/test_helpers.py
+++ b/safe_transaction_service/history/tests/test_helpers.py
@@ -22,7 +22,7 @@ class TestDelegateSignatureHelperV2(SafeTestCaseMixin, TestCase):
 
         # Hash calculated when totp previous is false
         expected_hash_previous_totp_false = HexBytes(
-            "0xc095ec37d1798b39b8cf9306a3d6788f6118f46a0d18fcfac037c8306bdbf397"
+            "0x40ef28feb993bf127265260d48ab1a427d5b852aa8b38f511fcd368bfc9cbfdf"
         )
 
         result_hash = DelegateSignatureHelperV2.calculate_hash(
@@ -34,7 +34,7 @@ class TestDelegateSignatureHelperV2(SafeTestCaseMixin, TestCase):
 
         # Hash calculated when totp previous is true
         expected_hash_previous_totp_true = HexBytes(
-            "0xbf910dbf371090157231e49e7530c44b5ecf6a24fd4322be85465c13dbcb1459"
+            "0x37fe1c77d467e92109ef91637e30a4053bab963de2ea74f9d6c4ba1918ff32e6"
         )
 
         result_hash = DelegateSignatureHelperV2.calculate_hash(

--- a/safe_transaction_service/history/views_v2.py
+++ b/safe_transaction_service/history/views_v2.py
@@ -98,12 +98,12 @@ class DelegateListView(ListCreateAPIView):
                     {"name": "version", "type": "string"},
                     {"name": "chainId", "type": "uint256"},
                 ],
-                "AddDelegate": [
-                    {"name": "delegateAddress", "type": "bytes32"},
+                "Delegate": [
+                    {"name": "delegateAddress", "type": "address"},
                     {"name": "totp", "type": "uint256"},
                 ],
             },
-            "primaryType": "AddDelegate",
+            "primaryType": "Delegate",
             "domain": {
                 "name": "Safe Transaction Service",
                 "version": "1.0",


### PR DESCRIPTION
### What was wrong? 👾

Closes #2084

### How was it fixed? 🎯

The Delegate EIP712 payload was using `bytes32` as the type for the delegate address (which is an Ethereum Address).

While this works, it represents the wrong input type and size constraints that we should accept for that field (an address is 20 bytes so any input bigger than that should not be valid).

### Considerations

Signatures made before this change will not be considered valid as the resulting has would be different. The new payload would need to be signed again by the required signers again in those scenarios.