### PR TITLE
Use Safe version 1.3.0 as default

### DIFF
--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -621,7 +621,7 @@ class SafeTxProcessor(TxProcessor):
                         self.get_safe_version_from_master_copy(
                             safe_last_status.master_copy
                         )
-                        or "1.0.0"
+                        or "1.3.0"
                     )
                 else:
                     base_gas = arguments["dataGas"]


### PR DESCRIPTION
- If Safe version cannot be detected (unofficial deployments), use 1.3.0 as default. New deployments should be always >= 1.3.0
