### PR TITLE
Clean cache after deleting txs

### DIFF
--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -146,12 +146,18 @@ class SafeTxProcessor(TxProcessor):
             Version("1.3.0"),  # ChainId was included
         )
 
-    def clear_cache(self, safe_address: Optional[ChecksumAddress] = None) -> None:
+    def clear_cache(self, safe_address: Optional[ChecksumAddress] = None) -> bool:
+        """
+        :param safe_address:
+        :return: `True` if anything was deleted from cache, `False` otherwise
+        """
         if safe_address:
-            if safe_address in self.safe_last_status_cache:
+            if result := (safe_address in self.safe_last_status_cache):
                 del self.safe_last_status_cache[safe_address]
+            return result
         else:
             self.safe_last_status_cache.clear()
+            return True
 
     def is_failed(
         self, ethereum_tx: EthereumTx, safe_tx_hash: Union[HexStr, bytes]

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -1101,11 +1101,11 @@ class InternalTx(models.Model):
 
 
 class InternalTxDecodedManager(BulkCreateSignalMixin, models.Manager):
-    def out_of_order_for_safe(self, safe_address: ChecksumAddress):
+    def out_of_order_for_safe(self, safe_address: ChecksumAddress) -> bool:
         """
         :param safe_address:
-        :return: `True` if there are transactions out of order (processed transactions newer
-            than no processed transactions, due to a reindex), `False` otherwise
+        :return: `True` if there are internal txs out of order (processed newer
+            than no processed, e.g. due to a reindex), `False` otherwise
         """
 
         return (

--- a/safe_transaction_service/history/services/index_service.py
+++ b/safe_transaction_service/history/services/index_service.py
@@ -354,7 +354,9 @@ class IndexService:
         queryset.update(processed=False)
 
     @transaction.atomic
-    def fix_out_of_order(self, address: ChecksumAddress, internal_tx: InternalTx):
+    def fix_out_of_order(
+        self, address: ChecksumAddress, internal_tx: InternalTx
+    ) -> None:
         """
         Fix a Safe that has transactions out of order (not processed transactions
         in between processed ones, usually due a reindex), by reprocessing all of them
@@ -372,7 +374,10 @@ class IndexService:
             tx_hash_hex,
             timestamp,
         )
-        logger.info("[%s] Marking InternalTxDecoded as not processed", address)
+        logger.info(
+            "[%s] Marking InternalTxDecoded newer than timestamp as not processed",
+            address,
+        )
         InternalTxDecoded.objects.filter(
             internal_tx___from=address, internal_tx__timestamp__gte=timestamp
         ).update(processed=False)
@@ -380,7 +385,7 @@ class IndexService:
         SafeStatus.objects.filter(
             address=address, internal_tx__timestamp__gte=timestamp
         ).delete()
-        logger.info("[%s] Removing and rebuilding SafeLastStatus", address)
+        logger.info("[%s] Removing SafeLastStatus", address)
         SafeLastStatus.objects.filter(address=address).delete()
         logger.info("[%s] Ended fixing out of order", address)
 

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -453,13 +453,13 @@ def process_decoded_internal_txs_for_safe_task(
             # Check if a new decoded tx appeared before other already processed (due to a reindex)
             if InternalTxDecoded.objects.out_of_order_for_safe(safe_address):
                 logger.error("[%s] Found out of order transactions", safe_address)
-                tx_processor.clear_cache(safe_address)
                 index_service.fix_out_of_order(
                     safe_address,
                     InternalTxDecoded.objects.pending_for_safe(safe_address)[
                         0
                     ].internal_tx,
                 )
+                tx_processor.clear_cache(safe_address)
 
             # Use chunks for memory issues
             number_processed = 0


### PR DESCRIPTION
- It shouldn't be an issue, but I think it's cleaner
- Improve logging
- Return `boolean` when cleaning `TxProcessor` cache
