### PR TITLE
Don't generate SafeLastStatus when fixing out of order txs

### DIFF
--- a/safe_transaction_service/history/services/index_service.py
+++ b/safe_transaction_service/history/services/index_service.py
@@ -382,7 +382,6 @@ class IndexService:
         ).delete()
         logger.info("[%s] Removing and rebuilding SafeLastStatus", address)
         SafeLastStatus.objects.filter(address=address).delete()
-        SafeLastStatus.objects.get_or_generate(address)
         logger.info("[%s] Ended fixing out of order", address)
 
     def reprocess_addresses(self, addresses: List[ChecksumAddress]):

--- a/safe_transaction_service/history/tests/test_index_service.py
+++ b/safe_transaction_service/history/tests/test_index_service.py
@@ -191,5 +191,5 @@ class TestIndexService(EthereumTestCaseMixin, TestCase):
             index_service.fix_out_of_order(safe_address, safe_status_3.internal_tx)
         )
         self.assertEqual(SafeStatus.objects.count(), 3)
-        self.assertEqual(SafeLastStatus.objects.count(), 1)
+        self.assertEqual(SafeLastStatus.objects.count(), 0)
         self.assertEqual(MultisigTransaction.objects.count(), 4)


### PR DESCRIPTION
- If SafeStatus is removed, `SafeLastStatus` cannot be generated and fixing cannot be performed
