### PR TITLE
Fix caching issues on tx-processor

### DIFF
--- a/safe_transaction_service/history/services/index_service.py
+++ b/safe_transaction_service/history/services/index_service.py
@@ -427,7 +427,6 @@ class IndexService:
                 safe_address,
                 InternalTxDecoded.objects.pending_for_safe(safe_address)[0].internal_tx,
             )
-            self.tx_processor.clear_cache(safe_address)
 
         # Use chunks for memory issues
         total_processed_txs = 0


### PR DESCRIPTION
- TxProcessor was shared between tasks, so cache was deleted for all of them
- Now only the involved Safe is deleted from the processor
- If there's an error processing a transaction, previously cache could become broken. Now a `finally` is used to make sure it's always cleaned
