### PR TITLE
Refactor all-transactions endpoint

### DIFF
--- a/safe_transaction_service/history/services/transaction_service.py
+++ b/safe_transaction_service/history/services/transaction_service.py
@@ -4,15 +4,13 @@ from collections import defaultdict
 from datetime import timedelta
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
-from django.conf import settings
-from django.db.models import Case, Exists, F, OuterRef, QuerySet, Subquery, Value, When
+from django.db.models import QuerySet
 from django.utils import timezone
 
 from eth_typing import ChecksumAddress, HexStr
 from redis import Redis
 
 from gnosis.eth import EthereumClient, get_auto_ethereum_client
-from gnosis.eth.django.models import Uint256Field
 
 from safe_transaction_service.tokens.models import Token
 from safe_transaction_service.utils.redis import get_redis
@@ -21,10 +19,10 @@ from ..models import (
     ERC20Transfer,
     ERC721Transfer,
     EthereumTx,
-    EthereumTxCallType,
     InternalTx,
     ModuleTransaction,
     MultisigTransaction,
+    SafeRelevantTransaction,
     TransferDict,
 )
 from ..serializers import (
@@ -129,185 +127,25 @@ class TransactionService:
     def get_all_tx_identifiers(
         self,
         safe_address: str,
-        executed: bool = False,
-        queued: bool = True,
-        trusted: bool = True,
     ) -> QuerySet:
         """
-        Build a queryset with identifiers (`safeTxHash` or `txHash`) for every tx for a Safe for paginated filtering.
-        In the case of Multisig Transactions, as some of them are not mined, we use the `safeTxHash`.
-        Criteria for building this list:
-          - Return ``SafeTxHash`` for every MultisigTx (even not executed)
-          - The endpoint should only show incoming transactions that have been mined
-          - The transactions should be sorted by execution date. If an outgoing transaction doesn't have an execution
-          date the execution date of the transaction with the same nonce that has been executed should be taken.
-          - Incoming and outgoing transfers or Eth/tokens must be under a Multisig/Module Tx if triggered by one.
-          Otherwise they should have their own entry in the list using a EthereumTx
+        Build a queryset with all the executed `ethereum transactions` for a Safe for paginated filtering.
+        That includes:
+        - MultisigTransactions
+        - ModuleTransactions
+        - ERC20/721 transfers
+        - Incoming native token transfers
 
         :param safe_address:
-        :param executed: By default `False`, all transactions are returned. With `True`, just txs executed are returned.
-        :param queued: By default `True`, all transactions are returned. With `False`, just txs with
-        `nonce < current Safe Nonce` are returned.
-        :param trusted: By default `True`, just txs that are trusted are returned (with at least one confirmation,
-        sent by a delegate or indexed). With `False` all txs are returned
-        :return: List with tx hashes sorted by date (newest first)
+        :return: Querylist with elements from `SafeRelevantTransaction` model
         """
         logger.debug(
-            "Safe=%s Getting all tx identifiers executed=%s queued=%s trusted=%s",
+            "[%s] Getting all tx identifiers",
             safe_address,
-            executed,
-            queued,
-            trusted,
         )
-        # If tx is not mined, get the execution date of a tx mined with the same nonce
-        case = Case(
-            When(
-                ethereum_tx__block=None,
-                then=MultisigTransaction.objects.filter(
-                    safe=OuterRef("safe"), nonce=OuterRef("nonce")
-                )
-                .exclude(ethereum_tx__block=None)
-                .values("ethereum_tx__block__timestamp"),
-            ),
-            default=F("ethereum_tx__block__timestamp"),
+        return SafeRelevantTransaction.objects.filter(safe=safe_address).order_by(
+            "-timestamp", "ethereum_tx_id"
         )
-        multisig_safe_tx_ids = (
-            MultisigTransaction.objects.filter(safe=safe_address)
-            .annotate(
-                execution_date=case,
-                block=F("ethereum_tx__block_id"),
-                safe_nonce=F("nonce"),
-            )
-            .values(
-                "safe_tx_hash",  # Tricky, we will merge SafeTx hashes with EthereumTx hashes
-                "execution_date",
-                "created",
-                "block",
-                "safe_nonce",
-            )
-            .order_by("-execution_date")
-        )
-        # Block is needed to get stable ordering
-
-        if not queued:  # Filter out txs with nonce >= Safe nonce
-            last_nonce_query = (
-                MultisigTransaction.objects.filter(safe=safe_address)
-                .executed()
-                .order_by("-nonce")
-                .values("nonce")
-            )
-            multisig_safe_tx_ids = multisig_safe_tx_ids.filter(
-                nonce__lte=Subquery(last_nonce_query[:1])
-            )
-
-        if trusted:  # Just show trusted transactions
-            multisig_safe_tx_ids = multisig_safe_tx_ids.trusted()
-
-        if executed:
-            multisig_safe_tx_ids = multisig_safe_tx_ids.executed()
-
-        # Get module txs
-        module_tx_ids = (
-            ModuleTransaction.objects.filter(safe=safe_address)
-            .annotate(
-                execution_date=F("created"),
-                block=F("internal_tx__block_number"),
-                safe_nonce=Value(0, output_field=Uint256Field()),
-            )
-            .values(
-                "internal_tx__ethereum_tx_id",
-                "execution_date",
-                "created",
-                "block",
-                "safe_nonce",
-            )
-            .order_by("-execution_date")
-        )
-
-        multisig_hashes = MultisigTransaction.objects.filter(
-            safe=safe_address, ethereum_tx_id=OuterRef("ethereum_tx_id")
-        )
-        module_hashes = ModuleTransaction.objects.filter(
-            safe=safe_address, internal_tx__ethereum_tx_id=OuterRef("ethereum_tx_id")
-        )
-
-        # Get incoming/outgoing tokens not included on Multisig or Module txs.
-        # Outgoing tokens can be triggered by another user after the Safe calls `approve`, that's why it will not
-        # always appear as a MultisigTransaction
-        erc20_tx_ids = (
-            ERC20Transfer.objects.to_or_from(safe_address)
-            .exclude(Exists(multisig_hashes))
-            .exclude(Exists(module_hashes))
-            .annotate(
-                execution_date=F("timestamp"),
-                created=F("timestamp"),
-                block=F("block_number"),
-                safe_nonce=Value(0, output_field=Uint256Field()),
-            )
-            .values(
-                "ethereum_tx_id", "execution_date", "created", "block", "safe_nonce"
-            )
-            .distinct()
-            .order_by("-execution_date")[
-                : settings.TX_SERVICE_ALL_TXS_ENDPOINT_LIMIT_TRANSFERS
-            ]
-        )
-
-        erc721_tx_ids = (
-            ERC721Transfer.objects.to_or_from(safe_address)
-            .exclude(Exists(multisig_hashes))
-            .exclude(Exists(module_hashes))
-            .annotate(
-                execution_date=F("timestamp"),
-                created=F("timestamp"),
-                block=F("block_number"),
-                safe_nonce=Value(0, output_field=Uint256Field()),
-            )
-            .values(
-                "ethereum_tx_id", "execution_date", "created", "block", "safe_nonce"
-            )
-            .distinct()
-            .order_by("-execution_date")[
-                : settings.TX_SERVICE_ALL_TXS_ENDPOINT_LIMIT_TRANSFERS
-            ]
-        )
-
-        # Get incoming ether txs not included on Multisig or Module txs
-        internal_tx_ids = (
-            InternalTx.objects.filter(
-                call_type=EthereumTxCallType.CALL.value,
-                value__gt=0,
-                to=safe_address,
-            )
-            .exclude(Exists(multisig_hashes))
-            .exclude(Exists(module_hashes))
-            .annotate(
-                execution_date=F("timestamp"),
-                created=F("timestamp"),
-                block=F("block_number"),
-                safe_nonce=Value(0, output_field=Uint256Field()),
-            )
-            .values(
-                "ethereum_tx_id", "execution_date", "created", "block", "safe_nonce"
-            )
-            .distinct()
-            .order_by("-execution_date")[
-                : settings.TX_SERVICE_ALL_TXS_ENDPOINT_LIMIT_TRANSFERS
-            ]
-        )
-
-        # Tricky, we merge SafeTx hashes with EthereumTx hashes
-        queryset = (
-            multisig_safe_tx_ids.union(erc20_tx_ids, all=True)
-            .union(erc721_tx_ids, all=True)
-            .union(internal_tx_ids, all=True)
-            .union(module_tx_ids, all=True)
-            .order_by("-execution_date", "-safe_nonce", "block", "-created")
-        )
-        # Order by block because `block_number < NULL`, so txs mined will have preference,
-        # and `created` to get always the same ordering with not executed transactions, as they will share
-        # the same `execution_date` that the mined tx
-        return queryset
 
     def get_all_txs_from_identifiers(
         self, safe_address: str, ids_to_search: Sequence[str]
@@ -321,7 +159,7 @@ class TransactionService:
         """
 
         logger.debug(
-            "Safe=%s Getting %d txs from identifiers", safe_address, len(ids_to_search)
+            "[%s] Getting %d txs from identifiers", safe_address, len(ids_to_search)
         )
         ids_with_cached_txs = {
             id_to_search: cached_txs
@@ -332,7 +170,7 @@ class TransactionService:
             if cached_txs
         }
         logger.debug(
-            "Safe=%s Got %d cached txs from identifiers",
+            "[%s] Got %d cached txs from identifiers",
             safe_address,
             len(ids_with_cached_txs),
         )
@@ -342,7 +180,7 @@ class TransactionService:
             if hash_to_search not in ids_with_cached_txs
         ]
         logger.debug(
-            "Safe=%s %d not cached txs from identifiers",
+            "[%s] %d not cached txs from identifiers",
             safe_address,
             len(ids_not_cached),
         )
@@ -357,7 +195,7 @@ class TransactionService:
             .order_by("-nonce", "-created")
         }
         logger.debug(
-            "Safe=%s Got %d Multisig txs from identifiers",
+            "[%s] Got %d Multisig txs from identifiers",
             safe_address,
             len(ids_with_multisig_txs),
         )
@@ -370,7 +208,7 @@ class TransactionService:
                 module_tx.internal_tx.ethereum_tx_id, []
             ).append(module_tx)
         logger.debug(
-            "Safe=%s Got %d Module txs from identifiers",
+            "[%s] Got %d Module txs from identifiers",
             safe_address,
             len(ids_with_module_txs),
         )
@@ -382,7 +220,7 @@ class TransactionService:
             ).select_related("block")
         }
         logger.debug(
-            "Safe=%s Got %d Plain Ethereum txs from identifiers",
+            "[%s] Got %d Plain Ethereum txs from identifiers",
             safe_address,
             len(ids_with_plain_ethereum_txs),
         )
@@ -418,7 +256,7 @@ class TransactionService:
             transfer_dict[transfer["transaction_hash"]].append(transfer)
 
         logger.debug(
-            "Safe=%s Got %d Transfers from identifiers", safe_address, len(transfers)
+            "[%s] Got %d Transfers from identifiers", safe_address, len(transfers)
         )
 
         # Add available information about the token on database for the transfers
@@ -433,7 +271,7 @@ class TransactionService:
             )
         }
         logger.debug(
-            "Safe=%s Got %d tokens for transfers from database",
+            "[%s] Got %d tokens for transfers from database",
             safe_address,
             len(tokens),
         )
@@ -481,7 +319,7 @@ class TransactionService:
                 )
 
         logger.debug(
-            "Safe=%s Got all transactions from tx identifiers. Storing in cache",
+            "[%s] Got all transactions from tx identifiers. Storing in cache",
             safe_address,
         )
         ids_with_txs = [
@@ -490,7 +328,7 @@ class TransactionService:
         ]
         self.store_txs_in_cache(safe_address, ids_with_txs)
         logger.debug(
-            "Safe=%s Got all transactions from tx identifiers. Stored in cache",
+            "[%s] Got all transactions from tx identifiers. Stored in cache",
             safe_address,
         )
         return list(

--- a/safe_transaction_service/history/services/transaction_service.py
+++ b/safe_transaction_service/history/services/transaction_service.py
@@ -187,7 +187,7 @@ class TransactionService:
         ids_with_multisig_txs: Dict[HexStr, List[MultisigTransaction]] = {
             multisig_tx.safe_tx_hash: [multisig_tx]
             for multisig_tx in MultisigTransaction.objects.filter(
-                safe=safe_address, safe_tx_hash__in=ids_not_cached
+                safe=safe_address, ethereum_tx_id__in=ids_not_cached
             )
             .with_confirmations_required()
             .prefetch_related("confirmations")
@@ -225,8 +225,8 @@ class TransactionService:
             len(ids_with_plain_ethereum_txs),
         )
 
-        # We also need the in/out transfers for the MultisigTxs, we add the MultisigTx Ethereum Tx hashes
-        # to not cached ids
+        # We also need the in/out transfers for the MultisigTxs,
+        # add the MultisigTx Ethereum Tx hashes to not cached ids
         all_ids = ids_not_cached + [
             multisig_tx.ethereum_tx_id
             for multisig_txs in ids_with_multisig_txs.values()

--- a/safe_transaction_service/history/tests/factories.py
+++ b/safe_transaction_service/history/tests/factories.py
@@ -31,6 +31,7 @@ from ..models import (
     SafeContractDelegate,
     SafeLastStatus,
     SafeMasterCopy,
+    SafeRelevantTransaction,
     SafeStatus,
     TokenTransfer,
 )
@@ -90,6 +91,23 @@ class TokenTransfer(DjangoModelFactory):
         model = TokenTransfer
         abstract = True
 
+    @factory.post_generation
+    def safe_relevant_tx(self, create, extracted, **kwargs):
+        if not create:
+            return
+        ethereum_tx_id = self.ethereum_tx_id
+        timestamp = self.ethereum_tx.block.timestamp
+        SafeRelevantTransaction.objects.get_or_create(
+            safe=self._from,
+            ethereum_tx_id=ethereum_tx_id,
+            defaults={"timestamp": timestamp},
+        )
+        SafeRelevantTransaction.objects.get_or_create(
+            safe=self.to,
+            ethereum_tx_id=ethereum_tx_id,
+            defaults={"timestamp": timestamp},
+        )
+
 
 class ERC20TransferFactory(TokenTransfer):
     value = factory.fuzzy.FuzzyInteger(0, 1000)
@@ -126,6 +144,16 @@ class InternalTxFactory(DjangoModelFactory):
     call_type = EthereumTxCallType.CALL.value
     trace_address = factory.Sequence(str)
     error = None
+
+    @factory.post_generation
+    def safe_relevant_tx(self, create, extracted, **kwargs):
+        if not create or not self.is_ether_transfer:
+            return
+        SafeRelevantTransaction.objects.get_or_create(
+            safe=self.to,
+            ethereum_tx_id=self.ethereum_tx_id,
+            defaults={"timestamp": self.ethereum_tx.block.timestamp},
+        )
 
 
 class InternalTxDecodedFactory(DjangoModelFactory):
@@ -230,6 +258,16 @@ class ModuleTransactionFactory(DjangoModelFactory):
     operation = FuzzyInteger(low=0, high=1)
     failed = False
 
+    @factory.post_generation
+    def safe_relevant_tx(self, create, extracted, **kwargs):
+        if not create:
+            return
+        SafeRelevantTransaction.objects.get_or_create(
+            safe=self.safe,
+            ethereum_tx_id=self.internal_tx.ethereum_tx_id,
+            defaults={"timestamp": self.internal_tx.ethereum_tx.block.timestamp},
+        )
+
 
 class MultisigTransactionFactory(DjangoModelFactory):
     class Meta:
@@ -254,6 +292,16 @@ class MultisigTransactionFactory(DjangoModelFactory):
     failed = False
     origin = factory.Faker("name")
     trusted = False
+
+    @factory.post_generation
+    def safe_relevant_tx(self, create, extracted, **kwargs):
+        if not create or not self.ethereum_tx:
+            return
+        SafeRelevantTransactionFactory(
+            safe=self.safe,
+            ethereum_tx_id=self.ethereum_tx_id,
+            timestamp=self.ethereum_tx.block.timestamp,
+        )
 
 
 class MultisigConfirmationFactory(DjangoModelFactory):
@@ -308,6 +356,15 @@ class SafeMasterCopyFactory(MonitoredAddressFactory):
 
     class Meta:
         model = SafeMasterCopy
+
+
+class SafeRelevantTransactionFactory(DjangoModelFactory):
+    timestamp = factory.LazyFunction(timezone.now)
+    ethereum_tx = factory.SubFactory(EthereumTxFactory)
+    safe = factory.LazyFunction(lambda: Account.create().address)
+
+    class Meta:
+        model = SafeRelevantTransaction
 
 
 class SafeLastStatusFactory(DjangoModelFactory):

--- a/safe_transaction_service/history/tests/factories.py
+++ b/safe_transaction_service/history/tests/factories.py
@@ -297,10 +297,10 @@ class MultisigTransactionFactory(DjangoModelFactory):
     def safe_relevant_tx(self, create, extracted, **kwargs):
         if not create or not self.ethereum_tx:
             return
-        SafeRelevantTransactionFactory(
+        SafeRelevantTransaction.objects.get_or_create(
             safe=self.safe,
             ethereum_tx_id=self.ethereum_tx_id,
-            timestamp=self.ethereum_tx.block.timestamp,
+            defaults={"timestamp": self.ethereum_tx.block.timestamp},
         )
 
 

--- a/safe_transaction_service/history/tests/test_internal_tx_indexer.py
+++ b/safe_transaction_service/history/tests/test_internal_tx_indexer.py
@@ -181,6 +181,9 @@ class TestInternalTxIndexer(TestCase):
                 )
             ),
         )
+        self.assertEqual(
+            SafeRelevantTransaction.objects.count(), 2
+        )  # 2 Ether Transfers
 
     def test_internal_tx_indexer(self):
         self._test_internal_tx_indexer()

--- a/safe_transaction_service/history/tests/test_transaction_service.py
+++ b/safe_transaction_service/history/tests/test_transaction_service.py
@@ -5,7 +5,12 @@ from django.utils import timezone
 
 from eth_account import Account
 
-from ..models import EthereumTx, ModuleTransaction, MultisigTransaction
+from ..models import (
+    EthereumTx,
+    ModuleTransaction,
+    MultisigTransaction,
+    SafeRelevantTransaction,
+)
 from ..services.transaction_service import (
     TransactionService,
     TransactionServiceProvider,
@@ -32,71 +37,50 @@ class TestTransactionService(TestCase):
     def test_get_all_tx_identifiers(self):
         transaction_service: TransactionService = self.transaction_service
         safe_address = Account.create().address
+        relevant_queryset = SafeRelevantTransaction.objects.filter(safe=safe_address)
         self.assertFalse(transaction_service.get_all_tx_identifiers(safe_address))
 
-        # Factories create the models using current datetime, so as the txs are returned sorted they should be
-        # in the reverse order that they were created
+        # Factories create the models using current datetime, so as the txs are returned
+        # sorted they should be in the reverse order that they were created
         multisig_transaction = MultisigTransactionFactory(safe=safe_address)
+        self.assertEqual(relevant_queryset.count(), 1)
         multisig_transaction_not_mined = MultisigTransactionFactory(
             safe=safe_address, nonce=multisig_transaction.nonce, ethereum_tx=None
         )
+        self.assertEqual(relevant_queryset.count(), 1)
         module_transaction = ModuleTransactionFactory(safe=safe_address)
+        self.assertEqual(relevant_queryset.count(), 2)
         internal_tx_in = InternalTxFactory(to=safe_address, value=4)
+        self.assertEqual(relevant_queryset.count(), 3)
         internal_tx_out = InternalTxFactory(
             _from=safe_address, value=5
         )  # Should not appear
+        self.assertEqual(relevant_queryset.count(), 3)
         erc20_transfer_in = ERC20TransferFactory(to=safe_address)
-        erc20_transfer_out = ERC20TransferFactory(
-            _from=safe_address
-        )  # Should not appear
+        self.assertEqual(relevant_queryset.count(), 4)
+        erc20_transfer_out = ERC20TransferFactory(_from=safe_address)
+        self.assertEqual(relevant_queryset.count(), 5)
         another_multisig_transaction = MultisigTransactionFactory(safe=safe_address)
-        another_safe_multisig_transaction = (
-            MultisigTransactionFactory()
-        )  # Should not appear, it's for another Safe
+        self.assertEqual(relevant_queryset.count(), 6)
+        MultisigTransactionFactory()  # Should not appear, it's for another Safe
+        self.assertEqual(relevant_queryset.count(), 6)
 
-        # Should not appear unless queued=True, nonce > last mined transaction
-        higher_nonce_safe_multisig_transaction = MultisigTransactionFactory(
-            safe=safe_address, ethereum_tx=None
-        )
-        higher_nonce_safe_multisig_transaction_2 = MultisigTransactionFactory(
-            safe=safe_address, ethereum_tx=None
-        )
+        # Just module txs and transfers are returned
+        queryset = transaction_service.get_all_tx_identifiers(safe_address)
+        self.assertEqual(queryset.count(), 6)
 
-        # As there is no multisig tx trusted, just module txs and transfers are returned
-        self.assertEqual(
-            transaction_service.get_all_tx_identifiers(
-                safe_address, queued=False, trusted=True
-            ).count(),
-            4,
-        )
+        all_tx_hashes = [element.ethereum_tx_id for element in queryset]
+        expected_hashes = [
+            another_multisig_transaction.ethereum_tx_id,
+            erc20_transfer_out.ethereum_tx_id,
+            erc20_transfer_in.ethereum_tx_id,
+            internal_tx_in.ethereum_tx_id,
+            module_transaction.internal_tx.ethereum_tx_id,
+            multisig_transaction.ethereum_tx_id,
+        ]
+        self.assertListEqual(all_tx_hashes, expected_hashes)
 
-        # We change a queued tx, a change was not expected unless we set queued=True
-        higher_nonce_safe_multisig_transaction.trusted = True
-        higher_nonce_safe_multisig_transaction.save()
-        self.assertEqual(
-            transaction_service.get_all_tx_identifiers(
-                safe_address, queued=False, trusted=True
-            ).count(),
-            4,
-        )
-        self.assertEqual(
-            transaction_service.get_all_tx_identifiers(
-                safe_address, queued=True, trusted=True
-            ).count(),
-            5,
-        )
-
-        queryset = transaction_service.get_all_tx_identifiers(
-            safe_address, queued=True, trusted=False
-        )
-        self.assertEqual(queryset.count(), 9)
-
-        queryset = transaction_service.get_all_tx_identifiers(
-            safe_address, queued=False, trusted=False
-        )
-        self.assertEqual(queryset.count(), 7)
-
-        every_execution_date = [element["execution_date"] for element in queryset]
+        every_execution_date = [element.timestamp for element in queryset]
         expected_times = [
             another_multisig_transaction.ethereum_tx.block.timestamp,
             erc20_transfer_out.ethereum_tx.block.timestamp,
@@ -104,26 +88,8 @@ class TestTransactionService(TestCase):
             internal_tx_in.ethereum_tx.block.timestamp,
             module_transaction.internal_tx.ethereum_tx.block.timestamp,
             multisig_transaction.ethereum_tx.block.timestamp,
-            multisig_transaction.ethereum_tx.block.timestamp,  # Should take timestamp from tx with same nonce and mined
         ]
-        self.assertEqual(every_execution_date, expected_times)
-
-        all_tx_hashes = [element["safe_tx_hash"] for element in queryset]
-        expected_hashes = [
-            another_multisig_transaction.safe_tx_hash,
-            erc20_transfer_out.ethereum_tx_id,
-            erc20_transfer_in.ethereum_tx_id,
-            internal_tx_in.ethereum_tx_id,
-            module_transaction.internal_tx.ethereum_tx_id,
-            multisig_transaction.safe_tx_hash,  # First the mined tx
-            multisig_transaction_not_mined.safe_tx_hash,
-        ]
-        self.assertEqual(all_tx_hashes, expected_hashes)
-
-        queryset = transaction_service.get_all_tx_identifiers(
-            safe_address, trusted=True, queued=False
-        )
-        self.assertEqual(queryset.count(), 4)
+        self.assertListEqual(every_execution_date, expected_times)
 
     def test_get_all_tx_identifiers_executed(self):
         transaction_service: TransactionService = self.transaction_service
@@ -133,80 +99,15 @@ class TestTransactionService(TestCase):
         MultisigTransactionFactory(safe=safe_address, ethereum_tx=None)
         MultisigTransactionFactory(safe=safe_address, ethereum_tx=None)
         self.assertEqual(
-            transaction_service.get_all_tx_identifiers(
-                safe_address, queued=False, trusted=False
-            ).count(),
+            transaction_service.get_all_tx_identifiers(safe_address).count(),
             0,
         )
-        self.assertEqual(
-            transaction_service.get_all_tx_identifiers(
-                safe_address, queued=True, trusted=False
-            ).count(),
-            2,
-        )
-        # Mine tx with higher nonce, all should appear
+        # Mine tx with higher nonce, only that one is executed
         MultisigTransactionFactory(safe=safe_address)
         self.assertEqual(
-            transaction_service.get_all_tx_identifiers(
-                safe_address, queued=False, trusted=False
-            ).count(),
-            3,
-        )
-
-        # Only one is executed
-        self.assertEqual(
-            transaction_service.get_all_tx_identifiers(
-                safe_address, executed=True, queued=False, trusted=False
-            ).count(),
+            transaction_service.get_all_tx_identifiers(safe_address).count(),
             1,
         )
-
-    def test_get_all_tx_identifiers_queued(self):
-        transaction_service: TransactionService = self.transaction_service
-        safe_address = Account.create().address
-
-        # No mined tx, so nothing is returned
-        MultisigTransactionFactory(safe=safe_address, ethereum_tx=None)
-        MultisigTransactionFactory(safe=safe_address, ethereum_tx=None)
-        self.assertEqual(
-            transaction_service.get_all_tx_identifiers(
-                safe_address, queued=False, trusted=False
-            ).count(),
-            0,
-        )
-        self.assertEqual(
-            transaction_service.get_all_tx_identifiers(
-                safe_address, queued=True, trusted=False
-            ).count(),
-            2,
-        )
-
-        # Mine tx with higher nonce, all should appear
-        MultisigTransactionFactory(safe=safe_address)
-        self.assertEqual(
-            transaction_service.get_all_tx_identifiers(
-                safe_address, queued=False, trusted=False
-            ).count(),
-            3,
-        )
-
-    def test_get_all_tx_nonce_sorting(self):
-        transaction_service: TransactionService = self.transaction_service
-        safe_address = Account.create().address
-        # Test edge case of 2 multisig transactions inside the same ethereum transaction
-        m_1 = MultisigTransactionFactory(safe=safe_address, trusted=True, nonce=1)
-        MultisigTransactionFactory(
-            safe=safe_address, trusted=True, ethereum_tx=m_1.ethereum_tx, nonce=0
-        )
-
-        # Test sorting
-        queryset = transaction_service.get_all_tx_identifiers(safe_address)
-        tx_hashes = [q["safe_tx_hash"] for q in queryset]
-        transactions = transaction_service.get_all_txs_from_identifiers(
-            safe_address, tx_hashes
-        )
-        self.assertEqual(transactions[0].nonce, 1)
-        self.assertEqual(transactions[1].nonce, 0)
 
     def test_get_all_txs_from_identifiers(self):
         transaction_service: TransactionService = self.transaction_service

--- a/safe_transaction_service/history/tests/test_transaction_service.py
+++ b/safe_transaction_service/history/tests/test_transaction_service.py
@@ -124,18 +124,14 @@ class TestTransactionService(TestCase):
         internal_tx_in = InternalTxFactory(to=safe_address, value=4)
         internal_tx_out = InternalTxFactory(_from=safe_address, value=5)
         erc20_transfer_in = ERC20TransferFactory(to=safe_address)
-        erc20_transfer_out = ERC20TransferFactory(
-            _from=safe_address
-        )  # Should not appear
+        erc20_transfer_out = ERC20TransferFactory(_from=safe_address)
         another_multisig_transaction = MultisigTransactionFactory(safe=safe_address)
         another_safe_multisig_transaction = (
             MultisigTransactionFactory()
         )  # Should not appear, it's for another Safe
 
-        queryset = transaction_service.get_all_tx_identifiers(
-            safe_address, queued=False, trusted=False
-        )
-        all_tx_hashes = [q["safe_tx_hash"] for q in queryset]
+        queryset = transaction_service.get_all_tx_identifiers(safe_address)
+        all_tx_hashes = [q.ethereum_tx_id for q in queryset]
 
         self.assertEqual(len(self.transaction_service.redis.keys("tx-service:*")), 0)
         all_txs = transaction_service.get_all_txs_from_identifiers(
@@ -179,10 +175,8 @@ class TestTransactionService(TestCase):
             ethereum_tx=module_transaction.internal_tx.ethereum_tx,
         )
 
-        queryset_2 = transaction_service.get_all_tx_identifiers(
-            safe_address, queued=False, trusted=False
-        )
-        all_tx_hashes_2 = [q["safe_tx_hash"] for q in queryset_2]
+        queryset_2 = transaction_service.get_all_tx_identifiers(safe_address)
+        all_tx_hashes_2 = [q.ethereum_tx_id for q in queryset_2]
 
         all_txs_2 = transaction_service.get_all_txs_from_identifiers(
             safe_address, all_tx_hashes_2

--- a/safe_transaction_service/history/tests/test_tx_processor.py
+++ b/safe_transaction_service/history/tests/test_tx_processor.py
@@ -70,6 +70,7 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
                 fallback_handler=fallback_handler,
                 internal_tx__to=master_copy,
                 internal_tx___from=safe_address,
+                internal_tx__value=0,
             )
         )
         self.assertEqual(SafeRelevantTransaction.objects.count(), 0)
@@ -87,13 +88,16 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         tx_processor.process_decoded_transactions(
             [
                 InternalTxDecodedFactory(
-                    function_name="execTransaction", internal_tx___from=safe_address
+                    function_name="execTransaction",
+                    internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
                 InternalTxDecodedFactory(
                     function_name="addOwnerWithThreshold",
                     owner=new_owner,
                     threshold=threshold,
                     internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
             ]
         )
@@ -121,13 +125,16 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         tx_processor.process_decoded_transactions(
             [
                 InternalTxDecodedFactory(
-                    function_name="execTransaction", internal_tx___from=safe_address
+                    function_name="execTransaction",
+                    internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
                 InternalTxDecodedFactory(
                     function_name="swapOwner",
                     old_owner=owner,
                     owner=another_owner,
                     internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
             ]
         )
@@ -178,13 +185,16 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         tx_processor.process_decoded_transactions(
             [
                 InternalTxDecodedFactory(
-                    function_name="execTransaction", internal_tx___from=safe_address
+                    function_name="execTransaction",
+                    internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
                 InternalTxDecodedFactory(
                     function_name="removeOwner",
                     old_owner=another_owner,
                     threshold=threshold,
                     internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
             ]
         )
@@ -218,12 +228,15 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         tx_processor.process_decoded_transactions(
             [
                 InternalTxDecodedFactory(
-                    function_name="execTransaction", internal_tx___from=safe_address
+                    function_name="execTransaction",
+                    internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
                 InternalTxDecodedFactory(
                     function_name="setFallbackHandler",
                     fallback_handler=fallback_handler,
                     internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
             ]
         )
@@ -239,12 +252,15 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         tx_processor.process_decoded_transactions(
             [
                 InternalTxDecodedFactory(
-                    function_name="execTransaction", internal_tx___from=safe_address
+                    function_name="execTransaction",
+                    internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
                 InternalTxDecodedFactory(
                     function_name="changeMasterCopy",
                     master_copy=master_copy,
                     internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
             ]
         )
@@ -260,12 +276,15 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         tx_processor.process_decoded_transactions(
             [
                 InternalTxDecodedFactory(
-                    function_name="execTransaction", internal_tx___from=safe_address
+                    function_name="execTransaction",
+                    internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
                 InternalTxDecodedFactory(
                     function_name="enableModule",
                     module=module,
                     internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
             ]
         )
@@ -279,12 +298,15 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         tx_processor.process_decoded_transactions(
             [
                 InternalTxDecodedFactory(
-                    function_name="execTransaction", internal_tx___from=safe_address
+                    function_name="execTransaction",
+                    internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
                 InternalTxDecodedFactory(
                     function_name="disableModule",
                     module=module,
                     internal_tx___from=safe_address,
+                    internal_tx__value=0,
                 ),
             ]
         )
@@ -309,6 +331,7 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
                         function_name="execTransactionFromModule",
                         internal_tx___from=safe_address,
                         internal_tx__trace_address="0,0",
+                        internal_tx__value=0,
                     )
                 ]
             )
@@ -335,6 +358,7 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
             hash_to_approve=hash_to_approve,
             internal_tx___from=safe_address,
             internal_tx__trace_address="0,1,0",
+            internal_tx__value=0,
         )
         approve_hash_previous_call_trace = dict(call_trace)
         approve_hash_previous_call_trace["action"]["from"] = owner_approving
@@ -350,7 +374,9 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
             tx_processor.process_decoded_transactions(
                 [
                     InternalTxDecodedFactory(
-                        function_name="execTransaction", internal_tx___from=safe_address
+                        function_name="execTransaction",
+                        internal_tx___from=safe_address,
+                        internal_tx__value=0,
                     ),
                     approve_hash_decoded_tx,
                 ]

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -1,14 +1,11 @@
-import datetime
 import json
 import logging
-import pickle
 from unittest import mock
 from unittest.mock import MagicMock, PropertyMock
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.urls import reverse
-from django.utils import timezone
 
 import eth_abi
 from eth_account import Account
@@ -45,12 +42,10 @@ from ..models import (
     SafeMasterCopy,
 )
 from ..serializers import TransferType
-from ..services import TransactionServiceProvider
 from ..views import SafeMultisigTransactionListView
 from .factories import (
     ERC20TransferFactory,
     ERC721TransferFactory,
-    EthereumBlockFactory,
     EthereumTxFactory,
     InternalTxFactory,
     ModuleTransactionFactory,
@@ -271,38 +266,12 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             MultisigTransactionFactory()
         )  # Should not appear, it's for another Safe
 
-        # Should not appear unless queued=True, nonce > last mined transaction
-        higher_nonce_safe_multisig_transaction = MultisigTransactionFactory(
-            safe=safe_address, ethereum_tx=None
-        )
-        higher_nonce_safe_multisig_transaction_2 = MultisigTransactionFactory(
-            safe=safe_address, ethereum_tx=None
-        )
+        # Should not appear as they are not executed
+        for _ in range(2):
+            MultisigTransactionFactory(safe=safe_address, ethereum_tx=None)
 
         response = self.client.get(
             reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?queued=False&trusted=True"
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["count"], 4)
-
-        response = self.client.get(
-            reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?queued=True&trusted=True"
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["count"], 4)
-
-        response = self.client.get(
-            reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?queued=True&trusted=False"
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["count"], 8)
-
-        response = self.client.get(
-            reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?queued=False&trusted=False"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 6)
@@ -323,8 +292,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
 
         # Test pagination
         response = self.client.get(
-            reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?limit=3&queued=False&trusted=False"
+            reverse("v1:history:all-transactions", args=(safe_address,)) + "?limit=3"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 6)
@@ -332,7 +300,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
 
         response = self.client.get(
             reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?limit=4&offset=4&queued=False&trusted=False"
+            + "?limit=4&offset=4"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 6)
@@ -349,7 +317,6 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         )
         response = self.client.get(
             reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?queued=False&trusted=False"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 6)
@@ -385,150 +352,56 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         # No mined
         MultisigTransactionFactory(safe=safe_address, ethereum_tx=None)
         MultisigTransactionFactory(safe=safe_address, ethereum_tx=None)
-        # Mine tx with higher nonce, all should appear
+        # Mined
         MultisigTransactionFactory(safe=safe_address)
 
         response = self.client.get(
             reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?executed=False&queued=True&trusted=False"
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["count"], 3)
-
-        response = self.client.get(
-            reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?executed=True&queued=True&trusted=False"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
     def test_all_transactions_ordering(self):
         safe_address = Account.create().address
-        block_2_days_ago = EthereumBlockFactory(
-            timestamp=timezone.now() - datetime.timedelta(days=2)
-        )
-        ethereum_tx_2_days_ago = EthereumTxFactory(block=block_2_days_ago)
+
         # Older transaction
-        MultisigTransactionFactory(
-            safe=safe_address, ethereum_tx=ethereum_tx_2_days_ago
-        )
-        # Earlier transactions
-        MultisigTransactionFactory(safe=safe_address)
-        MultisigTransactionFactory(safe=safe_address)
+        erc20_transfer = ERC20TransferFactory(to=safe_address)
+        # Newer transaction
+        multisig_transaction = MultisigTransactionFactory(safe=safe_address)
+
         # Nonce is not allowed as a sorting parameter
         response = self.client.get(
             reverse("v1:history:all-transactions", args=(safe_address,))
             + "?ordering=nonce"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        response = self.client.get(
-            reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?trusted=False&ordering=execution_date"
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["count"], 3)
-        first_result = response.data["results"][0]
-        self.assertEqual(
-            first_result["transaction_hash"], ethereum_tx_2_days_ago.tx_hash
-        )
-        response = self.client.get(
-            reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?trusted=False&ordering=-execution_date"
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["count"], 3)
-        last_result = response.data["results"][2]
-        self.assertEqual(
-            last_result["transaction_hash"], ethereum_tx_2_days_ago.tx_hash
-        )
 
-    def test_all_transactions_cache_view(self):
-        safe_address = "0x54f3c8e4Bf7bFDFF39B36d1FAE4e5ceBdD93C6A9"
-        # Older transaction
-        factory_transactions = [
-            MultisigTransactionFactory(safe=safe_address),
-            MultisigTransactionFactory(safe=safe_address),
-        ]
-        # all-txs:{safe_address}
-        cache_hash_key = f"all-txs:{safe_address}"
-        # {executed}{queued}{trusted}:{limit}:{offset}:{ordering}
-        cache_query_field = "100:10:0:execution_date"
-        redis = get_redis()
-        redis.unlink(cache_hash_key)
-        cache_result = redis.hget(cache_hash_key, cache_query_field)
-        # Should be empty at the beginning
-        self.assertIsNone(cache_result)
-
+        # By default, newer transactions first
         response = self.client.get(
             reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?executed=True&queued=False&trusted=False&ordering=execution_date"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 2)
-
-        cache_result = redis.hget(cache_hash_key, cache_query_field)
-        # Should be stored in redis cache
-        self.assertIsNotNone(cache_result)
-        # Cache should content the expected values
-        cache_values, cache_count = pickle.loads(cache_result)
-        self.assertEqual(cache_count, 2)
-        for cache_value, factory_transaction in zip(cache_values, factory_transactions):
-            self.assertEqual(
-                cache_value["safe_tx_hash"], factory_transaction.safe_tx_hash
-            )
-            self.assertEqual(cache_value["created"], factory_transaction.created)
-            self.assertEqual(
-                cache_value["execution_date"], factory_transaction.execution_date
-            )
-            self.assertEqual(
-                cache_value["block"], factory_transaction.ethereum_tx.block_id
-            )
-            self.assertEqual(cache_value["safe_nonce"], factory_transaction.nonce)
-        # Modify cache to empty list
-        redis.hset(cache_hash_key, cache_query_field, pickle.dumps(([], 0)))
-        redis.expire(cache_hash_key, 60 * 10)
+        self.assertEqual(
+            response.data["results"][0]["transaction_hash"],
+            multisig_transaction.ethereum_tx_id,
+        )
+        self.assertEqual(
+            response.data["results"][1]["tx_hash"], erc20_transfer.ethereum_tx_id
+        )
         response = self.client.get(
             reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?executed=True&queued=False&trusted=False&ordering=execution_date"
+            + "?ordering=timestamp"
         )
-        # Response should be returned from cache
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["count"], 0)
-
-        # Cache should be invalidated because there is new transaction
-        MultisigTransactionFactory(safe=safe_address)
-        response = self.client.get(
-            reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?executed=True&queued=False&trusted=False&ordering=execution_date"
+        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(
+            response.data["results"][0]["tx_hash"], erc20_transfer.ethereum_tx_id
         )
-        self.assertEqual(response.data["count"], 3)
-
-    def test_all_transactions_cache_limit_offset_view(self):
-        """
-        Test limit and offset
-        """
-        safe_address = "0x54f3c8e4Bf7bFDFF39B36d1FAE4e5ceBdD93C6A9"
-        number_transactions = 100
-        transaction_service = TransactionServiceProvider()
-        for _ in range(number_transactions):
-            MultisigTransactionFactory(safe=safe_address)
-
-        for limit, offset in ((57, 12), (13, 24)):
-            with self.subTest(limit=limit, offset=offset):
-                # all-txs:{safe_address}
-                cache_hash_key = f"all-txs:{safe_address}"
-                # {executed}{queued}{trusted}:{limit}:{offset}:{ordering}:{relevant_elements}
-                cache_query_field = f"100:{limit}:{offset}:execution_date"
-                redis = get_redis()
-                self.assertFalse(redis.hexists(cache_hash_key, cache_query_field))
-
-                response = self.client.get(
-                    reverse("v1:history:all-transactions", args=(safe_address,))
-                    + f"?executed=True&queued=False&trusted=False&ordering=execution_date&limit={limit}&offset={offset}"
-                )
-                self.assertEqual(response.data["count"], number_transactions)
-                self.assertEqual(len(response.data["results"]), limit)
-                self.assertTrue(redis.hexists(cache_hash_key, cache_query_field))
+        self.assertEqual(
+            response.data["results"][1]["transaction_hash"],
+            multisig_transaction.ethereum_tx_id,
+        )
 
     def test_all_transactions_wrong_transfer_type_view(self):
         # No token in database, so we must trust the event
@@ -596,6 +469,36 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         self.assertIsNone(response.data["results"][0]["transfers"][0]["token_id"])
         self.assertEqual(response.data["results"][0]["transfers"][0]["value"], "0")
 
+    def test_all_transactions_duplicated_multisig_tx_view(self):
+        """
+        Test 2 module transactions with the same tx_hash
+        """
+        safe_address = Account.create().address
+        multisig_transaction_1 = MultisigTransactionFactory(safe=safe_address)
+        multisig_transaction_2 = MultisigTransactionFactory(
+            safe=safe_address,
+            ethereum_tx=multisig_transaction_1.ethereum_tx,
+        )
+
+        self.assertEqual(
+            multisig_transaction_1.ethereum_tx,
+            multisig_transaction_2.ethereum_tx,
+        )
+
+        response = self.client.get(
+            reverse("v1:history:all-transactions", args=(safe_address,))
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 2)
+        # We are aware of this. Pagination is done by `tx_hash`, so 2 transactions
+        # with the same `tx_hash` will return a `count` of 1
+        self.assertEqual(response.data["count"], 1)
+        # Even if they have the same `tx_hash`, tx with higher nonce will come first
+        self.assertEqual(
+            [multisig_transaction_2.safe_tx_hash, multisig_transaction_1.safe_tx_hash],
+            [multisig_tx["safe_tx_hash"] for multisig_tx in response.data["results"]],
+        )
+
     def test_all_transactions_duplicated_module_view(self):
         """
         Test 2 module transactions with the same tx_hash
@@ -614,10 +517,12 @@ class TestViews(SafeTestCaseMixin, APITestCase):
 
         response = self.client.get(
             reverse("v1:history:all-transactions", args=(safe_address,))
-            + "?queued=False&trusted=True"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["results"]), response.data["count"], 2)
+        self.assertEqual(len(response.data["results"]), 2)
+        # We are aware of this. Pagination is done by `tx_hash`, so 2 transactions
+        # with the same `tx_hash` will return a `count` of 1
+        self.assertEqual(response.data["count"], 1)
         self.assertEqual(
             {module_transaction_1.module, module_transaction_2.module},
             {module_tx["module"] for module_tx in response.data["results"]},

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -251,7 +251,7 @@ class AllTransactionsListView(ListAPIView):
         django_filters.rest_framework.DjangoFilterBackend,
         OrderingFilter,
     )
-    ordering_fields = ["execution_date"]
+    ordering_fields = ["timestamp"]
     allowed_ordering_fields = ordering_fields + [
         f"-{ordering_field}" for ordering_field in ordering_fields
     ]
@@ -325,11 +325,7 @@ class AllTransactionsListView(ListAPIView):
         if not tx_identifiers_page:
             return self.get_paginated_response([])
 
-        # Tx identifiers are retrieved using `safe_tx_hash` attribute name due to how Django
-        # handles `UNION` of all the Transaction models using the first model attribute name
-        all_tx_identifiers = [
-            element["ethereum_tx_id"] for element in tx_identifiers_page
-        ]
+        all_tx_identifiers = [element.ethereum_tx_id for element in tx_identifiers_page]
         all_txs = transaction_service.get_all_txs_from_identifiers(
             safe, all_tx_identifiers
         )
@@ -388,7 +384,7 @@ class AllTransactionsListView(ListAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
                 data={
                     "code": 1,
-                    "message": "Ordering field is not valid, only `execution_date` is allowed",
+                    "message": f"Ordering field is not valid, only f{self.allowed_ordering_fields} are allowed",
                     "arguments": [ordering],
                 },
             )

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -1,6 +1,5 @@
 import hashlib
 import logging
-import pickle
 from typing import Any, Dict, Optional, Tuple
 
 from django.conf import settings
@@ -35,7 +34,6 @@ from safe_transaction_service import __version__
 from safe_transaction_service.utils.ethereum import get_chain_id
 from safe_transaction_service.utils.utils import parse_boolean_query_param
 
-from ..utils.redis import get_redis
 from . import filters, pagination, serializers
 from .helpers import add_tokens_to_transfers, is_valid_unique_transfer_id
 from .models import (
@@ -262,53 +260,11 @@ class AllTransactionsListView(ListAPIView):
         serializers.AllTransactionsSchemaSerializer
     )  # Just for docs, not used
 
-    _schema_executed_param = openapi.Parameter(
-        "executed",
-        openapi.IN_QUERY,
-        type=openapi.TYPE_BOOLEAN,
-        default=False,
-        description="If `True` only executed transactions are returned",
-    )
-    _schema_queued_param = openapi.Parameter(
-        "queued",
-        openapi.IN_QUERY,
-        type=openapi.TYPE_BOOLEAN,
-        default=True,
-        description="If `True` transactions with `nonce >= Safe current nonce` "
-        "are also returned",
-    )
-    _schema_trusted_param = openapi.Parameter(
-        "trusted",
-        openapi.IN_QUERY,
-        type=openapi.TYPE_BOOLEAN,
-        default=True,
-        description="If `True` just trusted transactions are shown (indexed, "
-        "added by a delegate or with at least one confirmation)",
-    )
     _schema_200_response = openapi.Response(
         "A list with every element with the structure of one of these transaction"
         "types",
         serializers.AllTransactionsSchemaSerializer,
     )
-
-    def get_parameters(self) -> Tuple[bool, bool, bool]:
-        """
-        Parse query parameters:
-        - queued: Default, True. If `queued=True` transactions with `nonce >= Safe current nonce` are also shown
-        - trusted: Default, True. If `trusted=True` just trusted transactions are shown (indexed, added by a delegate
-        or with at least one confirmation)
-        :return: Tuple with queued, trusted
-        """
-        executed = parse_boolean_query_param(
-            self.request.query_params.get("executed", False)
-        )
-        queued = parse_boolean_query_param(
-            self.request.query_params.get("queued", True)
-        )
-        trusted = parse_boolean_query_param(
-            self.request.query_params.get("trusted", True)
-        )
-        return executed, queued, trusted
 
     def get_ordering_parameter(self) -> Optional[str]:
         return self.request.query_params.get(OrderingFilter.ordering_param)
@@ -316,9 +272,6 @@ class AllTransactionsListView(ListAPIView):
     def get_page_tx_identifiers(
         self,
         safe: ChecksumAddress,
-        executed: bool,
-        queued: bool,
-        trusted: bool,
         ordering: Optional[str],
         limit: int,
         offset: int,
@@ -328,9 +281,6 @@ class AllTransactionsListView(ListAPIView):
         identifiers (``safeTxHash`` or ``txHash``) filtered
 
         :param safe:
-        :param executed:
-        :param queued:
-        :param trusted:
         :param ordering:
         :param limit:
         :param offset:
@@ -339,29 +289,21 @@ class AllTransactionsListView(ListAPIView):
         transaction_service = TransactionServiceProvider()
 
         logger.debug(
-            "%s: Getting all tx identifiers for Safe=%s executed=%s queued=%s trusted=%s ordering=%s limit=%d offset=%d",
+            "%s: Getting all tx identifiers for Safe=%s ordering=%s limit=%d offset=%d",
             self.__class__.__name__,
             safe,
-            executed,
-            queued,
-            trusted,
             ordering,
             limit,
             offset,
         )
         queryset = self.filter_queryset(
-            transaction_service.get_all_tx_identifiers(
-                safe, executed=executed, queued=queued, trusted=trusted
-            )
+            transaction_service.get_all_tx_identifiers(safe)
         )
         page = self.paginate_queryset(queryset)
         logger.debug(
-            "%s: Got all tx identifiers for Safe=%s executed=%s queued=%s trusted=%s ordering=%s limit=%d offset=%d",
+            "%s: Got all tx identifiers for Safe=%s ordering=%s limit=%d offset=%d",
             self.__class__.__name__,
             safe,
-            executed,
-            queued,
-            trusted,
             ordering,
             limit,
             offset,
@@ -369,91 +311,16 @@ class AllTransactionsListView(ListAPIView):
 
         return page
 
-    def get_cached_page_tx_identifiers(
-        self,
-        safe: ChecksumAddress,
-        executed: bool,
-        queued: bool,
-        trusted: bool,
-        ordering: Optional[str],
-        limit: int,
-        offset: int,
-    ) -> Optional[Response]:
-        """
-        Cache for tx identifiers. A quick ``SQL COUNT`` in all the transactions/events
-        tables will determinate if cache for the provided values is still valid or not
-
-        :param safe:
-        :param executed:
-        :param queued:
-        :param trusted:
-        :param ordering:
-        :param limit:
-        :param offset:
-        :return:
-        """
-        transaction_service = TransactionServiceProvider()
-        cache_timeout = settings.CACHE_ALL_TXS_VIEW
-        redis = get_redis()
-
-        # Get all relevant elements for a Safe to be cached
-        cache_hash_key = transaction_service.get_all_txs_cache_hash_key(safe)
-        cache_query_field = (
-            f"{int(executed)}{int(queued)}{int(trusted)}:{limit}:{offset}:{ordering}"
-        )
-        lock_key = f"locks:{cache_hash_key}:{cache_query_field}"
-
-        logger.debug(
-            "%s: All txs from identifiers for Safe=%s executed=%s queued=%s trusted=%s lock-key=%s",
-            self.__class__.__name__,
-            safe,
-            executed,
-            queued,
-            trusted,
-            lock_key,
-        )
-        if not cache_timeout:
-            # Cache disabled
-            return self.get_page_tx_identifiers(
-                safe, executed, queued, trusted, ordering, limit, offset
-            )
-
-        with redis.lock(
-            lock_key,
-            timeout=settings.GUNICORN_REQUEST_TIMEOUT,  # This prevents a service restart to leave a lock forever
-        ):
-            if result := redis.hget(cache_hash_key, cache_query_field):
-                # Count needs to be retrieved to set it up the paginator
-                page, count = pickle.loads(result)
-                # Setting the paginator like this is not very elegant and needs to be tested really well
-                self.paginator.count = count
-                self.paginator.limit = limit
-                self.paginator.offset = offset
-                self.paginator.request = self.request
-                return page
-
-            page = self.get_page_tx_identifiers(
-                safe, executed, queued, trusted, ordering, limit, offset
-            )
-            redis.hset(
-                cache_hash_key,
-                cache_query_field,
-                pickle.dumps((page, self.paginator.count)),
-            )
-            redis.expire(cache_hash_key, cache_timeout)
-            return page
-
     def list(self, request, *args, **kwargs):
         transaction_service = TransactionServiceProvider()
         safe = self.kwargs["address"]
-        executed, queued, trusted = self.get_parameters()
         ordering = self.get_ordering_parameter()
         # Trick to get limit and offset
         list_pagination = DummyPagination(self.request)
         limit, offset = list_pagination.limit, list_pagination.offset
 
-        tx_identifiers_page = self.get_cached_page_tx_identifiers(
-            safe, executed, queued, trusted, ordering, limit, offset
+        tx_identifiers_page = self.get_page_tx_identifiers(
+            safe, ordering, limit, offset
         )
         if not tx_identifiers_page:
             return self.get_paginated_response([])
@@ -461,36 +328,27 @@ class AllTransactionsListView(ListAPIView):
         # Tx identifiers are retrieved using `safe_tx_hash` attribute name due to how Django
         # handles `UNION` of all the Transaction models using the first model attribute name
         all_tx_identifiers = [
-            element["safe_tx_hash"] for element in tx_identifiers_page
+            element["ethereum_tx_id"] for element in tx_identifiers_page
         ]
         all_txs = transaction_service.get_all_txs_from_identifiers(
             safe, all_tx_identifiers
         )
         logger.debug(
-            "%s: Got all txs from identifiers for Safe=%s executed=%s queued=%s trusted=%s",
+            "%s: Got all txs from identifiers for Safe=%s",
             self.__class__.__name__,
             safe,
-            executed,
-            queued,
-            trusted,
         )
         all_txs_serialized = transaction_service.serialize_all_txs(all_txs)
         logger.debug(
-            "%s: All txs from identifiers for Safe=%s executed=%s queued=%s trusted=%s were serialized",
+            "%s: All txs from identifiers for Safe=%s were serialized",
             self.__class__.__name__,
             safe,
-            executed,
-            queued,
-            trusted,
         )
         paginated_response = self.get_paginated_response(all_txs_serialized)
         logger.debug(
-            "%s: All txs from identifiers for Safe=%s executed=%s queued=%s trusted=%s: %s",
+            "%s: All txs from identifiers for Safe=%s: %s",
             self.__class__.__name__,
             safe,
-            executed,
-            queued,
-            trusted,
             paginated_response.data["results"],
         )
         return paginated_response
@@ -500,11 +358,6 @@ class AllTransactionsListView(ListAPIView):
             200: _schema_200_response,
             422: "code = 1: Checksum address validation failed",
         },
-        manual_parameters=[
-            _schema_executed_param,
-            _schema_queued_param,
-            _schema_trusted_param,
-        ],
     )
     def get(self, request, *args, **kwargs):
         """

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -357,16 +357,18 @@ class AllTransactionsListView(ListAPIView):
     )
     def get(self, request, *args, **kwargs):
         """
-        Returns all the transactions for a given Safe address. The list has different structures depending on the
-        transaction type:
-        - Multisig Transactions for a Safe. `tx_type=MULTISIG_TRANSACTION`. If the query parameter `queued=False` is
-        set only the transactions with `safe nonce < current Safe nonce` will be displayed. By default, only the
-        `trusted` transactions will be displayed (transactions indexed, with at least one confirmation or proposed
-        by a delegate). If you need that behaviour to be disabled set the query parameter `trusted=False`
+        Returns all the *executed* transactions for a given Safe address.
+        The list has different structures depending on the transaction type:
+        - Multisig Transactions for a Safe. `tx_type=MULTISIG_TRANSACTION`.
         - Module Transactions for a Safe. `tx_type=MODULE_TRANSACTION`
         - Incoming Transfers of Ether/ERC20 Tokens/ERC721 Tokens. `tx_type=ETHEREUM_TRANSACTION`
-          Only 1000 newest transfers will be returned.
-        Ordering_fields: ["execution_date"] eg: `execution_date` or `-execution_date`
+        Ordering_fields: ["timestamp"] eg: `-timestamp` (default one) or `timestamp`
+
+        Note: This endpoint has a bug that will be fixed in next versions of the endpoint. Pagination is done
+        using the `Transaction Hash`, and due to that the number of relevant transactions with the same
+        `Transaction Hash` cannot be known beforehand. So if there are only 2 transactions
+        with the same `Transaction Hash`, `count` of the endpoint will be 1
+        but there will be 2 transactions in the list.
         """
         address = kwargs["address"]
         if not fast_is_checksum_address(address):


### PR DESCRIPTION
- Only return executed transactions
- Don't return queued stuff anymore
- Remove `executed`, `queued` and `trusted` query params
- Refactor tests
