### PR TITLE
Add support for delegates to delete transactions proposed by themselves

### DIFF
--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -571,19 +571,19 @@ class SafeMultisigTransactionDeleteSerializer(serializers.Serializer):
                 raise ValidationError("Only EOA and ETH_SIGN signatures are supported")
 
             # The transaction can be deleted by the proposer or by the delegate user who proposed it.
-            if safe_signature.owner == proposer:
+            owner = safe_signature.owner
+            if owner == proposer:
                 return attrs
-            if (
-                multisig_tx.proposed_by_delegate
-                and safe_signature.owner == multisig_tx.proposed_by_delegate
-            ):
+
+            proposed_by_delegate = multisig_tx.proposed_by_delegate
+            if proposed_by_delegate and owner == proposed_by_delegate:
                 delegates_for_proposer = (
                     SafeContractDelegate.objects.get_delegates_for_safe_and_owners(
                         safe_address, [proposer]
                     )
                 )
                 # Check if it's still a valid delegate.
-                if safe_signature.owner in delegates_for_proposer:
+                if owner in delegates_for_proposer:
                     return attrs
 
         raise ValidationError(

--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -569,10 +569,26 @@ class SafeMultisigTransactionDeleteSerializer(serializers.Serializer):
                 SafeSignatureType.ETH_SIGN,
             ):
                 raise ValidationError("Only EOA and ETH_SIGN signatures are supported")
+
+            # The transaction can be deleted by the proposer or by the delegate user who proposed it.
             if safe_signature.owner == proposer:
                 return attrs
+            if (
+                multisig_tx.proposed_by_delegate
+                and safe_signature.owner == multisig_tx.proposed_by_delegate
+            ):
+                delegates_for_proposer = (
+                    SafeContractDelegate.objects.get_delegates_for_safe_and_owners(
+                        safe_address, [proposer]
+                    )
+                )
+                # Check if it's still a valid delegate.
+                if safe_signature.owner in delegates_for_proposer:
+                    return attrs
 
-        raise ValidationError("Provided owner is not the proposer of the transaction")
+        raise ValidationError(
+            "Provided signer is not the proposer or the delegate user who proposed the transaction"
+        )
 
 
 class DataDecoderSerializer(serializers.Serializer):

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -543,7 +543,7 @@ class SafeMultisigTransactionDetailView(RetrieveAPIView):
     def delete(self, request, safe_tx_hash: HexStr):
         """
         Removes the queued but not executed multi-signature transaction associated with the given Safe tansaction hash.
-        Only the proposer or the delegate user who proposed the transaction can delete it.
+        Only the proposer or the delegate who proposed the transaction can delete it.
         If the transaction was proposed by a delegate, it must still be a valid delegate for the transaction proposer.
         An EOA is required to sign the following EIP-712 data:
 

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -544,7 +544,7 @@ class SafeMultisigTransactionDetailView(RetrieveAPIView):
         """
         Removes the queued but not executed multi-signature transaction associated with the given Safe tansaction hash.
         Only the proposer or the delegate user who proposed the transaction can delete it.
-        If the transaction was proposed by a delegate, must still be a valid delegate for the transaction proposer.
+        If the transaction was proposed by a delegate, it must still be a valid delegate for the transaction proposer.
         An EOA is required to sign the following EIP-712 data:
 
         ```python

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -543,8 +543,8 @@ class SafeMultisigTransactionDetailView(RetrieveAPIView):
     def delete(self, request, safe_tx_hash: HexStr):
         """
         Removes the queued but not executed multi-signature transaction associated with the given Safe tansaction hash.
-        Only the proposer can delete the transaction.
-        If the transaction was proposed by a delegate, the Safe owner who delegated to the delegate must be used.
+        Only the proposer or the delegate user who proposed the transaction can delete it.
+        If the transaction was proposed by a delegate, must still be a valid delegate for the transaction proposer.
         An EOA is required to sign the following EIP-712 data:
 
         ```python


### PR DESCRIPTION
- Closes #2284
  - Delegate users can only delete transactions proposed by themselves.
  - Delegate users must still be valid at the time of deletion.
