### PR TITLE
Optimize queries for ERC20 balances

### DIFF
--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -492,10 +492,24 @@ class TokenTransferQuerySet(models.QuerySet):
 
 
 class TokenTransferManager(BulkCreateSignalMixin, models.Manager):
-    def tokens_used_by_address(self, address: ChecksumAddress) -> Set[ChecksumAddress]:
-        return set(
-            self.to_or_from(address).values_list("address", flat=True).distinct()
-        )
+    def tokens_used_by_address(self, address: ChecksumAddress) -> list[ChecksumAddress]:
+        """
+        :param address:
+        :return: All the token addresses an `address` has sent or received
+        """
+        q1 = self.filter(_from=address).distinct()
+        q2 = self.filter(to=address).distinct()
+        return q1.union(q2).values_list("address", flat=True)
+
+    def fast_count(self, address: ChecksumAddress) -> int:
+        """
+        :param address:
+        :return: Optimized count using database indexes for the number of transfers for an address.
+                 Transfers sent from an address to itself (not really common) will be counted twice
+        """
+        q1 = self.filter(_from=address)
+        q2 = self.filter(to=address)
+        return q1.union(q2, all=True).count()
 
 
 class TokenTransfer(models.Model):

--- a/safe_transaction_service/history/services/balance_service.py
+++ b/safe_transaction_service/history/services/balance_service.py
@@ -158,7 +158,7 @@ class BalanceService:
             .filter(safe=safe_address)
             .count()
         )
-        number_erc20_events = ERC20Transfer.objects.to_or_from(safe_address).count()
+        number_erc20_events = ERC20Transfer.objects.fast_count(safe_address)
         number_eth_events = InternalTx.objects.ether_txs_for_address(
             safe_address
         ).count()

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -379,6 +379,19 @@ class TestEthereumTx(TestCase):
 
 
 class TestTokenTransfer(TestCase):
+    def test_fast_count(self):
+        address = Account.create().address
+
+        ERC20TransferFactory(to=address)
+        self.assertEqual(ERC20Transfer.objects.fast_count(address), 1)
+
+        ERC20TransferFactory(_from=address)
+        self.assertEqual(ERC20Transfer.objects.fast_count(address), 2)
+
+        # Optimization uses a UNION, so it counts transfers with `from=to` twice
+        ERC20TransferFactory(_from=address, to=address)
+        self.assertEqual(ERC20Transfer.objects.fast_count(address), 4)
+
     def test_transfer_to_erc721(self):
         erc20_transfer = ERC20TransferFactory()
         self.assertEqual(ERC721Transfer.objects.count(), 0)
@@ -410,9 +423,9 @@ class TestTokenTransfer(TestCase):
         ERC20TransferFactory()  # This event should not appear
         self.assertEqual(ERC20Transfer.objects.to_or_from(safe_address).count(), 2)
 
