### PR TITLE
Refactor processing of Internal Txs

### DIFF
--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -1927,7 +1927,11 @@ class SafeStatusBase(models.Model):
         """
         SafeStatus nonce must be incremental. If current nonce is bigger than the number of SafeStatus for that Safe
         something is wrong. There could be more SafeStatus than nonce (e.g. a call to a MultiSend
-        adding owners and enabling a Module in the same contract `execTransaction`)
+        adding owners and enabling a Module in the same contract `execTransaction`), but never less.
+
+        However, there's the possibility that there isn't a problem in the indexer. For example,
+        in a L2 network a Safe could be migrated from L1 to L2 and some transactions will never be detected
+        by the indexer.
 
         :return: `True` if corrupted, `False` otherwise
         """

--- a/safe_transaction_service/history/services/index_service.py
+++ b/safe_transaction_service/history/services/index_service.py
@@ -399,7 +399,7 @@ class IndexService:
         SafeLastStatus.objects.filter(address=address).delete()
         logger.info("[%s] Ended fixing out of order", address)
 
-    def process_address(self, safe_address: ChecksumAddress) -> int:
+    def process_decoded_txs(self, safe_address: ChecksumAddress) -> int:
         """
         Process all the pending `InternalTxDecoded` for a Safe
 
@@ -417,19 +417,19 @@ class IndexService:
             self.tx_processor.clear_cache(safe_address)
 
         # Use chunks for memory issues
-        number_processed = 0
+        total_processed_txs = 0
         while True:
             internal_txs_decoded_queryset = InternalTxDecoded.objects.pending_for_safe(
                 safe_address
             )[: self.eth_internal_tx_decoded_process_batch]
             if not internal_txs_decoded_queryset:
                 break
-            number_processed += len(
+            total_processed_txs += len(
                 self.tx_processor.process_decoded_transactions(
                     internal_txs_decoded_queryset
                 )
             )
-        return number_processed
+        return total_processed_txs
 
     def reprocess_addresses(self, addresses: List[ChecksumAddress]):
         """

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -285,7 +285,7 @@ def process_decoded_internal_txs_for_safe_task(
         with only_one_running_task(self, lock_name_suffix=safe_address):
             logger.info("[%s] Start processing decoded internal txs", safe_address)
             index_service: IndexService = IndexServiceProvider()
-            number_processed = index_service.process_address(safe_address)
+            number_processed = index_service.process_decoded_txs(safe_address)
             logger.info(
                 "[%s] Processed %d decoded transactions", safe_address, number_processed
             )

--- a/safe_transaction_service/history/tests/test_index_service.py
+++ b/safe_transaction_service/history/tests/test_index_service.py
@@ -126,28 +126,28 @@ class TestIndexService(EthereumTestCaseMixin, TestCase):
         current_block_number_mock.side_effect = RequestsConnectionError
         self.assertFalse(self.index_service.is_service_synced())
 
-    def test_process_address(self):
+    def test_process_decoded_txs(self):
         safe_address = Account.create().address
         with mock.patch.object(
             IndexService, "fix_out_of_order"
         ) as fix_out_of_order_mock:
-            self.assertEqual(self.index_service.process_address(safe_address), 0)
+            self.assertEqual(self.index_service.process_decoded_txs(safe_address), 0)
             fix_out_of_order_mock.assert_not_called()
 
             # Setup for a random Safe should not be processed
             InternalTxDecodedFactory(
                 function_name="setup",
             )
-            self.assertEqual(self.index_service.process_address(safe_address), 0)
+            self.assertEqual(self.index_service.process_decoded_txs(safe_address), 0)
 
             setup_internal_tx = InternalTxDecodedFactory(
                 function_name="setup",
                 internal_tx___from=safe_address,
             )
-            self.assertEqual(self.index_service.process_address(safe_address), 1)
+            self.assertEqual(self.index_service.process_decoded_txs(safe_address), 1)
             fix_out_of_order_mock.assert_not_called()
             # After processed, it should not be processed again
-            self.assertEqual(self.index_service.process_address(safe_address), 0)
+            self.assertEqual(self.index_service.process_decoded_txs(safe_address), 0)
 
             exec_transactions = [
                 InternalTxDecodedFactory(
@@ -157,15 +157,15 @@ class TestIndexService(EthereumTestCaseMixin, TestCase):
                 for _ in range(3)
             ]
 
-            self.assertEqual(self.index_service.process_address(safe_address), 3)
+            self.assertEqual(self.index_service.process_decoded_txs(safe_address), 3)
             fix_out_of_order_mock.assert_not_called()
             # After processed, they should not be processed again
-            self.assertEqual(self.index_service.process_address(safe_address), 0)
+            self.assertEqual(self.index_service.process_decoded_txs(safe_address), 0)
 
             # Add a transaction out of order
             exec_transactions[1].processed = False
             exec_transactions[1].save(update_fields=["processed"])
-            self.assertEqual(self.index_service.process_address(safe_address), 1)
+            self.assertEqual(self.index_service.process_decoded_txs(safe_address), 1)
             # Out of order transaction was detected
             fix_out_of_order_mock.assert_called_with(
                 safe_address, exec_transactions[1].internal_tx

--- a/safe_transaction_service/history/tests/test_index_service.py
+++ b/safe_transaction_service/history/tests/test_index_service.py
@@ -23,6 +23,7 @@ from ..services.index_service import (
 )
 from .factories import (
     EthereumTxFactory,
+    InternalTxDecodedFactory,
     MultisigTransactionFactory,
     SafeMasterCopyFactory,
     SafeStatusFactory,
@@ -124,6 +125,51 @@ class TestIndexService(EthereumTestCaseMixin, TestCase):
         # Test connection error to the node
         current_block_number_mock.side_effect = RequestsConnectionError
         self.assertFalse(self.index_service.is_service_synced())
+
+    def test_process_address(self):
+        safe_address = Account.create().address
+        with mock.patch.object(
+            IndexService, "fix_out_of_order"
+        ) as fix_out_of_order_mock:
+            self.assertEqual(self.index_service.process_address(safe_address), 0)
+            fix_out_of_order_mock.assert_not_called()
+
+            # Setup for a random Safe should not be processed
+            InternalTxDecodedFactory(
+                function_name="setup",
+            )
+            self.assertEqual(self.index_service.process_address(safe_address), 0)
+
+            setup_internal_tx = InternalTxDecodedFactory(
+                function_name="setup",
+                internal_tx___from=safe_address,
+            )
+            self.assertEqual(self.index_service.process_address(safe_address), 1)
+            fix_out_of_order_mock.assert_not_called()
+            # After processed, it should not be processed again
+            self.assertEqual(self.index_service.process_address(safe_address), 0)
+
+            exec_transactions = [
+                InternalTxDecodedFactory(
+                    function_name="execTransaction",
+                    internal_tx___from=safe_address,
+                )
+                for _ in range(3)
+            ]
+
+            self.assertEqual(self.index_service.process_address(safe_address), 3)
+            fix_out_of_order_mock.assert_not_called()
+            # After processed, they should not be processed again
+            self.assertEqual(self.index_service.process_address(safe_address), 0)
+
+            # Add a transaction out of order
+            exec_transactions[1].processed = False
+            exec_transactions[1].save(update_fields=["processed"])
+            self.assertEqual(self.index_service.process_address(safe_address), 1)
+            # Out of order transaction was detected
+            fix_out_of_order_mock.assert_called_with(
+                safe_address, exec_transactions[1].internal_tx
+            )
 
     def test_reprocess_addresses(self):
         index_service: IndexService = self.index_service

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -194,10 +194,10 @@ class TestTasks(TestCase):
         SafeLastStatus.objects.update_or_create_from_safe_status(safe_status_0)
         with self.assertLogs(logger=task_logger) as cm:
             with patch.object(
-                IndexService, "process_address", return_value=5
-            ) as process_address_mock:
+                IndexService, "process_decoded_txs", return_value=5
+            ) as process_decoded_txs_mock:
                 process_decoded_internal_txs_for_safe_task.delay(safe_address)
-                process_address_mock.assert_called_with(safe_address)
+                process_decoded_txs_mock.assert_called_with(safe_address)
                 self.assertIn(
                     f"[{safe_address}] Start processing decoded internal txs",
                     cm.output[0],

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -189,46 +189,23 @@ class TestTasks(TestCase):
         self.assertEqual(SafeStatus.objects.filter(address=safe_address).count(), 0)
 
     def test_process_decoded_internal_txs_for_safe_task(self):
-        # Test corrupted SafeStatus
         safe_status_0 = SafeStatusFactory(nonce=0)
         safe_address = safe_status_0.address
-        safe_status_2 = SafeStatusFactory(nonce=2, address=safe_address)
-        safe_status_5 = SafeStatusFactory(nonce=5, address=safe_address)
-        SafeLastStatus.objects.update_or_create_from_safe_status(safe_status_5)
-        with patch.object(IndexService, "reindex_master_copies") as reindex_mock:
-            with patch.object(IndexService, "reprocess_addresses") as reprocess_mock:
-                with self.assertLogs(logger=task_logger) as cm:
-                    process_decoded_internal_txs_for_safe_task.delay(safe_address)
-                    reprocess_mock.assert_called_with([safe_address])
-                    reindex_mock.assert_called_with(
-                        safe_status_0.block_number,
-                        to_block_number=safe_status_5.block_number,
-                        addresses=[safe_address],
-                    )
-                    self.assertIn(
-                        f"[{safe_address}] A problem was found in SafeStatus "
-                        f"with nonce=2 on internal-tx-id={safe_status_2.internal_tx_id}",
-                        cm.output[1],
-                    )
-                    self.assertIn(
-                        f"[{safe_address}] Processing traces again",
-                        cm.output[2],
-                    )
-                    self.assertIn(
-                        f"[{safe_address}] Last known not corrupted SafeStatus with nonce=0 on "
-                        f"block={safe_status_0.internal_tx.ethereum_tx.block_id} , "
-                        f"reindexing until block={safe_status_5.block_number}",
-                        cm.output[3],
-                    )
-                    self.assertIn(
-                        f"Reindexing master copies from-block={safe_status_0.internal_tx.ethereum_tx.block_id} "
-                        f"to-block={safe_status_5.block_number} addresses={[safe_address]}",
-                        cm.output[4],
-                    )
-                    self.assertIn(
-                        f"[{safe_address}] Processing traces again after reindexing",
-                        cm.output[5],
-                    )
+        SafeLastStatus.objects.update_or_create_from_safe_status(safe_status_0)
+        with self.assertLogs(logger=task_logger) as cm:
+            with patch.object(
+                IndexService, "process_address", return_value=5
+            ) as process_address_mock:
+                process_decoded_internal_txs_for_safe_task.delay(safe_address)
+                process_address_mock.assert_called_with(safe_address)
+                self.assertIn(
+                    f"[{safe_address}] Start processing decoded internal txs",
+                    cm.output[0],
+                )
+                self.assertIn(
+                    f"[{safe_address}] Processed 5 decoded transactions",
+                    cm.output[1],
+                )
 
     @patch.object(CollectiblesService, "get_metadata", autospec=True, return_value={})
     def test_retry_get_metadata_task(self, get_metadata_mock: MagicMock):


### PR DESCRIPTION
- Task was refactored into a function in `IndexService`
- Automatic reindexing of Safes was disabled. Reindexing issues should be fixed by the scheduled task `reindex_mastercopies_last_hours_task`. Also some Safes were corrupted due to users trying to trick the indexer or Safes converted from L1 -> L2, and reindexing was triggered forever
- Closes #2214 