### PR TITLE
Fix SafeRelevantTransaction default timestamp

### DIFF
--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -722,7 +722,7 @@ class SafeTxProcessor(TxProcessor):
                 SafeRelevantTransaction.objects.get_or_create(
                     ethereum_tx=ethereum_tx,
                     safe=contract_address,
-                    defaults={"timestamp": ethereum_tx.block.timestamp},
+                    defaults={"timestamp": internal_tx.timestamp},
                 )
 
                 # Don't modify created

--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -603,7 +603,7 @@ class SafeTxProcessor(TxProcessor):
                 SafeRelevantTransaction.objects.get_or_create(
                     ethereum_tx=ethereum_tx,
                     safe=contract_address,
-                    defaults={"timestamp": ethereum_tx.block.timestamp},
+                    defaults={"timestamp": internal_tx.timestamp},
                 )
                 # Detect 4337 UserOperations in this transaction
                 number_detected_user_operations = (

--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -603,7 +603,7 @@ class SafeTxProcessor(TxProcessor):
                 SafeRelevantTransaction.objects.get_or_create(
                     ethereum_tx=ethereum_tx,
                     safe=contract_address,
-                    defaults={"timestamp": ethereum_tx.created},
+                    defaults={"timestamp": ethereum_tx.block.timestamp},
                 )
                 # Detect 4337 UserOperations in this transaction
                 number_detected_user_operations = (
@@ -722,7 +722,7 @@ class SafeTxProcessor(TxProcessor):
                 SafeRelevantTransaction.objects.get_or_create(
                     ethereum_tx=ethereum_tx,
                     safe=contract_address,
-                    defaults={"timestamp": ethereum_tx.created},
+                    defaults={"timestamp": ethereum_tx.block.timestamp},
                 )
 
                 # Don't modify created


### PR DESCRIPTION
Sometimes when reindexing a safe, if a missing Tx appears, it is being inserted with the current date instead of the correct date. 

This causes an order problem in the `all-transactions` endpoint.