### PR TITLE
Unpin asgiref

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-asgiref==3.7.2
 boto3==1.34.144
 cachetools==5.4.0
 celery==5.4.0


### PR DESCRIPTION
- asgiref was broken a few versions ago and was pinned, it should not be required anymore
