### PR TITLE
Add code marks to swagger descriptions

### DIFF
--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -1243,7 +1243,7 @@ class DataDecoderView(GenericAPIView):
     def post(self, request, format=None):
         """
         Returns the decoded data using the Safe Transaction Service internal ABI information given
-        the transaction data as a 0x prefixed hexadecimal string.
+        the transaction data as a `0x` prefixed hexadecimal string.
         If the address of the receiving contract is provided, the decoded data will be more accurate,
         as in case of an ABI collision the Safe Transaction Service would know which ABI to use.
         """

--- a/safe_transaction_service/history/views_v2.py
+++ b/safe_transaction_service/history/views_v2.py
@@ -116,7 +116,7 @@ class DelegateListView(ListCreateAPIView):
         }
         ```
 
-        For the signature we use TOTP with T0=0 and Tx=3600. TOTP is calculated by taking the
+        For the signature we use `TOTP` with `T0=0` and `Tx=3600`. `TOTP` is calculated by taking the
         Unix UTC epoch time (no milliseconds) and dividing by 3600 (natural division, no decimals).
         """
         return super().post(request, **kwargs)
@@ -138,7 +138,7 @@ class DelegateDeleteView(GenericAPIView):
         """
         Removes every delegate/delegator pair found associated with a given delegate address. The
         signature is built the same way as for adding a delegate, but in this case the signer can be
-        either the delegator (owner) or the delegate itself. Check POST /delegates/ to learn more
+        either the `delegator` (owner) or the `delegate` itself. Check `POST /delegates/` to learn more.
         """
         if not fast_is_checksum_address(delegate_address):
             return Response(


### PR DESCRIPTION
Related with https://github.com/safe-global/safe-transaction-service/issues/2071

Detected in QA validation. Missed in https://github.com/safe-global/safe-transaction-service/pull/2114
