### PR TITLE
Add cache to all-transactions endpoint

### DIFF
--- a/safe_transaction_service/history/signals.py
+++ b/safe_transaction_service/history/signals.py
@@ -24,6 +24,7 @@ from .models import (
     SafeStatus,
     TokenTransfer,
 )
+from .services import TransactionServiceProvider
 from .services.notification_service import build_event_payload, is_relevant_notification
 
 logger = getLogger(__name__)
@@ -145,6 +146,23 @@ def get_safe_addresses_involved_from_db_instance(
     return addresses
 
 
+def _clean_all_txs_cache(
+    instance: Union[
+        TokenTransfer,
+        InternalTx,
+        MultisigConfirmation,
+        MultisigTransaction,
+    ]
+) -> None:
+    """
+    Remove the all-transactions cache related with instance modified
+    :param instance:
+    """
+    transaction_service = TransactionServiceProvider()
+    for address in get_safe_addresses_involved_from_db_instance(instance):
+        transaction_service.del_all_txs_cache_hash_key(address)
+
+
 def _process_notification_event(
     sender: Type[Model],
     instance: Union[
@@ -160,6 +178,10 @@ def _process_notification_event(
     assert not (
         created and deleted
     ), "An instance cannot be created and deleted at the same time"
+
+    # Ignore SafeContract because it is not affecting all-transaction cache.
+    if sender != SafeContract:
+        _clean_all_txs_cache(instance)
 
     logger.debug("Start building payloads for created=%s object=%s", created, instance)
     payloads = build_event_payload(sender, instance, deleted=deleted)

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import pickle
 from typing import Any, Dict, Optional, Tuple
 
 from django.conf import settings
@@ -34,6 +35,7 @@ from safe_transaction_service import __version__
 from safe_transaction_service.utils.ethereum import get_chain_id
 from safe_transaction_service.utils.utils import parse_boolean_query_param
 
+from ..utils.redis import get_redis
 from . import filters, pagination, serializers
 from .helpers import add_tokens_to_transfers, is_valid_unique_transfer_id
 from .models import (
@@ -311,6 +313,64 @@ class AllTransactionsListView(ListAPIView):
 
         return page
 
+    def get_cached_page_tx_identifiers(
+        self,
+        safe: ChecksumAddress,
+        ordering: Optional[str],
+        limit: int,
+        offset: int,
+    ) -> Optional[Response]:
+        """
+        Cache for tx identifiers. A quick ``SQL COUNT`` in all the transactions/events
+        tables will determinate if cache for the provided values is still valid or not
+        :param safe:
+        :param ordering:
+        :param limit:
+        :param offset:
+        :return:
+        """
+        transaction_service = TransactionServiceProvider()
+        cache_timeout = settings.CACHE_ALL_TXS_VIEW
+        redis = get_redis()
+
+        # Get all relevant elements for a Safe to be cached
+        cache_hash_key = transaction_service.get_all_txs_cache_hash_key(safe)
+        cache_query_field = f"{limit}:{offset}:{ordering}"
+        lock_key = f"locks:{cache_hash_key}:{cache_query_field}"
+
+        logger.debug(
+            "%s: All txs from identifiers for Safe=%s lock-key=%s",
+            self.__class__.__name__,
+            safe,
+            lock_key,
+        )
+        if not cache_timeout:
+            # Cache disabled
+            return self.get_page_tx_identifiers(safe, ordering, limit, offset)
+
+        with redis.lock(
+            lock_key,
+            timeout=settings.GUNICORN_REQUEST_TIMEOUT,  # This prevents a service restart to leave a lock forever
+        ):
+            if result := redis.hget(cache_hash_key, cache_query_field):
+                # Count needs to be retrieved to set it up the paginator
+                page, count = pickle.loads(result)
+                # Setting the paginator like this is not very elegant and needs to be tested really well
+                self.paginator.count = count
+                self.paginator.limit = limit
+                self.paginator.offset = offset
+                self.paginator.request = self.request
+                return page
+
+            page = self.get_page_tx_identifiers(safe, ordering, limit, offset)
+            redis.hset(
+                cache_hash_key,
+                cache_query_field,
+                pickle.dumps((page, self.paginator.count)),
+            )
+            redis.expire(cache_hash_key, cache_timeout)
+            return page
+
     def list(self, request, *args, **kwargs):
         transaction_service = TransactionServiceProvider()
         safe = self.kwargs["address"]
@@ -319,7 +379,7 @@ class AllTransactionsListView(ListAPIView):
         list_pagination = DummyPagination(self.request)
         limit, offset = list_pagination.limit, list_pagination.offset
 
-        tx_identifiers_page = self.get_page_tx_identifiers(
+        tx_identifiers_page = self.get_cached_page_tx_identifiers(
             safe, ordering, limit, offset
         )
         if not tx_identifiers_page:


### PR DESCRIPTION
Closes #2188 

- The cache is added again to the all-transactions endpoint, which had been removed in this [PR](https://github.com/safe-global/safe-transaction-service/pull/2166)