### PR TITLE
Fix typo in views.py

### DIFF
--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -587,7 +587,7 @@ class SafeMultisigTransactionDetailView(RetrieveAPIView):
 
     def delete(self, request, safe_tx_hash: HexStr):
         """
-        Removes the queued but not executed multi-signature transaction associated with the given Safe tansaction hash.
+        Removes the queued but not executed multi-signature transaction associated with the given Safe transaction hash.
         Only the proposer or the delegate who proposed the transaction can delete it.
         If the transaction was proposed by a delegate, it must still be a valid delegate for the transaction proposer.
         An EOA is required to sign the following EIP-712 data:


### PR DESCRIPTION
### What was wrong? 👾

Small typo in the multisig_transaction DELETE path.

### How was it fixed? 🎯

Fixed the typo manually
