### PR TITLE
Bump web3 from 6.20.0 to 6.20.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ psycopg2==2.9.9
 redis==5.0.7
 requests==2.32.3
 safe-eth-py[django]==6.0.0b35
-web3==6.20.0
+web3==6.20.2


### PR DESCRIPTION

- Avoiding a type error in the CI

