### PR TITLE
Fix swagger locally is not working

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -56,4 +56,5 @@ DEBUG_TOOLBAR_CONFIG = {
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#internal-ips
 INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
 
+# Enable to get the host from header
 USE_X_FORWARDED_HOST = True

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -55,3 +55,5 @@ DEBUG_TOOLBAR_CONFIG = {
 }
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#internal-ips
 INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
+
+USE_X_FORWARDED_HOST = True

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -59,8 +59,7 @@ http {
             # redirects, we set the Host: header above already.
             proxy_redirect off;
             proxy_pass http://app_server/;
-
-            proxy_set_header X-Forwarded-Host $server_name;
+            proxy_set_header X-Forwarded-Host $host:$server_port;
             proxy_set_header X-Real-IP $remote_addr;
             add_header              Front-End-Https   on;
         }


### PR DESCRIPTION
# Description
Try endpoints from swagger always failed because the port was not included.
![image](https://github.com/user-attachments/assets/6bd385a3-89eb-4bc2-86e5-5d6505964f54)

# Other issues
-  X_FORWARDED_HOST were configured in  nginx but were not enabled in Django.
- $server_name is not configured, using the host instead.


