### PR TITLE
Add SafeToL2Migration contract abi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ psycogreen==1.0.2
 psycopg2==2.9.9
 redis==5.0.8
 requests==2.32.3
-safe-eth-py[django]==6.0.0b37
+safe-eth-py[django]==6.0.0b38
 web3==6.20.2

--- a/safe_transaction_service/contracts/management/commands/setup_safe_contracts.py
+++ b/safe_transaction_service/contracts/management/commands/setup_safe_contracts.py
@@ -7,7 +7,7 @@ from safe_eth.safe.safe_deployments import safe_deployments
 from config.settings.base import STATICFILES_DIRS
 from safe_transaction_service.contracts.models import Contract
 
-TRUSTED_FOR_DELEGATE_CALL = ["MultiSendCallOnly", "MultiSend"]
+TRUSTED_FOR_DELEGATE_CALL = ["MultiSendCallOnly", "MultiSend", "SafeToL2Migration"]
 
 
 def generate_safe_contract_display_name(contract_name: str, version: str) -> str:

--- a/safe_transaction_service/contracts/tests/test_commands.py
+++ b/safe_transaction_service/contracts/tests/test_commands.py
@@ -60,7 +60,7 @@ class TestCommands(TestCase):
         self.assertEqual(current_no_safe_contract_logo, previous_random_contract_logo)
 
         # Missing safe addresses should be added
-        self.assertEqual(Contract.objects.count(), 19)
+        self.assertEqual(Contract.objects.count(), 22)
 
         # Contract name and display name should be correctly generated
         safe_l2_130_address = "0x3E5c63644E683549055b9Be8653de26E0B4CD36E"
@@ -91,4 +91,11 @@ class TestCommands(TestCase):
         self.assertEqual(contract.name, "MultiSendCallOnly")
         self.assertEqual(contract.display_name, "Safe: MultiSendCallOnly 1.4.1")
         # MultiSendCallOnly should be trusted for delegate calls
+        self.assertTrue(contract.trusted_for_delegate_call)
+
+        safe_to_l2_migration = "0xfF83F6335d8930cBad1c0D439A841f01888D9f69"
+        contract = Contract.objects.get(address=safe_to_l2_migration)
+        self.assertEqual(contract.name, "SafeToL2Migration")
+        self.assertEqual(contract.display_name, "SafeToL2Migration 1.4.1")
+        # SafeToL2Migration should be trusted for delegate calls
         self.assertTrue(contract.trusted_for_delegate_call)

--- a/safe_transaction_service/contracts/tx_decoder.py
+++ b/safe_transaction_service/contracts/tx_decoder.py
@@ -29,6 +29,7 @@ from safe_eth.eth.contracts import (
     get_erc721_contract,
     get_kyber_network_proxy_contract,
     get_multi_send_contract,
+    get_safe_to_l2_migration_contract,
     get_safe_V0_0_1_contract,
     get_safe_V1_0_0_contract,
     get_safe_V1_1_1_contract,
@@ -476,6 +477,9 @@ class TxDecoder(SafeTxDecoder):
         ]
 
         gnosis_safe = [gnosis_safe_allowance_module_abi]
+
+        safe_to_l2_migration = [get_safe_to_l2_migration_contract(self.dummy_w3).abi]
+
         erc_contracts = [
             get_erc721_contract(self.dummy_w3).abi,
             get_erc20_contract(self.dummy_w3).abi,
@@ -502,6 +506,7 @@ class TxDecoder(SafeTxDecoder):
             + sight_contracts
             + gnosis_protocol
             + gnosis_safe
+            + safe_to_l2_migration
             + erc_contracts
             + self.multisend_abis
             + supported_abis

--- a/safe_transaction_service/history/tests/mocks/deployments_mock.py
+++ b/safe_transaction_service/history/tests/mocks/deployments_mock.py
@@ -30,8 +30,20 @@ mainnet_deployments_1_4_1 = {
             "address": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
         },
         {
+            "contractName": "SafeMigration",
+            "address": "0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6",
+        },
+        {
             "contractName": "SafeProxyFactory",
             "address": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
+        },
+        {
+            "contractName": "SafeToL2Migration",
+            "address": "0xfF83F6335d8930cBad1c0D439A841f01888D9f69",
+        },
+        {
+            "contractName": "SafeToL2Setup",
+            "address": "0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54",
         },
         {
             "contractName": "SignMessageLib",


### PR DESCRIPTION
Closes #2243 

- Updated the tests with the new contract addresses in the `safe_deployments` file of `safe-eth-py`.
