### PR TITLE
Force recreate containers in test script

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 export DJANGO_SETTINGS_MODULE=config.settings.test
 export DJANGO_DOT_ENV_FILE=.env.test
 docker compose -f docker-compose.yml -f docker-compose.dev.yml build --force-rm db redis ganache rabbitmq
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up --no-start db redis ganache rabbitmq
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --no-start --force-recreate db redis ganache rabbitmq
 docker compose -f docker-compose.yml -f docker-compose.dev.yml start db redis ganache rabbitmq
 
 python manage.py check


### PR DESCRIPTION
There might be situations where `docker compose up` tries to add an existing container to a network that no longer exists (Docker daemon returns an error in those cases).

For a test script, we do want to have a new environment (network) created which the new containers can interact with.

See https://docs.docker.com/reference/cli/docker/compose/up/