-        self.assertSetEqual(
+        self.assertCountEqual(
             ERC20Transfer.objects.tokens_used_by_address(safe_address),
-            {e1.address, e2.address},
+            [e1.address, e2.address],
         )
 
     def test_erc721_events(self):
@@ -422,9 +435,9 @@ class TestTokenTransfer(TestCase):
         ERC721TransferFactory()  # This event should not appear
         self.assertEqual(ERC721Transfer.objects.to_or_from(safe_address).count(), 2)
 
-        self.assertSetEqual(
+        self.assertCountEqual(
             ERC721Transfer.objects.tokens_used_by_address(safe_address),
-            {e1.address, e2.address},
+            [e1.address, e2.address],
         )
 
     def test_incoming_tokens(self):


### PR DESCRIPTION
Query for used tokens
---------------------

Before:
```
EXPLAIN ANALYZE SELECT DISTINCT "history_erc20transfer"."address"
  FROM "history_erc20transfer"
 WHERE ("history_erc20transfer"."to" = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea OR "history_erc20transfer"."_from" = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea);
                                                                        QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------
 HashAggregate  (cost=2871805.29..2871815.76 rows=1047 width=21) (actual time=96564.298..96565.725 rows=1344 loops=1)
   Group Key: address
   Batches: 1  Memory Usage: 193kB
   ->  Gather  (cost=1000.00..2865068.91 rows=2694550 width=21) (actual time=1.969..96005.333 rows=2665149 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Parallel Seq Scan on history_erc20transfer  (cost=0.00..2594613.91 rows=1122729 width=21) (actual time=0.986..96075.232 rows=888383 loops=3)
               Filter: (("to" = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea) OR (_from = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea))
               Rows Removed by Filter: 32790615
 Planning Time: 0.856 ms
 Execution Time: 96565.877 ms
(11 rows)
```

After:
```
 EXPLAIN ANALYZE SELECT DISTINCT "history_erc20transfer"."address"
  FROM "history_erc20transfer"
 WHERE ("history_erc20transfer"."_from" = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea)
UNION
SELECT DISTINCT "history_erc20transfer"."address"
  FROM "history_erc20transfer"
 WHERE ("history_erc20transfer"."to" = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea);
                                                                                                     QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 HashAggregate  (cost=574996.32..575016.95 rows=2063 width=32) (actual time=527.189..527.461 rows=1345 loops=1)
   Group Key: history_erc20transfer.address
   Batches: 1  Memory Usage: 241kB
   ->  Append  (cost=0.57..574991.17 rows=2063 width=32) (actual time=0.023..526.742 rows=1352 loops=1)
         ->  Unique  (cost=0.57..1106.00 rows=1016 width=21) (actual time=0.022..0.041 rows=8 loops=1)
               ->  Index Only Scan using history_erc__from_d88198_idx on history_erc20transfer  (cost=0.57..1096.78 rows=3690 width=21) (actual time=0.021..0.035 rows=24 loops=1)
                     Index Cond: (_from = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea)
                     Heap Fetches: 1
         ->  Unique  (cost=0.57..573854.22 rows=1047 width=21) (actual time=0.016..526.584 rows=1344 loops=1)
               ->  Index Only Scan using history_erc_to_d39948_idx on history_erc20transfer history_erc20transfer_1  (cost=0.57..567117.75 rows=2694590 width=21) (actual time=0.016..309.009 rows=2667923 loops=1)
                     Index Cond: ("to" = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea)
                     Heap Fetches: 29393
 Planning Time: 0.153 ms
 Execution Time: 527.569 ms
(14 rows)
```

Query for transfer count
------------------------

Before:
```
EXPLAIN ANALYZE SELECT COUNT(*) AS "__count"
  FROM "history_erc20transfer"
 WHERE ("history_erc20transfer"."to" = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea OR "history_erc20transfer"."_from" = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea);

---------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=2430041.15..2430041.16 rows=1 width=8) (actual time=113268.200..113269.485 rows=1 loops=1)
   ->  Gather  (cost=2430040.94..2430041.15 rows=2 width=8) (actual time=113268.143..113269.478 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=2429040.94..2429040.95 rows=1 width=8) (actual time=113264.014..113264.014 rows
=1 loops=3)
               ->  Parallel Seq Scan on history_erc20transfer  (cost=0.00..2426316.06 rows=1089950 width=0) (actual t
ime=4650.088..113194.321 rows=884515 loops=3)
                     Filter: (("to" = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea) OR (_from = '\x930dedddb92
fef1b4ab2665d250877339f064eac'::bytea))
                     Rows Removed by Filter: 30602818
 Planning Time: 0.754 ms
 Execution Time: 113269.580 ms
```

After:
```
EXPLAIN ANALYZE SELECT SUM(transfers) FROM (
    SELECT COUNT(*) AS transfers FROM "history_erc20transfer"
    WHERE "history_erc20transfer"."to" = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea
    UNION ALL
    SELECT COUNT(*) AS transfers FROM "history_erc20transfer"
    WHERE "history_erc20transfer"."_from" = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea
) as temp;
                                                                                                  QUERY PLAN

---------------------------------------------------------------------------------------------------------------------------
-----------------------------------------------------------------------------------
 Aggregate  (cost=104575.15..104575.16 rows=1 width=32) (actual time=145.724..146.996 rows=1 loops=1)
   ->  Append  (cost=104400.65..104575.14 rows=2 width=8) (actual time=145.681..146.990 rows=2 loops=1)
         ->  Finalize Aggregate  (cost=104400.65..104400.66 rows=1 width=8) (actual time=145.680..146.950 rows=1 loops=1)
               ->  Gather  (cost=104400.44..104400.65 rows=2 width=8) (actual time=145.575..146.945 rows=3 loops=1)
                     Workers Planned: 2
                     Workers Launched: 2
                     ->  Partial Aggregate  (cost=103400.44..103400.45 rows=1 width=8) (actual time=143.237..143.237 rows=1
 loops=3)
                           ->  Parallel Index Only Scan using history_erc_to_d39948_idx on history_erc20transfer  (cost=0.5
7..100496.31 rows=1161652 width=0) (actual time=0.022..90.723 rows=884527 loops=3)
                                 Index Cond: ("to" = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea)
                                 Heap Fetches: 14998
         ->  Aggregate  (cost=174.44..174.45 rows=1 width=8) (actual time=0.036..0.036 rows=1 loops=1)
               ->  Index Only Scan using history_erc__from_d88198_idx on history_erc20transfer history_erc20transfer_1  (co
st=0.57..165.68 rows=3502 width=0) (actual time=0.021..0.031 rows=24 loops=1)
                     Index Cond: (_from = '\x930dedddb92fef1b4ab2665d250877339f064eac'::bytea)
                     Heap Fetches: 1
 Planning Time: 0.157 ms
 Execution Time: 147.045 ms
(16 rows)
```
