### PR TITLE
Add ENS Subgraph configuration

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -516,6 +516,14 @@ TOKENS_ERC20_GET_BALANCES_BATCH = env.int(
     "TOKENS_ERC20_GET_BALANCES_BATCH", default=2_000
 )  # Number of tokens to get balances from in the same request. From 2_500 some nodes raise HTTP 413
 
+# ENS
+# ------------------------------------------------------------------------------
+# See https://docs.ens.domains/web/subgraph for more details
+
+ENS_SUBGRAPH_URL = env.str("ENS_SUBGRAPH_URL", default=None)
+ENS_SUBGRAPH_API_KEY = env.str("ENS_SUBGRAPH_API_KEY", default=None)
+ENS_SUBGRAPH_ID = env.str("ENS_SUBGRAPH_ID", default=None)
+
 # Notifications
 # ------------------------------------------------------------------------------
 SLACK_API_WEBHOOK = env("SLACK_API_WEBHOOK", default=None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@ psycogreen==1.0.2
 psycopg2==2.9.9
 redis==5.0.7
 requests==2.32.3
-safe-eth-py[django]==6.0.0b31
+safe-eth-py[django]==6.0.0b32
 web3==6.20.0


### PR DESCRIPTION
- Adds the possibility to add an ENS Subgraph configuration.
- The Subgraph requires an API key which can be obtained via The Graph interface (https://thegraph.com/docs/en/querying/querying-the-graph/)
- Adds three environment variables that should be used if The Subgraph support needs to be enabled:
  * `ENS_SUBGRAPH_URL` – the base url to query the subgraph from
  * `ENS_SUBGRAPH_API_KEY` – the API key that was obtained from The Graph
  * `ENS_SUBGRAPH_ID` – the subgraph id. An example of an ENS Subgraph can be found in https://thegraph.com/explorer/subgraphs/5XqPmWe6gjyrJtFn9cLy237i4cWw2j9HcUJEXsP5qGtH?view=Query&chain=arbitrum-one. To query this graph, you should use `5XqPmWe6gjyrJtFn9cLy237i4cWw2j9HcUJEXsP5qGtH` as the subgraph id.
- The ENS Subgraph configuration is only required if querying on `Mainnet`. 
- Support was added to `Sepolia` and `Holesky`. These two networks do not require an API key but should not be considered for production usage (rate limits might apply).
- If the current chain is `Mainnet` and the Subgraph configuration was not provided, a fallback for Mainnet is used. However, such fallback might be under stricter rate limits and should only be used in a testing environment. A warning is logged if the fallback option is used.
