### PR TITLE
typo fix local.py

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -29,7 +29,7 @@ CACHES = {
         "LOCATION": REDIS_URL,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            # Mimicing memcache behavior.
+            # Mimicking memcache behavior.
             # http://niwinz.github.io/django-redis/latest/#_memcached_exceptions_behavior
             "IGNORE_EXCEPTIONS": True,
         },


### PR DESCRIPTION
## Typo Fix in `local.py`

This pull request corrects a typo in the `local.py` file. The word "Mimicing" has been corrected to "Mimicking."

### Changes:
- Fixed the typo **"Mimicing"** to **"Mimicking"** in the `local.py` file.

### Checklist:
- [x] Typo fixed and changes reviewed.
- [x] Pull request description completed.
