### PR TITLE
Enable SignMessageLib as trusted for delegates by default

### DIFF
--- a/safe_transaction_service/contracts/management/commands/setup_safe_contracts.py
+++ b/safe_transaction_service/contracts/management/commands/setup_safe_contracts.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--force-update-contracts",
-            help="Update all the information related to the safe contracts",
+            help="Update all the information related to the Safe contracts",
             action="store_true",
             default=False,
         )

--- a/safe_transaction_service/contracts/management/commands/setup_safe_contracts.py
+++ b/safe_transaction_service/contracts/management/commands/setup_safe_contracts.py
@@ -7,7 +7,12 @@ from safe_eth.safe.safe_deployments import safe_deployments
 from config.settings.base import STATICFILES_DIRS
 from safe_transaction_service.contracts.models import Contract
 
-TRUSTED_FOR_DELEGATE_CALL = ["MultiSendCallOnly", "MultiSend", "SafeToL2Migration"]
+TRUSTED_FOR_DELEGATE_CALL = [
+    "MultiSendCallOnly",
+    "MultiSend",
+    "SafeToL2Migration",
+    "SignMessageLib",
+]
 
 
 def generate_safe_contract_display_name(contract_name: str, version: str) -> str:
@@ -35,8 +40,8 @@ class Command(BaseCommand):
             "--safe-version", type=str, help="Contract version", required=False
         )
         parser.add_argument(
-            "--force-update-contract-names",
-            help="Update all the safe contract names and display names",
+            "--force-update-contracts",
+            help="Update all the information related to the safe contracts",
             action="store_true",
             default=False,
         )
@@ -57,7 +62,7 @@ class Command(BaseCommand):
         :return:
         """
         safe_version = options["safe_version"]
-        force_update_contract_names = options["force_update_contract_names"]
+        force_update_contracts = options["force_update_contracts"]
         logo_path = options["logo_path"]
         ethereum_client = get_auto_ethereum_client()
         chain_id = ethereum_client.get_chain_id()
@@ -71,7 +76,7 @@ class Command(BaseCommand):
                 f"Wrong Safe version {safe_version}, supported versions {safe_deployments.keys()}"
             )
 
-        if force_update_contract_names:
+        if force_update_contracts:
             # update all safe contract names
             queryset = Contract.objects.update_or_create
         else:
@@ -98,7 +103,7 @@ class Command(BaseCommand):
                         # Remove previous logo file
                         contract.logo.delete(save=True)
                         # update name only for contracts with empty names
-                        if not force_update_contract_names and contract.name == "":
+                        if not force_update_contracts and contract.name == "":
                             contract.display_name = display_name
                             contract.name = contract_name
 

--- a/safe_transaction_service/contracts/tests/test_commands.py
+++ b/safe_transaction_service/contracts/tests/test_commands.py
@@ -77,7 +77,7 @@ class TestCommands(TestCase):
         # Force to update contract names should update the name and display name of the contract
         call_command(
             command,
-            "--force-update-contract-names",
+            "--force-update-contracts",
             stdout=buf,
         )
         contract = Contract.objects.get(address=multisend_address)
@@ -98,4 +98,11 @@ class TestCommands(TestCase):
         self.assertEqual(contract.name, "SafeToL2Migration")
         self.assertEqual(contract.display_name, "SafeToL2Migration 1.4.1")
         # SafeToL2Migration should be trusted for delegate calls
+        self.assertTrue(contract.trusted_for_delegate_call)
+
+        sign_message_lib = "0xd53cd0aB83D845Ac265BE939c57F53AD838012c9"
+        contract = Contract.objects.get(address=sign_message_lib)
+        self.assertEqual(contract.name, "SignMessageLib")
+        self.assertEqual(contract.display_name, "Safe: SignMessageLib 1.4.1")
+        # SignMessageLib should be trusted for delegate calls
         self.assertTrue(contract.trusted_for_delegate_call)


### PR DESCRIPTION
Closes #2266

# Other changes
- Rename `--force-update-contract-names` option