### PR TITLE
Update deprecated firebase function

### DIFF
--- a/safe_transaction_service/notifications/clients/firebase_client.py
+++ b/safe_transaction_service/notifications/clients/firebase_client.py
@@ -159,7 +159,9 @@ class FirebaseClient(MessagingClient):
             data=data,
             tokens=tokens,
         )
-        batch_response: BatchResponse = messaging.send_multicast(message, app=self.app)
+        batch_response: BatchResponse = messaging.send_each_for_multicast(
+            message, app=self.app
+        )
         responses: List[SendResponse] = batch_response.responses
         # Check if there are invalid tokens
         invalid_tokens = [

--- a/safe_transaction_service/notifications/tasks.py
+++ b/safe_transaction_service/notifications/tasks.py
@@ -112,6 +112,8 @@ def send_notification_task(
         success_count, failure_count, invalid_tokens = firebase_client.send_message(
             tokens, payload
         )
+        if failure_count:
+            logger.error("Push notification failed for %i devices", failure_count)
         if invalid_tokens:
             logger.info(
                 "Removing invalid tokens for safe=%s. Tokens=%s",

--- a/safe_transaction_service/notifications/tests/test_firebase_client.py
+++ b/safe_transaction_service/notifications/tests/test_firebase_client.py
@@ -48,7 +48,7 @@ class TestFirebaseClient(TestCase):
                     ]
                     batch_response = BatchResponse(responses)
                     with mock.patch(
-                        "firebase_admin.messaging.send_multicast",
+                        "firebase_admin.messaging.send_each_for_multicast",
                         return_value=batch_response,
                     ):
                         (


### PR DESCRIPTION
# Description
We are having issues because `send_multicast` was deprecated, updating to the new function with the same purpose. 
