### PR TITLE
Add expirity and priority to handle Safes processing

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -262,6 +262,8 @@ CELERY_TASK_DEFAULT_PRIORITY = 5
 CELERY_TASK_QUEUE_MAX_PRIORITY = 10
 # https://docs.celeryproject.org/en/latest/userguide/configuration.html#broker-transport-options
 CELERY_BROKER_TRANSPORT_OPTIONS = {}
+# Used for some tasks that shouldn't have long live in the queue
+CELERY_TASK_EXPIRATION = env.int("CELERY_TASK_EXPIRATION", default=60)
 
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_routes
 CELERY_ROUTES = (


### PR DESCRIPTION
# Description
- Add expirity time for process_decoded_internal_tx_task (if the task cannot be executed for more than one minute shouldn't be run) 
- Add priority for process Safes from process process_decoded_internal_tx_task.

