### PR TITLE
Fix delegates events payload attribute name

### DIFF
--- a/safe_transaction_service/history/services/notification_service.py
+++ b/safe_transaction_service/history/services/notification_service.py
@@ -209,7 +209,7 @@ def build_reorg_payload(block_number: int) -> ReorgPayload:
 
 class DelegatePayload(TypedDict):
     type: str
-    safeAddress: Optional[str]
+    address: Optional[str]
     delegate: str
     delegator: str
     label: str
@@ -234,7 +234,7 @@ def _build_delegate_payload(
     """
     return DelegatePayload(
         type=event_type.name,
-        safeAddress=instance.safe_contract_id if instance.safe_contract_id else None,
+        address=instance.safe_contract_id if instance.safe_contract_id else None,
         delegate=instance.delegate,
         delegator=instance.delegator,
         label=instance.label,

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -206,7 +206,7 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         delegate_for_safe = SafeContractDelegateFactory()
         new_delegate_user_payload = {
             "type": TransactionServiceEventType.NEW_DELEGATE.name,
-            "safeAddress": delegate_for_safe.safe_contract.address,
+            "address": delegate_for_safe.safe_contract.address,
             "delegate": delegate_for_safe.delegate,
             "delegator": delegate_for_safe.delegator,
             "label": delegate_for_safe.label,
@@ -220,7 +220,7 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         )
         new_delegate_user_payload = {
             "type": TransactionServiceEventType.NEW_DELEGATE.name,
-            "safeAddress": None,
+            "address": None,
             "delegate": permanent_delegate_without_safe.delegate,
             "delegator": permanent_delegate_without_safe.delegator,
             "label": permanent_delegate_without_safe.label,
@@ -240,7 +240,7 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         delegate_to_update.save()
         updated_delegate_user_payload = {
             "type": TransactionServiceEventType.UPDATED_DELEGATE.name,
-            "safeAddress": new_safe.address,
+            "address": new_safe.address,
             "delegate": delegate_to_update.delegate,
             "delegator": delegate_to_update.delegator,
             "label": new_label,
@@ -254,7 +254,7 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         delegate_to_delete.delete()
         updated_delegate_user_payload = {
             "type": TransactionServiceEventType.DELETED_DELEGATE.name,
-            "safeAddress": delegate_to_delete.safe_contract.address,
+            "address": delegate_to_delete.safe_contract.address,
             "delegate": delegate_to_delete.delegate,
             "delegator": delegate_to_delete.delegator,
             "label": delegate_to_delete.label,


### PR DESCRIPTION
- Related with #2299 

All events processed by the events service expect the name of the attribute containing the address of the safe to be in the address attribute. [Example](https://github.com/safe-global/safe-events-service/blob/d58e3427fbbd7cc795ebe335ba5ba866a5791bf3/src/routes/events/events.service.ts#L33) 

