### PR TITLE
Fix get_safe_creation_info query

### DIFF
--- a/safe_transaction_service/history/services/safe_service.py
+++ b/safe_transaction_service/history/services/safe_service.py
@@ -22,7 +22,13 @@ from safe_transaction_service.account_abstraction import models as aa_models
 from safe_transaction_service.utils.abis.gelato import gelato_relay_1_balance_v2_abi
 
 from ..exceptions import NodeConnectionException
-from ..models import EthereumTx, InternalTx, SafeLastStatus, SafeMasterCopy
+from ..models import (
+    EthereumTx,
+    InternalTx,
+    InternalTxType,
+    SafeLastStatus,
+    SafeMasterCopy,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +122,8 @@ class SafeService:
             # Get first the actual creation transaction for the safe
             creation_internal_tx = (
                 InternalTx.objects.filter(
-                    ethereum_tx__status=1  # Ignore Internal Transactions for failed Transactions
+                    ethereum_tx__status=1,  # Ignore Internal Transactions for failed Transactions
+                    tx_type=InternalTxType.CREATE.value,
                 )
                 .select_related("ethereum_tx__block")
                 .get(contract_address=safe_address)

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -37,6 +37,7 @@ from ...utils.redis import get_redis
 from ..helpers import DelegateSignatureHelper, DeleteMultisigTxSignatureHelper
 from ..models import (
     IndexingStatus,
+    InternalTxType,
     MultisigConfirmation,
     MultisigTransaction,
     SafeContractDelegate,
@@ -3274,6 +3275,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
                 contract_address=safe_address,
                 trace_address="0,0",
                 ethereum_tx__status=1,
+                tx_type=InternalTxType.CREATE.value,
             )
             response = self.client.get(
                 reverse("v1:history:safe-creation", args=(safe_address,)),


### PR DESCRIPTION
- Closes #2309

In some cases more than one result was being returned for the query. The CREATE filter is added to return only the creation Tx.

A test case is added to check this case.
