### PR TITLE
Allow configuration for Celery Prefetch Multiplier

### DIFF
--- a/docker/web/celery/worker/run.sh
+++ b/docker/web/celery/worker/run.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-TASK_CONCURRENCY=${CELERYD_CONCURRENCY:-15000}
+TASK_CONCURRENCY=${CELERYD_CONCURRENCY:-5000}
+PREFETCH_MULTIPLIER=${CELERYD_PREFETCH_MULTIPLIER:-2}  # Default is 4
 
 # DEBUG set in .env_docker_compose
 if [ ${DEBUG:-0} = 1 ]; then
@@ -30,6 +31,7 @@ exec celery --no-color -A config.celery_app worker \
      --pool=gevent \
      --loglevel $log_level \
      --concurrency="${TASK_CONCURRENCY}" \
+     --prefetch-multiplier="${PREFETCH_MULTIPLIER}" \
      --without-heartbeat \
      --without-gossip \
      --without-mingle -E -Q "$WORKER_QUEUES"

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -258,10 +258,10 @@ def process_decoded_internal_txs_task(self) -> Optional[int]:
                         safe_to_process
                     ).not_processed().update(processed=True)
                 else:
-                    count += 1
                     process_decoded_internal_txs_for_safe_task.delay(
                         safe_to_process, reindex_master_copies=True
                     )
+                    count += 1
 
             if not count:
                 logger.info("No Safes to process")


### PR DESCRIPTION
- By default now is `2` (it was `4`)
- Clean some code in tasks
