### PR TITLE
Add custom timeout decorator

### DIFF
--- a/safe_transaction_service/analytics/tasks.py
+++ b/safe_transaction_service/analytics/tasks.py
@@ -10,11 +10,13 @@ from safe_transaction_service.analytics.services.analytics_service import (
     AnalyticsService,
 )
 from safe_transaction_service.history.models import MultisigTransaction
+from safe_transaction_service.utils.celery import task_timeout
 from safe_transaction_service.utils.redis import get_redis
-from safe_transaction_service.utils.tasks import LOCK_TIMEOUT, SOFT_TIMEOUT
+from safe_transaction_service.utils.tasks import LOCK_TIMEOUT
 
 
-@app.shared_task(soft_time_limit=SOFT_TIMEOUT, time_limit=LOCK_TIMEOUT)
+@app.shared_task()
+@task_timeout(timeout_seconds=LOCK_TIMEOUT)
 def get_transactions_per_safe_app_task():
     today = timezone.now()
     last_week = today - relativedelta(days=7)

--- a/safe_transaction_service/tokens/tasks.py
+++ b/safe_transaction_service/tokens/tasks.py
@@ -14,6 +14,7 @@ from web3.exceptions import Web3Exception
 from safe_transaction_service.utils.ethereum import get_ethereum_network
 from safe_transaction_service.utils.utils import close_gevent_db_connection_decorator
 
+from ..utils.celery import task_timeout
 from .exceptions import TokenListRetrievalException
 from .models import Token, TokenList, TokenListToken
 
@@ -42,8 +43,9 @@ class EthValueWithTimestamp:
         return f"{self.eth_value}:{self.timestamp.timestamp()}"
 
 
-@app.shared_task(soft_time_limit=TASK_SOFT_TIME_LIMIT, time_limit=TASK_TIME_LIMIT)
+@app.shared_task()
 @close_gevent_db_connection_decorator
+@task_timeout(timeout_seconds=TASK_TIME_LIMIT)
 def fix_pool_tokens_task() -> Optional[int]:
     """
     Fix names for generic pool tokens, like Balancer or Uniswap

--- a/safe_transaction_service/utils/celery.py
+++ b/safe_transaction_service/utils/celery.py
@@ -1,6 +1,14 @@
+from functools import wraps
+from typing import Optional
+
 from celery._state import get_current_task
 from celery.app.log import TaskFormatter
-from celery.utils.log import ColorFormatter
+from celery.utils.log import ColorFormatter, get_task_logger
+from gevent import Timeout
+
+
+class TaskTimeoutException(Exception):
+    pass
 
 
 class PatchedCeleryFormatterOriginal(TaskFormatter):  # pragma: no cover
@@ -30,3 +38,31 @@ class PatchedCeleryFormatter(ColorFormatter):  # pragma: no cover
             record.__dict__.setdefault("task_name", "???")
             record.__dict__.setdefault("task_id", "???")
         return super().format(record)
+
+
+def task_timeout(timeout_seconds: int, raise_exception: Optional[bool] = False):
+    """
+    Catches Timeout exceptions and logs a clear, task-specific message. Ensures better tracking of hard limit errors and maintains consistent log formatting, improving visibility beyond Celery's generic error output.
+
+    :param timeout_seconds:
+    :param raise_exception: if True, raise TaskTimeoutException
+    :return:
+    """
+
+    def decorator(func):
+        @wraps(func)  # keep the name of the wrapped function
+        def wrapper(*args, **kwargs):
+            try:
+                with Timeout(timeout_seconds):
+                    return func(*args, **kwargs)
+            except Timeout:
+                logger = get_task_logger(func.__name__)
+                logger.error("Task exceeded timeout %i seconds", timeout_seconds)
+                if raise_exception:
+                    logger.error("Raising exception")
+                    raise TaskTimeoutException()
+                return None
+
+        return wrapper
+
+    return decorator

--- a/safe_transaction_service/utils/celery.py
+++ b/safe_transaction_service/utils/celery.py
@@ -42,7 +42,9 @@ class PatchedCeleryFormatter(ColorFormatter):  # pragma: no cover
 
 def task_timeout(timeout_seconds: int, raise_exception: Optional[bool] = False):
     """
