### PR TITLE
Revert "4337: Use timestamps with milliseconds"

### DIFF
--- a/safe_transaction_service/account_abstraction/serializers.py
+++ b/safe_transaction_service/account_abstraction/serializers.py
@@ -208,7 +208,7 @@ class SafeOperationSerializer(
         attrs = super().validate(attrs)
 
         valid_after, valid_until = [
-            int(attrs[key].timestamp() * 1_000) if attrs[key] else 0
+            int(attrs[key].timestamp()) if attrs[key] else 0
             for key in ("valid_after", "valid_until")
         ]
         if valid_after and valid_until and valid_after > valid_until:

--- a/safe_transaction_service/account_abstraction/tests/test_views.py
+++ b/safe_transaction_service/account_abstraction/tests/test_views.py
@@ -518,7 +518,7 @@ class TestAccountAbstractionViews(SafeTestCaseMixin, APITestCase):
         valid_until = timezone.now() + datetime.timedelta(minutes=90)
         data["valid_until"] = datetime_to_str(valid_until)
         new_safe_operation = dataclasses.replace(
-            safe_operation, valid_until=int(valid_until.timestamp() * 1_000)
+            safe_operation, valid_until=int(valid_until.timestamp())
         )
         safe_operation_hash = new_safe_operation.get_safe_operation_hash(
             safe_4337_chain_id_mock, safe_4337_module_address_mock


### PR DESCRIPTION
- Reverts safe-global/safe-transaction-service#2134
- Timestamps are in seconds