### PR TITLE
Move process_decoded_internal_txs_for_safe_task to processing queue

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -285,6 +285,10 @@ CELERY_ROUTES = (
             {"queue": "processing", "delivery_mode": "transient"},
         ),
         (
+            "safe_transaction_service.history.tasks.process_decoded_internal_txs_task",
+            {"queue": "processing", "delivery_mode": "transient"},
+        ),
+        (
             "safe_transaction_service.history.tasks.*",
             {"queue": "indexing", "delivery_mode": "transient"},
         ),

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -281,6 +281,10 @@ CELERY_ROUTES = (
             {"queue": "indexing"},
         ),
         (
+            "safe_transaction_service.history.tasks.process_decoded_internal_txs_for_safe_task",
+            {"queue": "processing", "delivery_mode": "transient"},
+        ),
+        (
             "safe_transaction_service.history.tasks.*",
             {"queue": "indexing", "delivery_mode": "transient"},
         ),

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -280,6 +280,8 @@ def process_decoded_internal_txs_task(self) -> Optional[int]:
             else:
                 logger.info("%d Safes to process", count)
 
+            return count
+
 
 @app.shared_task(bind=True)
 @task_timeout(timeout_seconds=LOCK_TIMEOUT)


### PR DESCRIPTION
# Description
Adding the configurable queue names to be able to move some tasks to other workers. 
For now just process_safes have a different variable.