-    Catches Timeout exceptions and logs a clear, task-specific message. Ensures better tracking of hard limit errors and maintains consistent log formatting, improving visibility beyond Celery's generic error output.
+    Catches Timeout exceptions and logs a clear, task-specific message.
+    Ensures better tracking of hard limit errors and maintains consistent log formatting,
+    improving visibility beyond Celery's generic error output.
 
     :param timeout_seconds:
     :param raise_exception: if True, raise TaskTimeoutException
@@ -57,9 +59,8 @@ def task_timeout(timeout_seconds: int, raise_exception: Optional[bool] = False):
                     return func(*args, **kwargs)
             except Timeout:
                 logger = get_task_logger(func.__name__)
-                logger.error("Task exceeded timeout %i seconds", timeout_seconds)
+                logger.error("Task timeout exceeded: %i seconds", timeout_seconds)
                 if raise_exception:
-                    logger.error("Raising exception")
                     raise TaskTimeoutException()
                 return None
 


### PR DESCRIPTION
### Description
This PR adds a custom timeout using the `gevent` timeout (the same that is using Celery) adding some improvements to Celery implementation:
- Log the task timeout errors following our log format
- Can raise an exception if necessary
- Task timeouts can be retried
- Remove unused soft timeout (`Celery` with `gevent` is not using it)

## Example with Celery
```
@app.shared_task(bind=True,
    soft_time_limit=2,
    time_limit=5,
    autoretry_for=(TimeLimitExceeded,),
    default_retry_delay=15,
    retry_kwargs={"max_retries": 3},)
def task_timeout_error(self):
    url = "https://httpbin.org/delay/10"
    logger.info("Start task_timeout_error")
    response = requests.get(url, timeout=10)
```
Output:
```
indexer-worker-1  | 2024-10-10 11:52:08,306 [INFO] [36eb5567/task_timeout_error] Start task_timeout_error
indexer-worker-1  | 2024-10-10 11:52:13,318 [ERROR] [???/???] Hard time limit (5s) exceeded for safe_transaction_service.history.tasks.task_timeout_error[36eb5567-d346-4baa-9bf9-434d29faa58f]
```
In this case Celery is catching the exception and for this reason the retries didn't work.

