### PR TITLE
Send data for the MULTISIG_TRANSACTION payloads

### DIFF
--- a/safe_transaction_service/history/services/notification_service.py
+++ b/safe_transaction_service/history/services/notification_service.py
@@ -70,6 +70,7 @@ def build_event_payload(
             #  'type': None,  It will be assigned later
             "safeTxHash": HexBytes(instance.safe_tx_hash).hex(),
             "to": instance.to,
+            "data": HexBytes(instance.data).hex() if instance.data else None,
         }
         if instance.executed:
             payload["type"] = (

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 import factory
+from hexbytes import HexBytes
 from safe_eth.eth import EthereumNetwork
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 
@@ -179,9 +180,10 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         multisig_tx: MultisigTransaction = MultisigTransactionFactory(trusted=True)
         pending_multisig_transaction_payload = {
             "address": multisig_tx.safe,
-            "to": multisig_tx.to,
-            "safeTxHash": multisig_tx.safe_tx_hash,
             "type": TransactionServiceEventType.EXECUTED_MULTISIG_TRANSACTION.name,
+            "safeTxHash": multisig_tx.safe_tx_hash,
+            "to": multisig_tx.to,
+            "data": HexBytes(multisig_tx.data).hex() if multisig_tx.data else None,
             "failed": "false",
             "txHash": multisig_tx.ethereum_tx_id,
             "chainId": str(EthereumNetwork.GANACHE.value),
@@ -195,8 +197,8 @@ class TestSignals(SafeTestCaseMixin, TestCase):
 
         deleted_multisig_transaction_payload = {
             "address": multisig_tx.safe,
-            "safeTxHash": safe_tx_hash,
             "type": TransactionServiceEventType.DELETED_MULTISIG_TRANSACTION.name,
+            "safeTxHash": safe_tx_hash,
             "chainId": str(EthereumNetwork.GANACHE.value),
         }
         send_event_mock.assert_called_with(deleted_multisig_transaction_payload)

--- a/safe_transaction_service/notifications/tasks.py
+++ b/safe_transaction_service/notifications/tasks.py
@@ -80,6 +80,12 @@ def send_notification_task(
     if not (address and payload):  # Both must be present
         return 0, 0
 
+    # Hacky solution, don't send transaction `data` to firebase, as it can exceed maximum message size
+    if "data" in payload:
+        # Copy payload, don't modify dictionary passed as argument, as it's mutable
+        payload = dict(payload)
+        payload.pop("data")
+
     # Make sure notification has not been sent before
     if not mark_notification_as_processed(address, payload):
         # Notification was processed already


### PR DESCRIPTION
- Required for Multisend support on the **data decoder**
- `data` will not be sent to Firebase, as it can exceed the maximum message size
