### PR TITLE
Remove ens client mainnet base url

### DIFF
--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -172,11 +172,12 @@ class CollectiblesService:
                 api_key=api_key,
                 subgraph_id=subgraph_id,
             )
-        # Else, provide fallback for Sepolia, Holesky and Mainnet
+        # Else, provide fallback for Sepolia, Holesky or empty configuration.
         else:
             logger.warning(
                 "Using fallback EnsClient configuration. This configuration is not suitable for production and it is "
-                "recommended to setup a Subgraph API key. See https://docs.ens.domains/web/subgraph"
+                "recommended to setup a Subgraph API key. Mandatory for networks other than Sepolia or Holesky."
+                "See https://docs.ens.domains/web/subgraph"
             )
             config = self.fallback_ens_client()
 
@@ -197,9 +198,7 @@ class CollectiblesService:
                 "https://api.studio.thegraph.com/query/49574/ensholesky/version/latest",
             )
         else:
-            return EnsClient.Config(
-                "https://api.thegraph.com/subgraphs/name/ensdomains/ens/",
-            )
+            return EnsClient.Config("")
 
     def get_metadata_cache_key(self, address: str, token_id: int):
         return f"metadata:{address}:{token_id}"

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -198,6 +198,10 @@ class CollectiblesService:
                 "https://api.studio.thegraph.com/query/49574/ensholesky/version/latest",
             )
         else:
+            logger.warning(
+                "No fallback Ens Client configuration for network=%s available",
+                self.ethereum_network,
+            )
             return EnsClient.Config("")
 
     def get_metadata_cache_key(self, address: str, token_id: int):


### PR DESCRIPTION
The URL https://api.thegraph.com/subgraphs/name/ensdomains/ens is no longer supported and it is necessary to use the ENS Mainnet subgraph (https://thegraph.com/explorer/subgraphs/5XqPmWe6gjyrJtFn9cLy237i4cWw2j9HcUJEXsP5qGtH) and the subgraph config to make the same queries to the TheGraph api.

- Related with https://github.com/safe-global/safe-eth-py/issues/1481