## New example with Celery
```
@app.shared_task(bind=True,
    autoretry_for=(TaskTimeoutException,),
    default_retry_delay=15,
    retry_kwargs={"max_retries": 3},)
@task_timeout(timeout_seconds=5, raise_exception=True)
def task_timeout_with_gevent_retry(self):
    url = "https://httpbin.org/delay/10"
    logger.info("Start task_timeout_with_gevent")
    response = requests.get(url, timeout=10)
```
Output:
```
indexer-worker-1  | 2024-10-10 11:52:47,844 [INFO] [79c63f2d/task_timeout_with_gevent_retry] Start task_timeout_with_gevent
indexer-worker-1  | 2024-10-10 11:52:52,848 [ERROR] [79c63f2d/task_timeout_with_gevent_retry] Task exceeded timeout 5 seconds
indexer-worker-1  | 2024-10-10 11:52:52,848 [ERROR] [79c63f2d/task_timeout_with_gevent_retry] Raising exception
indexer-worker-1  | 2024-10-10 11:52:52,891 [INFO] [79c63f2d/task_timeout_with_gevent_retry] Task safe_transaction_service.history.tasks.task_timeout_with_gevent_retry[79c63f2d-3f43-4790-a986-01b6df753198] retry: Retry in 15s: TaskTimeoutException()
indexer-worker-1  | 2024-10-10 11:53:07,852 [INFO] [79c63f2d/task_timeout_with_gevent_retry] Start task_timeout_with_gevent
indexer-worker-1  | 2024-10-10 11:53:12,855 [ERROR] [79c63f2d/task_timeout_with_gevent_retry] Task exceeded timeout 5 seconds
indexer-worker-1  | 2024-10-10 11:53:12,855 [ERROR] [79c63f2d/task_timeout_with_gevent_retry] Raising exception
indexer-worker-1  | 2024-10-10 11:53:12,868 [INFO] [79c63f2d/task_timeout_with_gevent_retry] Task safe_transaction_service.history.tasks.task_timeout_with_gevent_retry[79c63f2d-3f43-4790-a986-01b6df753198] retry: Retry in 15s: TaskTimeoutException()
indexer-worker-1  | 2024-10-10 11:53:27,858 [INFO] [79c63f2d/task_timeout_with_gevent_retry] Start task_timeout_with_gevent
indexer-worker-1  | 2024-10-10 11:53:32,861 [ERROR] [79c63f2d/task_timeout_with_gevent_retry] Task exceeded timeout 5 seconds
indexer-worker-1  | 2024-10-10 11:53:32,861 [ERROR] [79c63f2d/task_timeout_with_gevent_retry] Raising exception
indexer-worker-1  | 2024-10-10 11:53:32,873 [INFO] [79c63f2d/task_timeout_with_gevent_retry] Task safe_transaction_service.history.tasks.task_timeout_with_gevent_retry[79c63f2d-3f43-4790-a986-01b6df753198] retry: Retry in 15s: TaskTimeoutException()
indexer-worker-1  | 2024-10-10 11:53:47,864 [INFO] [79c63f2d/task_timeout_with_gevent_retry] Start task_timeout_with_gevent
indexer-worker-1  | 2024-10-10 11:53:52,865 [ERROR] [79c63f2d/task_timeout_with_gevent_retry] Task exceeded timeout 5 seconds
indexer-worker-1  | 2024-10-10 11:53:52,865 [ERROR] [79c63f2d/task_timeout_with_gevent_retry] Raising exception
indexer-worker-1  | 2024-10-10 11:53:52,877 [ERROR] [79c63f2d/task_timeout_with_gevent_retry] Task safe_transaction_service.history.tasks.task_timeout_with_gevent_retry[79c63f2d-3f43-4790-a986-01b6df753198] raised unexpected: TaskTimeoutException()
indexer-worker-1  | Traceback (most recent call last):
indexer-worker-1  |   File "/app/safe_transaction_service/utils/celery.py", line 54, in wrapper
indexer-worker-1  |     return func(*args, **kwargs)
indexer-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/app/safe_transaction_service/history/tasks.py", line 522, in task_timeout_with_gevent_retry
indexer-worker-1  |     response = requests.get(url, timeout=10)
indexer-worker-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/requests/api.py", line 73, in get
indexer-worker-1  |     return request("get", url, params=params, **kwargs)
indexer-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/requests/api.py", line 59, in request
indexer-worker-1  |     return session.request(method=method, url=url, **kwargs)
indexer-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 589, in request
indexer-worker-1  |     resp = self.send(prep, **send_kwargs)
indexer-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 703, in send
indexer-worker-1  |     r = adapter.send(request, **kwargs)
indexer-worker-1  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/requests/adapters.py", line 667, in send
indexer-worker-1  |     resp = conn.urlopen(
indexer-worker-1  |            ^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 789, in urlopen
indexer-worker-1  |     response = self._make_request(
indexer-worker-1  |                ^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 536, in _make_request
indexer-worker-1  |     response = conn.getresponse()
indexer-worker-1  |                ^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/urllib3/connection.py", line 507, in getresponse
indexer-worker-1  |     httplib_response = super().getresponse()
indexer-worker-1  |                        ^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/http/client.py", line 1428, in getresponse
indexer-worker-1  |     response.begin()
indexer-worker-1  |   File "/usr/local/lib/python3.12/http/client.py", line 331, in begin
indexer-worker-1  |     version, status, reason = self._read_status()
indexer-worker-1  |                               ^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/http/client.py", line 292, in _read_status
indexer-worker-1  |     line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
indexer-worker-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/socket.py", line 720, in readinto
indexer-worker-1  |     return self._sock.recv_into(b)
indexer-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/gevent/ssl.py", line 625, in recv_into
indexer-worker-1  |     return self.read(nbytes, buffer)
indexer-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/gevent/ssl.py", line 440, in read
indexer-worker-1  |     self._wait(self._read_event, timeout_exc=_SSLErrorReadTimeout)
indexer-worker-1  |   File "src/gevent/_hub_primitives.py", line 317, in gevent._gevent_c_hub_primitives.wait_on_socket
indexer-worker-1  |   File "src/gevent/_hub_primitives.py", line 322, in gevent._gevent_c_hub_primitives.wait_on_socket
indexer-worker-1  |   File "src/gevent/_hub_primitives.py", line 313, in gevent._gevent_c_hub_primitives._primitive_wait
indexer-worker-1  |   File "src/gevent/_hub_primitives.py", line 314, in gevent._gevent_c_hub_primitives._primitive_wait
indexer-worker-1  |   File "src/gevent/_hub_primitives.py", line 46, in gevent._gevent_c_hub_primitives.WaitOperationsGreenlet.wait
indexer-worker-1  |   File "src/gevent/_hub_primitives.py", line 46, in gevent._gevent_c_hub_primitives.WaitOperationsGreenlet.wait
indexer-worker-1  |   File "src/gevent/_hub_primitives.py", line 55, in gevent._gevent_c_hub_primitives.WaitOperationsGreenlet.wait
indexer-worker-1  |   File "src/gevent/_waiter.py", line 154, in gevent._gevent_c_waiter.Waiter.get
indexer-worker-1  |   File "src/gevent/_greenlet_primitives.py", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
indexer-worker-1  |   File "src/gevent/_greenlet_primitives.py", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
indexer-worker-1  |   File "src/gevent/_greenlet_primitives.py", line 65, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
indexer-worker-1  |   File "src/gevent/_gevent_c_greenlet_primitives.pxd", line 35, in gevent._gevent_c_greenlet_primitives._greenlet_switch
indexer-worker-1  | gevent.timeout.Timeout: 5 seconds
indexer-worker-1  | 
indexer-worker-1  | During handling of the above exception, another exception occurred:
indexer-worker-1  | 
indexer-worker-1  | Traceback (most recent call last):
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/celery/app/trace.py", line 453, in trace_task
indexer-worker-1  |     R = retval = fun(*args, **kwargs)
indexer-worker-1  |                  ^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/celery/app/trace.py", line 736, in __protected_call__
indexer-worker-1  |     return self.run(*args, **kwargs)
indexer-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/celery/app/autoretry.py", line 60, in run
indexer-worker-1  |     ret = task.retry(exc=exc, **retry_kwargs)
indexer-worker-1  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/celery/app/task.py", line 736, in retry
indexer-worker-1  |     raise_with_context(exc)
indexer-worker-1  |   File "/usr/local/lib/python3.12/site-packages/celery/app/autoretry.py", line 38, in run
indexer-worker-1  |     return task._orig_run(*args, **kwargs)
indexer-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
indexer-worker-1  |   File "/app/safe_transaction_service/utils/celery.py", line 60, in wrapper
indexer-worker-1  |     raise TaskTimeoutException()
indexer-worker-1  | safe_transaction_service.utils.celery.TaskTimeoutException
```
With the new implementation, the exception is raised, and retries work. Even when the maximum number of retries is reached, the exception trace will be logged, helping us to find the reason. 