### PR TITLE
Fix ERC20 reindex

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.2.1"
+__version__ = "5.2.2"
 __version_info__ = tuple(
     int(num) if num.isdigit() else num
     for num in __version__.replace("-", ".", 1).split(".")

--- a/safe_transaction_service/history/services/index_service.py
+++ b/safe_transaction_service/history/services/index_service.py
@@ -392,17 +392,18 @@ class IndexService:
             # No issues on modifying the indexer as we should be provided with a new instance
             indexer.IGNORE_ADDRESSES_ON_LOG_FILTER = False
         else:
-            addresses = list(
-                indexer.database_queryset.values_list("address", flat=True)
-            )
+            addresses = set(indexer.database_queryset.values_list("address", flat=True))
 
         element_number: int = 0
         if not addresses:
             logger.warning("No addresses to process")
         else:
             # Don't log all the addresses
+            addresses_len = len(addresses)
             addresses_str = (
-                str(addresses) if len(addresses) < 10 else f"{addresses[:10]}..."
+                str(addresses)
+                if addresses_len < 10
+                else f"{addresses_len} addresses..."
             )
             logger.info("Start reindexing addresses %s", addresses_str)
             current_block_number = self.ethereum_client.current_block_number

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -209,22 +209,23 @@ class TestCommands(SafeTestCaseMixin, TestCase):
                     f"--from-block-number={from_block_number}",
                     stdout=buf,
                 )
+                expected_addresses = {safe_master_copy.address}
                 self.assertIn(
-                    f"Start reindexing addresses {[safe_master_copy.address]}",
+                    f"Start reindexing addresses {expected_addresses}",
                     cm.output[0],
                 )
                 self.assertIn("found 0 traces/events", cm.output[1])
                 self.assertIn(
-                    f"End reindexing addresses {[safe_master_copy.address]}",
+                    f"End reindexing addresses {expected_addresses}",
                     cm.output[3],
                 )
                 find_relevant_elements_mock.assert_any_call(
-                    [safe_master_copy.address],
+                    {safe_master_copy.address},
                     from_block_number,
                     from_block_number + block_process_limit - 1,
                 )
                 find_relevant_elements_mock.assert_any_call(
-                    [safe_master_copy.address],
+                    {safe_master_copy.address},
                     from_block_number + block_process_limit,
                     current_block_number_mock.return_value,
                 )
@@ -251,22 +252,23 @@ class TestCommands(SafeTestCaseMixin, TestCase):
                         f"--from-block-number={from_block_number}",
                         stdout=buf,
                     )
+                    expected_addresses = {safe_l2_master_copy.address}
                     self.assertIn(
-                        f"Start reindexing addresses {[safe_l2_master_copy.address]}",
+                        f"Start reindexing addresses {expected_addresses}",
                         cm.output[0],
                     )
                     self.assertIn("found 0 traces/events", cm.output[1])
                     self.assertIn(
-                        f"End reindexing addresses {[safe_l2_master_copy.address]}",
+                        f"End reindexing addresses {expected_addresses}",
                         cm.output[3],
                     )
                     find_relevant_elements_mock.assert_any_call(
-                        [safe_l2_master_copy.address],
+                        {safe_l2_master_copy.address},
                         from_block_number,
                         from_block_number + block_process_limit - 1,
                     )
                     find_relevant_elements_mock.assert_any_call(
-                        [safe_l2_master_copy.address],
+                        {safe_l2_master_copy.address},
                         from_block_number + block_process_limit,
                         current_block_number_mock.return_value,
                     )
@@ -313,22 +315,23 @@ class TestCommands(SafeTestCaseMixin, TestCase):
                     f"--from-block-number={from_block_number}",
                     stdout=buf,
                 )
+                expected_addresses = {safe_contract.address}
                 self.assertIn(
-                    f"Start reindexing addresses {[safe_contract.address]}",
+                    f"Start reindexing addresses {expected_addresses}",
                     cm.output[0],
                 )
                 self.assertIn("found 0 traces/events", cm.output[1])
                 self.assertIn(
-                    f"End reindexing addresses {[safe_contract.address]}",
+                    f"End reindexing addresses {expected_addresses}",
                     cm.output[3],
                 )
                 find_relevant_elements_mock.assert_any_call(
-                    [safe_contract.address],
+                    {safe_contract.address},
                     from_block_number,
                     from_block_number + block_process_limit - 1,
                 )
                 find_relevant_elements_mock.assert_any_call(
-                    [safe_contract.address],
+                    {safe_contract.address},
                     from_block_number + block_process_limit,
                     current_block_number_mock.return_value,
                 )


### PR DESCRIPTION
- A `set` should be passed, not a list, so check can be instant
