### PR TITLE
Bump web3 to v7 and HexBytes to v1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ drf-spectacular==0.28.0
 firebase-admin==6.5.0
 flower==2.0.1
 gunicorn[gevent]==22.0.0
-hexbytes==0.3.1
 hiredis==3.0.0
 packaging>=21.0
 pika==1.3.2
@@ -33,5 +32,5 @@ psycogreen==1.0.2
 psycopg[binary]==3.2.3
 redis==5.2.1
 requests==2.32.3
-safe-eth-py[django]==6.4.0
-web3==6.20.2
+safe-eth-py[django]==7.0.0
+web3==7.8.0

--- a/safe_transaction_service/account_abstraction/admin.py
+++ b/safe_transaction_service/account_abstraction/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
 from safe_eth.eth.django.admin import AdvancedAdminSearchMixin
+from safe_eth.util.util import to_0x_hex_str
 
 from .models import SafeOperation, UserOperation, UserOperationReceipt
 
@@ -42,11 +43,11 @@ class ForeignClassToUserOperationAdmin(AdvancedAdminSearchMixin, admin.ModelAdmi
 
     @admin.display()
     def ethereum_tx(self, obj: ForeignClassToUserOperationType) -> str:
-        return HexBytes(obj.user_operation.ethereum_tx.tx_hash).hex()
+        return to_0x_hex_str(HexBytes(obj.user_operation.ethereum_tx.tx_hash))
 
     @admin.display()
     def user_operation_hash(self, obj: ForeignClassToUserOperationType) -> str:
-        return HexBytes(obj.user_operation.hash).hex()
+        return to_0x_hex_str(HexBytes(obj.user_operation.hash))
 
     @admin.display()
     def user_operation_sender(

--- a/safe_transaction_service/account_abstraction/management/commands/reindex_4337.py
+++ b/safe_transaction_service/account_abstraction/management/commands/reindex_4337.py
@@ -4,6 +4,7 @@ from django.core.management.base import BaseCommand
 
 from eth_typing import ChecksumAddress
 from safe_eth.eth.utils import fast_to_checksum_address
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.history.models import EthereumTx
 
@@ -39,7 +40,7 @@ class Command(BaseCommand):
         self,
         addresses: Optional[Sequence[ChecksumAddress]],
     ) -> None:
-        topic = USER_OPERATION_EVENT_TOPIC.hex()
+        topic = to_0x_hex_str(USER_OPERATION_EVENT_TOPIC)
         aa_processor_service = get_aa_processor_service()
         processed_user_operations = 0
         for tx in EthereumTx.objects.account_abstraction_txs():

--- a/safe_transaction_service/account_abstraction/models.py
+++ b/safe_transaction_service/account_abstraction/models.py
@@ -18,6 +18,7 @@ from safe_eth.eth.django.models import (
 )
 from safe_eth.safe.account_abstraction import SafeOperation as SafeOperationClass
 from safe_eth.safe.safe_signature import SafeSignatureType
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.history import models as history_models
 from safe_transaction_service.utils.constants import SIGNATURE_LENGTH
@@ -58,7 +59,7 @@ class UserOperation(models.Model):
         ]
 
     def __str__(self) -> str:
-        return f"{HexBytes(self.hash).hex()} UserOperation for sender={self.sender} with nonce={self.nonce}"
+        return f"{to_0x_hex_str(HexBytes(self.hash))} UserOperation for sender={self.sender} with nonce={self.nonce}"
 
     @cached_property
     def paymaster_and_data(self) -> Optional[HexBytes]:
@@ -123,7 +124,7 @@ class UserOperationReceipt(models.Model):
     deposited = Uint256Field()
 
     def __str__(self) -> str:
-        return f"{HexBytes(self.user_operation_id).hex()} UserOperationReceipt"
+        return f"{to_0x_hex_str(HexBytes(self.user_operation_id))} UserOperationReceipt"
 
 
 class SafeOperationQuerySet(models.QuerySet):
@@ -151,7 +152,7 @@ class SafeOperation(TimeStampedModel):
     module_address = EthereumAddressBinaryField(db_index=True)
 
     def __str__(self) -> str:
-        return f"{HexBytes(self.hash).hex()} SafeOperation for user-operation={HexBytes(self.user_operation_id).hex()}"
+        return f"{to_0x_hex_str(HexBytes(self.hash))} SafeOperation for user-operation={to_0x_hex_str(HexBytes(self.user_operation_id))}"
 
     def build_signature_prefix(self) -> bytes:
         """
@@ -217,5 +218,5 @@ class SafeOperationConfirmation(TimeStampedModel):
     def __str__(self):
         return (
             f"Safe Operation Confirmation of owner={self.owner} for "
-            f"safe-operation={HexBytes(self.safe_operation_id).hex()}"
+            f"safe-operation={to_0x_hex_str(HexBytes(self.safe_operation_id))}"
         )

--- a/safe_transaction_service/account_abstraction/serializers.py
+++ b/safe_transaction_service/account_abstraction/serializers.py
@@ -15,6 +15,7 @@ from safe_eth.eth.account_abstraction import UserOperation as UserOperationClass
 from safe_eth.eth.utils import fast_keccak, fast_to_checksum_address
 from safe_eth.safe.account_abstraction import SafeOperation as SafeOperationClass
 from safe_eth.safe.safe_signature import SafeSignature, SafeSignatureType
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.utils.constants import SIGNATURE_LENGTH
 from safe_transaction_service.utils.ethereum import get_chain_id
@@ -72,11 +73,11 @@ class SafeOperationSignatureValidatorMixin:
             if owner not in safe_owners:
                 raise ValidationError(
                     f"Signer={owner} is not an owner. Current owners={safe_owners}. "
-                    f"Safe-operation-hash={safe_operation_hash.hex()}"
+                    f"Safe-operation-hash={to_0x_hex_str(safe_operation_hash)}"
                 )
             if not safe_signature.is_valid(self.ethereum_client, safe_address):
                 raise ValidationError(
-                    f"Signature={safe_signature.signature.hex()} for owner={owner} is not valid"
+                    f"Signature={to_0x_hex_str(safe_signature.signature)} for owner={owner} is not valid"
                 )
             if owner in owners_processed:
                 raise ValidationError(f"Signature for owner={owner} is duplicated")
@@ -241,7 +242,7 @@ class SafeOperationSerializer(
 
         if SafeOperationModel.objects.filter(hash=safe_operation_hash).exists():
             raise ValidationError(
-                f"SafeOperation with hash={safe_operation_hash.hex()} already exists"
+                f"SafeOperation with hash={to_0x_hex_str(safe_operation_hash)} already exists"
             )
 
         safe_signatures = self._validate_signature(
@@ -456,7 +457,7 @@ class SafeOperationResponseSerializer(serializers.Serializer):
         :return: Serialized queryset
         """
         signature = obj.build_signature()
-        return HexStr(HexBytes(signature).hex())
+        return to_0x_hex_str(HexBytes(signature))
 
 
 class SafeOperationWithUserOperationResponseSerializer(SafeOperationResponseSerializer):

--- a/safe_transaction_service/account_abstraction/services/aa_processor_service.py
+++ b/safe_transaction_service/account_abstraction/services/aa_processor_service.py
@@ -18,6 +18,7 @@ from safe_eth.eth.account_abstraction import (
 from safe_eth.eth.utils import fast_to_checksum_address
 from safe_eth.safe.account_abstraction import SafeOperation
 from safe_eth.safe.safe_signature import SafeSignature
+from safe_eth.util.util import to_0x_hex_str
 from web3.types import LogReceipt
 
 from safe_transaction_service.history import models as history_models
@@ -161,7 +162,7 @@ class AaProcessorService:
                 "[%s] Cannot find ExecutionFromModuleSuccess or ExecutionFromModuleFailure "
                 "events for user-operation-hash=%s , it seems like UserOperation was reverted",
                 user_operation_model.sender,
-                user_operation.user_operation_hash.hex(),
+                to_0x_hex_str(user_operation.user_operation_hash),
             )
             if user_operation_receipt.get_deployed_account():
                 # UserOperation `initCode` was executed but `callData` failed, so account was deployed but
@@ -169,7 +170,7 @@ class AaProcessorService:
                 logger.info(
                     "[%s] user-operation-hash=%s was reverted but contract was deployed",
                     user_operation_model.sender,
-                    user_operation.user_operation_hash.hex(),
+                    to_0x_hex_str(user_operation.user_operation_hash),
                 )
             # As `module_address` cannot be detected there's not enough data to index the SafeOperation
             return None
@@ -195,8 +196,8 @@ class AaProcessorService:
             logger.debug(
                 "[%s] safe-operation-hash=%s for user-operation-hash=%s was already indexed",
                 user_operation_model.sender,
-                HexBytes(safe_operation_hash).hex(),
-                user_operation.user_operation_hash.hex(),
+                to_0x_hex_str(HexBytes(safe_operation_hash)),
+                to_0x_hex_str(user_operation.user_operation_hash),
             )
         self.index_safe_operation_confirmations(
             HexBytes(safe_operation.signature), safe_operation_model, safe_operation
@@ -214,8 +215,8 @@ class AaProcessorService:
         :return: Tuple with ``UserOperation`` and ``UserOperationReceipt``
         """
         safe_address = user_operation_model.sender
-        user_operation_hash_hex = HexBytes(user_operation_model.hash).hex()
-        tx_hash = HexBytes(user_operation_model.ethereum_tx_id).hex()
+        user_operation_hash_hex = to_0x_hex_str(HexBytes(user_operation_model.hash))
+        tx_hash = to_0x_hex_str(HexBytes(user_operation_model.ethereum_tx_id))
         logger.debug(
             "[%s] Retrieving UserOperation Receipt with user-operation-hash=%s on tx-hash=%s",
             safe_address,
@@ -285,7 +286,7 @@ class AaProcessorService:
         :param ethereum_tx: Stored EthereumTx in database containing the ``UserOperation``
         :return: tuple of ``UserOperationModel`` and ``UserOperation``
         """
-        user_operation_hash_hex = user_operation_hash.hex()
+        user_operation_hash_hex = to_0x_hex_str(user_operation_hash)
         # If the UserOperationReceipt is present, UserOperation was already processed and mined
         if self.is_user_operation_indexed(user_operation_hash_hex):
             logger.warning(

--- a/safe_transaction_service/account_abstraction/tests/factories.py
+++ b/safe_transaction_service/account_abstraction/tests/factories.py
@@ -8,6 +8,7 @@ from factory.django import DjangoModelFactory
 from safe_eth.eth.constants import NULL_ADDRESS
 from safe_eth.eth.utils import fast_keccak_text
 from safe_eth.safe.safe_signature import SafeSignatureType
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.history.tests import factories as history_factories
 
@@ -23,7 +24,9 @@ class UserOperationFactory(DjangoModelFactory):
         valid_after = 0
         valid_until = 0
 
-    hash = factory.Sequence(lambda n: fast_keccak_text(f"user-operation-{n}").hex())
+    hash = factory.Sequence(
+        lambda n: to_0x_hex_str(fast_keccak_text(f"user-operation-{n}"))
+    )
     ethereum_tx = factory.SubFactory(history_factories.EthereumTxFactory)
     sender = factory.LazyFunction(lambda: Account.create().address)
     nonce = factory.Sequence(lambda n: n)
@@ -59,7 +62,9 @@ class SafeOperationFactory(DjangoModelFactory):
     class Meta:
         model = models.SafeOperation
 
-    hash = factory.Sequence(lambda n: fast_keccak_text(f"safe-operation-{n}").hex())
+    hash = factory.Sequence(
+        lambda n: to_0x_hex_str(fast_keccak_text(f"safe-operation-{n}"))
+    )
     user_operation = factory.SubFactory(UserOperationFactory)
     valid_after = factory.LazyFunction(timezone.now)
     valid_until = factory.LazyFunction(timezone.now)
@@ -76,6 +81,6 @@ class SafeOperationConfirmationFactory(DjangoModelFactory):
     safe_operation = factory.SubFactory(SafeOperationFactory)
     owner = factory.LazyAttribute(lambda o: o.signing_owner.address)
     signature = factory.LazyAttribute(
-        lambda o: o.signing_owner.signHash(o.safe_operation.hash)["signature"]
+        lambda o: o.signing_owner.unsafe_sign_hash(o.safe_operation.hash)["signature"]
     )
     signature_type = SafeSignatureType.EOA.value

--- a/safe_transaction_service/account_abstraction/tests/services/test_aa_processor_service.py
+++ b/safe_transaction_service/account_abstraction/tests/services/test_aa_processor_service.py
@@ -17,6 +17,7 @@ from safe_eth.eth.tests.mocks.mock_bundler import (
     user_operation_v07_hash,
     user_operation_v07_mock,
 )
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.account_abstraction.services import (
     get_aa_processor_service,
@@ -71,7 +72,8 @@ class TestAaProcessorService(TestCase):
         "get_user_operation_by_hash",
         autospec=True,
         return_value=UserOperationClass.from_bundler_response(
-            safe_4337_user_operation_hash_mock.hex(), user_operation_mock["result"]
+            to_0x_hex_str(safe_4337_user_operation_hash_mock),
+            user_operation_mock["result"],
         ),
     )
     @mock.patch.object(
@@ -97,10 +99,10 @@ class TestAaProcessorService(TestCase):
         user_operation_confirmation_model = SafeOperationConfirmationModel.objects.get()
 
         self.assertEqual(
-            user_operation_model.hash, aa_expected_user_operation_hash.hex()
+            user_operation_model.hash, to_0x_hex_str(aa_expected_user_operation_hash)
         )
         self.assertEqual(
-            safe_operation_model.hash, aa_expected_safe_operation_hash.hex()
+            safe_operation_model.hash, to_0x_hex_str(aa_expected_safe_operation_hash)
         )
         self.assertEqual(user_operation_receipt_model.deposited, 759940285250436)
         self.assertEqual(
@@ -128,7 +130,8 @@ class TestAaProcessorService(TestCase):
         "get_user_operation_by_hash",
         autospec=True,
         return_value=UserOperationClass.from_bundler_response(
-            user_operation_v07_hash.hex(), user_operation_v07_mock["result"]
+            to_0x_hex_str(user_operation_v07_hash),
+            user_operation_v07_mock["result"],
         ),
     )
     @mock.patch.object(

--- a/safe_transaction_service/account_abstraction/tests/test_models.py
+++ b/safe_transaction_service/account_abstraction/tests/test_models.py
@@ -8,6 +8,7 @@ from safe_eth.eth.tests.mocks.mock_bundler import (
     user_operation_mock,
 )
 from safe_eth.safe.account_abstraction import SafeOperation as SafeOperationClass
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.history.tests import factories as history_factories
 
@@ -20,7 +21,8 @@ class TestModels(TestCase):
     def test_user_operation(self):
         expected_user_operation_hash = safe_4337_user_operation_hash_mock
         expected_user_operation = UserOperationClass.from_bundler_response(
-            expected_user_operation_hash.hex(), user_operation_mock["result"]
+            to_0x_hex_str(expected_user_operation_hash),
+            user_operation_mock["result"],
         )
         expected_safe_operation = SafeOperationClass.from_user_operation(
             expected_user_operation

--- a/safe_transaction_service/contracts/tests/test_tx_decoder.py
+++ b/safe_transaction_service/contracts/tests/test_tx_decoder.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from hexbytes import HexBytes
 from safe_eth.eth.constants import NULL_ADDRESS
 from safe_eth.safe.multi_send import MultiSendOperation
+from safe_eth.util.util import to_0x_hex_str
 from web3 import Web3
 
 from safe_transaction_service.contracts.tests.factories import (
@@ -186,7 +187,7 @@ class TestTxDecoder(TestCase):
                 "operation": operation,
                 "to": safe_contract_address,
                 "value": value,
-                "data": change_master_copy_data.hex(),
+                "data": to_0x_hex_str(change_master_copy_data),
                 "data_decoded": {
                     "method": "changeMasterCopy",
                     "parameters": [
@@ -202,7 +203,7 @@ class TestTxDecoder(TestCase):
                 "operation": operation,
                 "to": safe_contract_address,
                 "value": value,
-                "data": change_fallback_manager_data.hex(),
+                "data": to_0x_hex_str(change_fallback_manager_data),
                 "data_decoded": {
                     "method": "setFallbackHandler",
                     "parameters": [
@@ -231,7 +232,7 @@ class TestTxDecoder(TestCase):
                             "operation": operation,
                             "to": safe_contract_address,
                             "value": value,
-                            "data": change_master_copy_data.hex(),
+                            "data": to_0x_hex_str(change_master_copy_data),
                             "data_decoded": {
                                 "method": "changeMasterCopy",
                                 "parameters": [
@@ -247,7 +248,7 @@ class TestTxDecoder(TestCase):
                             "operation": operation,
                             "to": safe_contract_address,
                             "value": value,
-                            "data": change_fallback_manager_data.hex(),
+                            "data": to_0x_hex_str(change_fallback_manager_data),
                             "data_decoded": {
                                 "method": "setFallbackHandler",
                                 "parameters": [

--- a/safe_transaction_service/history/admin.py
+++ b/safe_transaction_service/history/admin.py
@@ -12,6 +12,7 @@ from rest_framework.authtoken.admin import TokenAdmin
 from safe_eth.eth import get_auto_ethereum_client
 from safe_eth.eth.django.admin import AdvancedAdminSearchMixin
 from safe_eth.safe import SafeTx
+from safe_eth.util.util import to_0x_hex_str
 
 from .models import (
     Chain,
@@ -444,7 +445,7 @@ class ModuleTransactionAdmin(AdvancedAdminSearchMixin, admin.ModelAdmin):
     search_fields = ["==safe", "==module", "==to"]
 
     def data_hex(self, o: ModuleTransaction):
-        return HexBytes(o.data).hex() if o.data else None
+        return to_0x_hex_str(HexBytes(o.data)) if o.data else None
 
     def tx_hash(self, o: ModuleTransaction):
         return o.internal_tx.ethereum_tx_id

--- a/safe_transaction_service/history/indexers/element_already_processed_checker.py
+++ b/safe_transaction_service/history/indexers/element_already_processed_checker.py
@@ -2,6 +2,7 @@ from logging import getLogger
 from typing import Optional
 
 from hexbytes import HexBytes
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.utils.utils import FixedSizeDict
 
@@ -53,16 +54,16 @@ class ElementAlreadyProcessedChecker:
         if tx_id in self._processed_element_cache:
             logger.debug(
                 "Element with tx-hash=%s on block=%s with index=%d was already processed",
-                tx_hash.hex(),
-                block_hash.hex(),
+                to_0x_hex_str(tx_hash),
+                to_0x_hex_str(block_hash),
                 index,
             )
             return False
         else:
             logger.debug(
                 "Marking element with tx-hash=%s on block=%s with index=%d as processed",
-                tx_hash.hex(),
-                block_hash.hex(),
+                to_0x_hex_str(tx_hash),
+                to_0x_hex_str(block_hash),
                 index,
             )
             self._processed_element_cache[tx_id] = None

--- a/safe_transaction_service/history/indexers/events_indexer.py
+++ b/safe_transaction_service/history/indexers/events_indexer.py
@@ -11,6 +11,7 @@ from eth_typing import ChecksumAddress, HexStr
 from eth_utils import event_abi_to_log_topic
 from gevent import pool
 from hexbytes import HexBytes
+from safe_eth.util.util import to_0x_hex_str
 from web3.contract.contract import ContractEvent
 from web3.exceptions import LogTopicError
 from web3.types import EventData, FilterParams, LogReceipt
@@ -75,7 +76,7 @@ class EventsIndexer(EthereumIndexer):
         """
         events_to_listen = {}
         for event in self.contract_events:
-            key = HexStr(HexBytes(event_abi_to_log_topic(event.abi)).hex())
+            key = to_0x_hex_str(HexBytes(event_abi_to_log_topic(event.abi)))
             events_to_listen.setdefault(key, []).append(event)
         return events_to_listen
 
@@ -221,7 +222,7 @@ class EventsIndexer(EthereumIndexer):
             or `None` if decoding was not possible
         """
         for event_to_listen in self.events_to_listen[
-            HexStr(log_receipt["topics"][0].hex())
+            to_0x_hex_str(log_receipt["topics"][0])
         ]:
             # Try to decode using all the existing ABIs
             # One topic can have multiple matching ABIs due to `indexed` elements changing how to decode it

--- a/safe_transaction_service/history/indexers/internal_tx_indexer.py
+++ b/safe_transaction_service/history/indexers/internal_tx_indexer.py
@@ -8,6 +8,7 @@ from django.db import transaction
 from eth_typing import ChecksumAddress, HexStr
 from hexbytes import HexBytes
 from safe_eth.eth import EthereumClient
+from safe_eth.util.util import to_0x_hex_str
 from web3.types import BlockTrace, FilterTrace
 
 from safe_transaction_service.contracts.tx_decoder import (
@@ -251,9 +252,11 @@ class InternalTxIndexer(EthereumIndexer):
                     processed=False,
                 )
             except CannotDecode as exc:
-                logger.debug("Cannot decode %s: %s", data.hex(), exc)
+                logger.debug("Cannot decode %s: %s", to_0x_hex_str(data), exc)
             except UnexpectedProblemDecoding as exc:
-                logger.warning("Unexpected problem decoding %s: %s", data.hex(), exc)
+                logger.warning(
+                    "Unexpected problem decoding %s: %s", to_0x_hex_str(data), exc
+                )
 
     def trace_transactions(
         self, tx_hashes: Sequence[HexStr], batch_size: int

--- a/safe_transaction_service/history/indexers/proxy_factory_indexer.py
+++ b/safe_transaction_service/history/indexers/proxy_factory_indexer.py
@@ -9,6 +9,7 @@ from safe_eth.eth.contracts import (
     get_proxy_factory_V1_3_0_contract,
     get_proxy_factory_V1_4_1_contract,
 )
+from safe_eth.util.util import to_0x_hex_str
 from web3.contract.contract import ContractEvent
 from web3.types import EventData, LogReceipt
 
@@ -72,7 +73,7 @@ class ProxyFactoryIndexer(EventsIndexer):
         contract_address = decoded_element["args"]["proxy"]
         if contract_address != NULL_ADDRESS:
             if (block_number := decoded_element["blockNumber"]) == 0:
-                transaction_hash = decoded_element["transactionHash"].hex()
+                transaction_hash = to_0x_hex_str(decoded_element["transactionHash"])
                 log_msg = (
                     f"Events are reporting blockNumber=0 for tx-hash={transaction_hash}"
                 )

--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -17,6 +17,7 @@ from safe_eth.eth.contracts import (
     get_safe_V1_3_0_contract,
     get_safe_V1_4_1_contract,
 )
+from safe_eth.util.util import to_0x_hex_str
 from web3.contract.contract import ContractEvent
 from web3.types import EventData
 
@@ -345,7 +346,7 @@ class SafeEventsIndexer(EventsIndexer):
         trace_address = str(log_index)
         args = dict(decoded_element["args"])
         ethereum_tx_hash = HexBytes(decoded_element["transactionHash"])
-        ethereum_tx_hash_hex = ethereum_tx_hash.hex()
+        ethereum_tx_hash_hex = to_0x_hex_str(ethereum_tx_hash)
         ethereum_block_timestamp = EthereumBlock.objects.get_timestamp_by_hash(
             decoded_element["blockHash"]
         )
@@ -377,8 +378,8 @@ class SafeEventsIndexer(EventsIndexer):
         elif event_name == "SafeMultiSigTransaction":
             internal_tx_decoded.function_name = "execTransaction"
             data = HexBytes(args["data"])
-            args["data"] = data.hex()
-            args["signatures"] = HexBytes(args["signatures"]).hex()
+            args["data"] = to_0x_hex_str(data)
+            args["signatures"] = to_0x_hex_str(HexBytes(args["signatures"]))
             additional_info = HexBytes(
                 internal_tx_decoded.arguments.pop("additionalInfo")
             )
@@ -393,7 +394,7 @@ class SafeEventsIndexer(EventsIndexer):
                     safe_address,
                     event_name,
                     ethereum_tx_hash_hex,
-                    additional_info.hex(),
+                    to_0x_hex_str(additional_info),
                 )
             if args["value"] and not data:  # Simulate ether transfer
                 child_internal_tx = self._get_internal_tx_from_decoded_event(
@@ -405,10 +406,10 @@ class SafeEventsIndexer(EventsIndexer):
 
         elif event_name == "SafeModuleTransaction":
             internal_tx_decoded.function_name = "execTransactionFromModule"
-            args["data"] = HexBytes(args["data"]).hex()
+            args["data"] = to_0x_hex_str(HexBytes(args["data"]))
         elif event_name == "ApproveHash":
             internal_tx_decoded.function_name = "approveHash"
-            args["hashToApprove"] = args.pop("approvedHash").hex()
+            args["hashToApprove"] = to_0x_hex_str(args.pop("approvedHash"))
         elif event_name == "EnabledModule":
             internal_tx_decoded.function_name = "enableModule"
         elif event_name == "DisabledModule":
@@ -464,7 +465,7 @@ class SafeEventsIndexer(EventsIndexer):
                         "Ignoring already processed event %s for Safe %s on tx-hash=%s: %s",
                         event_name,
                         safe_address,
-                        decoded_element["transactionHash"].hex(),
+                        to_0x_hex_str(decoded_element["transactionHash"]),
                         exc,
                     )
                     return None
@@ -624,7 +625,7 @@ class SafeEventsIndexer(EventsIndexer):
                 except IntegrityError:
                     logger.info(
                         "Ignoring already processed InternalTx with tx-hash=%s and trace-address=%s",
-                        internal_decoded_tx.internal_tx.ethereum_tx_id.hex(),
+                        to_0x_hex_str(internal_decoded_tx.internal_tx.ethereum_tx_id),
                         internal_decoded_tx.internal_tx.trace_address,
                     )
                     pass
@@ -637,7 +638,7 @@ class SafeEventsIndexer(EventsIndexer):
                 except IntegrityError:
                     logger.info(
                         "Ignoring already processed InternalTx with tx-hash=%s and trace-address=%s",
-                        internal_tx.ethereum_tx_id.hex(),
+                        to_0x_hex_str(internal_tx.ethereum_tx_id),
                         internal_tx.trace_address,
                     )
                     pass

--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -24,6 +24,7 @@ from safe_eth.eth.django.serializers import (
 from safe_eth.safe import Safe
 from safe_eth.safe.safe_signature import EthereumBytes, SafeSignature, SafeSignatureType
 from safe_eth.safe.serializers import SafeMultisigTxSerializer
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.account_abstraction import serializers as aa_serializers
 from safe_transaction_service.contracts.tx_decoder import (
@@ -125,7 +126,7 @@ class SafeMultisigConfirmationSerializer(serializers.Serializer):
                 )
             if not safe_signature.is_valid(ethereum_client, safe_address):
                 raise ValidationError(
-                    f"Signature={safe_signature.signature.hex()} for owner={owner} is not valid"
+                    f"Signature={to_0x_hex_str(safe_signature.signature)} for owner={owner} is not valid"
                 )
             if owner in signature_owners:
                 raise ValidationError(f"Signature for owner={owner} is duplicated")
@@ -203,8 +204,8 @@ class SafeMultisigTransactionSerializer(SafeMultisigTxSerializer):
         # Check safe tx hash matches
         if safe_tx_hash != attrs["contract_transaction_hash"]:
             raise ValidationError(
-                f"Contract-transaction-hash={safe_tx_hash.hex()} "
-                f'does not match provided contract-tx-hash={attrs["contract_transaction_hash"].hex()}'
+                f"Contract-transaction-hash={to_0x_hex_str(safe_tx_hash)} "
+                f'does not match provided contract-tx-hash={to_0x_hex_str(attrs["contract_transaction_hash"])}'
             )
 
         # Check there's not duplicated tx with same `nonce` or same `safeTxHash` for the same Safe.
@@ -214,9 +215,9 @@ class SafeMultisigTransactionSerializer(SafeMultisigTxSerializer):
         ).executed()
         if multisig_transactions:
             for multisig_transaction in multisig_transactions:
-                if multisig_transaction.safe_tx_hash == safe_tx_hash.hex():
+                if multisig_transaction.safe_tx_hash == to_0x_hex_str(safe_tx_hash):
                     raise ValidationError(
-                        f"Tx with safe-tx-hash={safe_tx_hash.hex()} "
+                        f"Tx with safe-tx-hash={to_0x_hex_str(safe_tx_hash)} "
                         f"for safe={safe_address} was already executed in "
                         f"tx-hash={multisig_transaction.ethereum_tx_id}"
                     )
@@ -252,7 +253,7 @@ class SafeMultisigTransactionSerializer(SafeMultisigTxSerializer):
             owner = safe_signature.owner
             if not safe_signature.is_valid(ethereum_client, safe_address):
                 raise ValidationError(
-                    f"Signature={safe_signature.signature.hex()} for owner={owner} is not valid"
+                    f"Signature={to_0x_hex_str(safe_signature.signature)} for owner={owner} is not valid"
                 )
 
             if owner in delegates and len(parsed_signatures) > 1:

--- a/safe_transaction_service/history/services/notification_service.py
+++ b/safe_transaction_service/history/services/notification_service.py
@@ -6,6 +6,7 @@ from django.db.models import Model
 from django.utils import timezone
 
 from hexbytes import HexBytes
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.history.models import (
     ERC20Transfer,
@@ -51,9 +52,9 @@ def build_event_payload(
                 "address": instance.multisig_transaction.safe,  # This could make a db call
                 "type": TransactionServiceEventType.NEW_CONFIRMATION.name,
                 "owner": instance.owner,
-                "safeTxHash": HexBytes(
-                    instance.multisig_transaction.safe_tx_hash
-                ).hex(),
+                "safeTxHash": to_0x_hex_str(
+                    HexBytes(instance.multisig_transaction.safe_tx_hash)
+                ),
             }
         ]
     elif sender == MultisigTransaction and deleted:
@@ -61,16 +62,16 @@ def build_event_payload(
             {
                 "address": instance.safe,
                 "type": TransactionServiceEventType.DELETED_MULTISIG_TRANSACTION.name,
-                "safeTxHash": HexBytes(instance.safe_tx_hash).hex(),
+                "safeTxHash": to_0x_hex_str(HexBytes(instance.safe_tx_hash)),
             }
         ]
     elif sender == MultisigTransaction:
         payload = {
             "address": instance.safe,
             #  'type': None,  It will be assigned later
-            "safeTxHash": HexBytes(instance.safe_tx_hash).hex(),
+            "safeTxHash": to_0x_hex_str(HexBytes(instance.safe_tx_hash)),
             "to": instance.to,
-            "data": HexBytes(instance.data).hex() if instance.data else None,
+            "data": to_0x_hex_str(HexBytes(instance.data)) if instance.data else None,
         }
         if instance.executed:
             payload["type"] = (
@@ -79,7 +80,7 @@ def build_event_payload(
             payload["failed"] = json.dumps(
                 instance.failed
             )  # Firebase only accepts strings
-            payload["txHash"] = HexBytes(instance.ethereum_tx_id).hex()
+            payload["txHash"] = to_0x_hex_str(HexBytes(instance.ethereum_tx_id))
         else:
             payload["type"] = (
                 TransactionServiceEventType.PENDING_MULTISIG_TRANSACTION.name
@@ -89,7 +90,7 @@ def build_event_payload(
         incoming_payload = {
             "address": instance.to,
             "type": TransactionServiceEventType.INCOMING_ETHER.name,
-            "txHash": HexBytes(instance.ethereum_tx_id).hex(),
+            "txHash": to_0x_hex_str(HexBytes(instance.ethereum_tx_id)),
             "value": str(instance.value),
         }
         outgoing_payload = dict(incoming_payload)
@@ -102,7 +103,7 @@ def build_event_payload(
             "address": instance.to,
             "type": TransactionServiceEventType.INCOMING_TOKEN.name,
             "tokenAddress": instance.address,
-            "txHash": HexBytes(instance.ethereum_tx_id).hex(),
+            "txHash": to_0x_hex_str(HexBytes(instance.ethereum_tx_id)),
         }
         if isinstance(instance, ERC20Transfer):
             incoming_payload["value"] = str(instance.value)
@@ -117,7 +118,7 @@ def build_event_payload(
             {
                 "address": instance.address,
                 "type": TransactionServiceEventType.SAFE_CREATED.name,
-                "txHash": HexBytes(instance.ethereum_tx_id).hex(),
+                "txHash": to_0x_hex_str(HexBytes(instance.ethereum_tx_id)),
                 "blockNumber": instance.created_block_number,
             }
         ]
@@ -127,7 +128,7 @@ def build_event_payload(
                 "address": instance.safe,
                 "type": TransactionServiceEventType.MODULE_TRANSACTION.name,
                 "module": instance.module,
-                "txHash": HexBytes(instance.internal_tx.ethereum_tx_id).hex(),
+                "txHash": to_0x_hex_str(HexBytes(instance.internal_tx.ethereum_tx_id)),
             }
         ]
     elif sender == SafeMessage:
@@ -135,7 +136,7 @@ def build_event_payload(
             {
                 "address": instance.safe,
                 "type": TransactionServiceEventType.MESSAGE_CREATED.name,
-                "messageHash": HexBytes(instance.message_hash).hex(),
+                "messageHash": to_0x_hex_str(HexBytes(instance.message_hash)),
             }
         ]
     elif sender == SafeMessageConfirmation:
@@ -143,7 +144,9 @@ def build_event_payload(
             {
                 "address": instance.safe_message.safe,  # This could make a db call
                 "type": TransactionServiceEventType.MESSAGE_CONFIRMATION.name,
-                "messageHash": HexBytes(instance.safe_message.message_hash).hex(),
+                "messageHash": to_0x_hex_str(
+                    HexBytes(instance.safe_message.message_hash)
+                ),
             }
         ]
 

--- a/safe_transaction_service/history/services/reorg_service.py
+++ b/safe_transaction_service/history/services/reorg_service.py
@@ -6,6 +6,7 @@ from django.db import transaction
 
 from hexbytes import HexBytes
 from safe_eth.eth import EthereumClient, get_auto_ethereum_client
+from safe_eth.util.util import to_0x_hex_str
 
 from ..indexers import (
     Erc20EventsIndexerProvider,
@@ -123,15 +124,15 @@ class ReorgService:
                         logger.debug(
                             "Block with number=%d and hash=%s is matching blockchain one, setting as confirmed",
                             database_block.number,
-                            HexBytes(blockchain_block["hash"]).hex(),
+                            to_0x_hex_str(HexBytes(blockchain_block["hash"])),
                         )
                         database_block.set_confirmed()
                 else:
                     logger.warning(
                         "Block with number=%d and hash=%s is not matching blockchain hash=%s, reorg found",
                         database_block.number,
-                        HexBytes(database_block.block_hash).hex(),
-                        HexBytes(blockchain_block["hash"]).hex(),
+                        to_0x_hex_str(HexBytes(database_block.block_hash)),
+                        to_0x_hex_str(HexBytes(blockchain_block["hash"])),
                     )
                     return database_block.number
 

--- a/safe_transaction_service/history/services/safe_service.py
+++ b/safe_transaction_service/history/services/safe_service.py
@@ -17,6 +17,7 @@ from safe_eth.safe.exceptions import CannotRetrieveSafeInfoException
 from safe_eth.safe.multi_send import MultiSend
 from safe_eth.safe.safe import SafeInfo
 from web3 import Web3
+from web3.exceptions import Web3RPCError
 
 from safe_transaction_service.account_abstraction import models as aa_models
 from safe_transaction_service.utils.abis.gelato import gelato_relay_1_balance_v2_abi
@@ -394,7 +395,7 @@ class SafeService:
             return next_traces and InternalTx.objects.build_from_trace(
                 next_traces[0], internal_tx.ethereum_tx
             )
-        except ValueError:
+        except (ValueError, Web3RPCError):
             return None
 
     def _get_parent_internal_tx(self, internal_tx: InternalTx) -> Optional[InternalTx]:
@@ -411,5 +412,5 @@ class SafeService:
             return previous_trace and InternalTx.objects.build_from_trace(
                 previous_trace, internal_tx.ethereum_tx
             )
-        except ValueError:
+        except (ValueError, Web3RPCError):
             return None

--- a/safe_transaction_service/history/tests/factories.py
+++ b/safe_transaction_service/history/tests/factories.py
@@ -11,6 +11,7 @@ from hexbytes import HexBytes
 from safe_eth.eth.constants import NULL_ADDRESS
 from safe_eth.eth.utils import fast_keccak_text
 from safe_eth.safe.safe_signature import SafeSignatureType
+from safe_eth.util.util import to_0x_hex_str
 
 from ..models import (
     ERC20Transfer,
@@ -53,8 +54,12 @@ class EthereumBlockFactory(DjangoModelFactory):
     gas_limit = factory.fuzzy.FuzzyInteger(100000000, 200000000)
     gas_used = factory.fuzzy.FuzzyInteger(100000, 500000)
     timestamp = factory.LazyFunction(timezone.now)
-    block_hash = factory.Sequence(lambda n: fast_keccak_text(f"block-{n}").hex())
-    parent_hash = factory.Sequence(lambda n: fast_keccak_text(f"block{n - 1}").hex())
+    block_hash = factory.Sequence(
+        lambda n: to_0x_hex_str(fast_keccak_text(f"block-{n}"))
+    )
+    parent_hash = factory.Sequence(
+        lambda n: to_0x_hex_str(fast_keccak_text(f"block{n - 1}"))
+    )
 
 
 class EthereumTxFactory(DjangoModelFactory):
@@ -63,7 +68,7 @@ class EthereumTxFactory(DjangoModelFactory):
 
     block = factory.SubFactory(EthereumBlockFactory)
     tx_hash = factory.Sequence(
-        lambda n: fast_keccak_text(f"ethereum_tx_hash-{n}").hex()
+        lambda n: to_0x_hex_str(fast_keccak_text(f"ethereum_tx_hash-{n}"))
     )
     _from = factory.LazyFunction(lambda: Account.create().address)
     gas = factory.fuzzy.FuzzyInteger(1000, 5000)
@@ -274,7 +279,7 @@ class MultisigTransactionFactory(DjangoModelFactory):
         model = MultisigTransaction
 
     safe_tx_hash = factory.Sequence(
-        lambda n: fast_keccak_text(f"multisig-tx-{n}").hex()
+        lambda n: to_0x_hex_str(fast_keccak_text(f"multisig-tx-{n}"))
     )
     safe = factory.LazyFunction(lambda: Account.create().address)
     proposer = None
@@ -313,7 +318,7 @@ class MultisigConfirmationFactory(DjangoModelFactory):
     ethereum_tx = factory.SubFactory(EthereumTxFactory)
     multisig_transaction = factory.SubFactory(MultisigTransactionFactory)
     multisig_transaction_hash = factory.Sequence(
-        lambda n: fast_keccak_text(f"multisig-confirmation-tx-{n}").hex()
+        lambda n: to_0x_hex_str(fast_keccak_text(f"multisig-confirmation-tx-{n}"))
     )
     owner = factory.LazyFunction(lambda: Account.create().address)
     signature = None

--- a/safe_transaction_service/history/tests/test_internal_tx_indexer.py
+++ b/safe_transaction_service/history/tests/test_internal_tx_indexer.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from eth_typing import HexStr
 from safe_eth.eth import EthereumClient
 from safe_eth.eth.ethereum_client import TracingManager
+from safe_eth.util.util import to_0x_hex_str
 
 from ..indexers import InternalTxIndexer, InternalTxIndexerProvider
 from ..indexers.internal_tx_indexer import InternalTxIndexerWithTraceBlock
@@ -65,7 +66,7 @@ class TestInternalTxIndexer(TestCase):
         :param hashes:
         :return:
         """
-        block_dict = {block["hash"].hex(): block for block in block_result}
+        block_dict = {to_0x_hex_str(block["hash"]): block for block in block_result}
         return [block_dict[provided_hash] for provided_hash in hashes]
 
     @mock.patch.object(

--- a/safe_transaction_service/history/tests/test_migrations.py
+++ b/safe_transaction_service/history/tests/test_migrations.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from django_test_migrations.migrator import Migrator
 from eth_account import Account
 from safe_eth.eth.utils import fast_keccak, fast_keccak_text
+from safe_eth.util.util import to_0x_hex_str
 
 
 class TestMigrations(TestCase):
@@ -53,7 +54,7 @@ class TestMigrations(TestCase):
         ]
         for origin in origins:
             MultisigTransactionOld.objects.create(
-                safe_tx_hash=fast_keccak_text(f"multisig-tx-{origin}").hex(),
+                safe_tx_hash=to_0x_hex_str(fast_keccak_text(f"multisig-tx-{origin}")),
                 safe=Account.create().address,
                 value=0,
                 operation=0,
@@ -72,21 +73,21 @@ class TestMigrations(TestCase):
         )
 
         # String should keep string
-        hash = fast_keccak_text(f"multisig-tx-{origins[0]}").hex()
+        hash = to_0x_hex_str(fast_keccak_text(f"multisig-tx-{origins[0]}"))
         self.assertEqual(MultisigTransactionNew.objects.get(pk=hash).origin, origins[0])
 
         # String json should be converted to json
-        hash = fast_keccak_text(f"multisig-tx-{origins[1]}").hex()
+        hash = to_0x_hex_str(fast_keccak_text(f"multisig-tx-{origins[1]}"))
         self.assertEqual(
             MultisigTransactionNew.objects.get(pk=hash).origin, json.loads(origins[1])
         )
 
         # Empty string should be empty object
-        hash = fast_keccak_text(f"multisig-tx-{origins[2]}").hex()
+        hash = to_0x_hex_str(fast_keccak_text(f"multisig-tx-{origins[2]}"))
         self.assertEqual(MultisigTransactionNew.objects.get(pk=hash).origin, {})
 
         # None should be empty object
-        hash = fast_keccak_text(f"multisig-tx-{origins[2]}").hex()
+        hash = to_0x_hex_str(fast_keccak_text(f"multisig-tx-{origins[2]}"))
         self.assertEqual(MultisigTransactionNew.objects.get(pk=hash).origin, {})
 
     def test_migration_backward_0068(self):
@@ -99,7 +100,7 @@ class TestMigrations(TestCase):
         origins = ["{ TestString", {"url": "https://example.com", "name": "app"}, {}]
         for origin in origins:
             MultisigTransactionNew.objects.create(
-                safe_tx_hash=fast_keccak_text(f"multisig-tx-{origin}").hex(),
+                safe_tx_hash=to_0x_hex_str(fast_keccak_text(f"multisig-tx-{origin}")),
                 safe=Account.create().address,
                 value=0,
                 operation=0,
@@ -118,17 +119,17 @@ class TestMigrations(TestCase):
         )
 
         # String should keep string
-        hash = fast_keccak_text(f"multisig-tx-{origins[0]}").hex()
+        hash = to_0x_hex_str(fast_keccak_text(f"multisig-tx-{origins[0]}"))
         self.assertEqual(MultisigTransactionOld.objects.get(pk=hash).origin, origins[0])
 
         # Json should be converted to a string json
-        hash = fast_keccak_text(f"multisig-tx-{origins[1]}").hex()
+        hash = to_0x_hex_str(fast_keccak_text(f"multisig-tx-{origins[1]}"))
         self.assertEqual(
             MultisigTransactionOld.objects.get(pk=hash).origin, json.dumps(origins[1])
         )
 
         # Empty object should be None
-        hash = fast_keccak_text(f"multisig-tx-{origins[2]}").hex()
+        hash = to_0x_hex_str(fast_keccak_text(f"multisig-tx-{origins[2]}"))
         self.assertEqual(MultisigTransactionOld.objects.get(pk=hash).origin, None)
 
     def test_migration_forward_0069(self):
@@ -262,7 +263,7 @@ class TestMigrations(TestCase):
         MultisigTransaction = new_state.apps.get_model("history", "MultisigTransaction")
         for origin in origins:
             MultisigTransaction.objects.create(
-                safe_tx_hash=fast_keccak_text(f"multisig-tx-{origin}").hex(),
+                safe_tx_hash=to_0x_hex_str(fast_keccak_text(f"multisig-tx-{origin}")),
                 safe=Account.create().address,
                 value=0,
                 operation=0,
@@ -310,7 +311,7 @@ class TestMigrations(TestCase):
         MultisigTransaction = new_state.apps.get_model("history", "MultisigTransaction")
         for origin in origins:
             MultisigTransaction.objects.create(
-                safe_tx_hash=fast_keccak_text(f"multisig-tx-{origin}").hex(),
+                safe_tx_hash=to_0x_hex_str(fast_keccak_text(f"multisig-tx-{origin}")),
                 safe=Account.create().address,
                 value=0,
                 operation=0,

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -214,7 +214,7 @@ class TestMultisigTransaction(TestCase):
         self.assertEqual(multisig_transaction.owners, [])
 
         account = Account.create()
-        multisig_transaction.signatures = account.signHash(
+        multisig_transaction.signatures = account.unsafe_sign_hash(
             multisig_transaction.safe_tx_hash
         )["signature"]
         multisig_transaction.save()

--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -7,6 +7,7 @@ from safe_eth.eth.constants import NULL_ADDRESS, SENTINEL_ADDRESS
 from safe_eth.eth.contracts import get_safe_V1_3_0_contract, get_safe_V1_4_1_contract
 from safe_eth.safe import Safe
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
+from safe_eth.util.util import to_0x_hex_str
 from web3 import Web3
 from web3.auto import w3
 from web3.datastructures import AttributeDict
@@ -139,7 +140,8 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
 
         # Dangling event topic is "supported"
         self.assertIn(
-            dangling_event["topics"][0].hex(), self.safe_events_indexer.events_to_listen
+            to_0x_hex_str(dangling_event["topics"][0]),
+            self.safe_events_indexer.events_to_listen,
         )
 
         # Dangling event cannot be decoded
@@ -147,7 +149,8 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
 
         # Valid event is supported
         self.assertIn(
-            valid_event["topics"][0].hex(), self.safe_events_indexer.events_to_listen
+            to_0x_hex_str(valid_event["topics"][0]),
+            self.safe_events_indexer.events_to_listen,
         )
 
         # Dangling event cannot be decoded, but valid event is
@@ -287,7 +290,7 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
         self.assertEqual(MultisigTransaction.objects.count(), 1)
         self.assertEqual(
             MultisigTransaction.objects.get().safe_tx_hash,
-            multisig_tx.safe_tx_hash.hex(),
+            to_0x_hex_str(multisig_tx.safe_tx_hash),
         )
         self.assertEqual(MultisigConfirmation.objects.count(), 1)
 
@@ -323,7 +326,7 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
         self.assertEqual(MultisigTransaction.objects.count(), 2)
         self.assertEqual(
             MultisigTransaction.objects.order_by("-nonce")[0].safe_tx_hash,
-            multisig_tx.safe_tx_hash.hex(),
+            to_0x_hex_str(multisig_tx.safe_tx_hash),
         )
         self.assertEqual(MultisigConfirmation.objects.count(), 2)
 
@@ -371,7 +374,7 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
         self.assertEqual(MultisigTransaction.objects.count(), 3)
         self.assertEqual(
             MultisigTransaction.objects.order_by("-nonce")[0].safe_tx_hash,
-            multisig_tx.safe_tx_hash.hex(),
+            to_0x_hex_str(multisig_tx.safe_tx_hash),
         )
         self.assertEqual(MultisigConfirmation.objects.count(), 4)
 
@@ -408,7 +411,7 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
         self.assertEqual(MultisigTransaction.objects.count(), 4)
         self.assertEqual(
             MultisigTransaction.objects.order_by("-nonce")[0].safe_tx_hash,
-            multisig_tx.safe_tx_hash.hex(),
+            to_0x_hex_str(multisig_tx.safe_tx_hash),
         )
         self.assertEqual(MultisigConfirmation.objects.count(), 5)
 
@@ -464,7 +467,7 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
         self.assertEqual(MultisigTransaction.objects.count(), 5)
         self.assertEqual(
             MultisigTransaction.objects.order_by("-nonce")[0].safe_tx_hash,
-            multisig_tx.safe_tx_hash.hex(),
+            to_0x_hex_str(multisig_tx.safe_tx_hash),
         )
         self.assertEqual(MultisigConfirmation.objects.count(), 6)
 
@@ -500,7 +503,7 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
         self.assertEqual(MultisigTransaction.objects.count(), 6)
         self.assertEqual(
             MultisigTransaction.objects.order_by("-nonce")[0].safe_tx_hash,
-            multisig_tx.safe_tx_hash.hex(),
+            to_0x_hex_str(multisig_tx.safe_tx_hash),
         )
         self.assertEqual(MultisigConfirmation.objects.count(), 7)
 
@@ -515,7 +518,7 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
             }
         )
         tx = owner_account_1.sign_transaction(tx)
-        self.w3.eth.send_raw_transaction(tx["rawTransaction"])
+        self.w3.eth.send_raw_transaction(tx["raw_transaction"])
         # Process events: ApproveHash
         self.assertEqual(self.safe_events_indexer.start(), (1, 1))
         self.safe_tx_processor.process_decoded_transactions(txs_decoded_queryset.all())
@@ -524,7 +527,7 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
         # Check a MultisigConfirmation was created
         self.assertTrue(
             MultisigConfirmation.objects.filter(
-                multisig_transaction_hash=random_hash.hex()
+                multisig_transaction_hash=to_0x_hex_str(random_hash)
             ).exists()
         )
         self.assertEqual(
@@ -559,7 +562,7 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
         self.assertEqual(MultisigTransaction.objects.count(), 7)
         self.assertEqual(
             MultisigTransaction.objects.order_by("-nonce")[0].safe_tx_hash,
-            multisig_tx.safe_tx_hash.hex(),
+            to_0x_hex_str(multisig_tx.safe_tx_hash),
         )
         self.assertEqual(MultisigConfirmation.objects.count(), 9)
 
@@ -602,7 +605,7 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
 
         self.assertEqual(
             MultisigTransaction.objects.order_by("-nonce")[0].safe_tx_hash,
-            multisig_tx.safe_tx_hash.hex(),
+            to_0x_hex_str(multisig_tx.safe_tx_hash),
         )
         expected_multisig_transactions = 8
         expected_multisig_confirmations = 10
@@ -802,7 +805,7 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
             {"nonce": self.w3.eth.get_transaction_count(owner_account_1.address)}
         )
         signed_tx = owner_account_1.sign_transaction(setup_call)
-        tx_hash = w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
         self.assertEqual(self.safe_events_indexer.start(), (1, 1))
         # We remove the proxyCreation internaltx
         self.assertEqual(InternalTx.objects.count(), 1)
@@ -830,7 +833,7 @@ class TestSafeEventsIndexerV1_4_1(SafeTestCaseMixin, TestCase):
             {"nonce": self.w3.eth.get_transaction_count(owner_account_1.address)}
         )
         signed_tx = owner_account_1.sign_transaction(setup_call)
-        tx_hash = w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
         self.assertEqual(self.safe_events_indexer.start(), (2, 2))
         # Proxy creation InternalTx must contain the Safe address
         self.assertEqual(

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -11,6 +11,7 @@ import factory
 from hexbytes import HexBytes
 from safe_eth.eth import EthereumNetwork
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
+from safe_eth.util.util import to_0x_hex_str
 
 from ...events.services.queue_service import QueueService
 from ...safe_messages.models import SafeMessage, SafeMessageConfirmation
@@ -183,7 +184,9 @@ class TestSignals(SafeTestCaseMixin, TestCase):
             "type": TransactionServiceEventType.EXECUTED_MULTISIG_TRANSACTION.name,
             "safeTxHash": multisig_tx.safe_tx_hash,
             "to": multisig_tx.to,
-            "data": HexBytes(multisig_tx.data).hex() if multisig_tx.data else None,
+            "data": (
+                to_0x_hex_str(HexBytes(multisig_tx.data)) if multisig_tx.data else None
+            ),
             "failed": "false",
             "txHash": multisig_tx.ethereum_tx_id,
             "chainId": str(EthereumNetwork.GANACHE.value),

--- a/safe_transaction_service/history/tests/test_tx_processor.py
+++ b/safe_transaction_service/history/tests/test_tx_processor.py
@@ -9,6 +9,7 @@ from safe_eth.eth.ethereum_client import TracingManager
 from safe_eth.eth.utils import fast_keccak_text
 from safe_eth.safe.safe_signature import SafeSignatureType
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.safe_messages.models import SafeMessageConfirmation
 from safe_transaction_service.safe_messages.tests.factories import (
@@ -354,7 +355,7 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
             self.assertTrue(multisig_transaction.trusted)
 
         # Test ApproveHash. For that we need the `previous_trace` to get the owner
-        hash_to_approve = keccak(text="HariSeldon").hex()
+        hash_to_approve = to_0x_hex_str(keccak(text="HariSeldon"))
         owner_approving = Account.create().address
         approve_hash_decoded_tx = InternalTxDecodedFactory(
             function_name="approveHash",
@@ -411,7 +412,7 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         ethereum_tx = EthereumTxFactory(logs=logs)
         self.assertTrue(tx_processor.is_failed(ethereum_tx, logs[0]["data"]))
         self.assertFalse(
-            tx_processor.is_failed(ethereum_tx, fast_keccak_text("hola").hex())
+            tx_processor.is_failed(ethereum_tx, to_0x_hex_str(fast_keccak_text("hola")))
         )
 
         # Event for Safes >= 1.1.1
@@ -430,7 +431,7 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         ethereum_tx = EthereumTxFactory(logs=logs)
         self.assertTrue(tx_processor.is_failed(ethereum_tx, safe_tx_hash))
         self.assertFalse(
-            tx_processor.is_failed(ethereum_tx, fast_keccak_text("hola").hex())
+            tx_processor.is_failed(ethereum_tx, to_0x_hex_str(fast_keccak_text("hola")))
         )
 
         # Event for Safes >= 1.4.1
@@ -449,7 +450,7 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         ethereum_tx = EthereumTxFactory(logs=logs)
         self.assertTrue(tx_processor.is_failed(ethereum_tx, safe_tx_hash))
         self.assertFalse(
-            tx_processor.is_failed(ethereum_tx, fast_keccak_text("hola").hex())
+            tx_processor.is_failed(ethereum_tx, to_0x_hex_str(fast_keccak_text("hola")))
         )
 
     def test_tx_is_version_breaking_signatures(self):
@@ -566,7 +567,7 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
             self.assertEqual(ModuleTransaction.objects.count(), 1)
             module_tx = ModuleTransaction.objects.get()
             self.assertEqual(
-                "0x" + bytes(module_tx.data).hex(),
+                to_0x_hex_str(bytes(module_tx.data)),
                 module_internal_tx_decoded.arguments["data"],
             )
             self.assertEqual(

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -24,6 +24,7 @@ from safe_eth.safe import CannotEstimateGas, Safe, SafeOperationEnum
 from safe_eth.safe.safe_signature import SafeSignature, SafeSignatureType
 from safe_eth.safe.signatures import signature_to_bytes
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.account_abstraction.tests import factories as aa_factories
 from safe_transaction_service.contracts.models import ContractQuerySet
@@ -710,7 +711,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
                 "module": module_transaction.module,
                 "to": module_transaction.to,
                 "value": str(module_transaction.value),
-                "data": module_transaction.data.hex(),
+                "data": to_0x_hex_str(module_transaction.data),
                 "operation": module_transaction.operation,
                 "dataDecoded": None,
                 "moduleTransactionId": module_transaction_id,
@@ -718,7 +719,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         )
 
     def test_get_multisig_confirmation(self):
-        random_safe_tx_hash = fast_keccak_text("enxebre").hex()
+        random_safe_tx_hash = to_0x_hex_str(fast_keccak_text("enxebre"))
         response = self.client.get(
             reverse(
                 "v1:history:multisig-transaction-confirmations",
@@ -744,11 +745,11 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         self.assertEqual(response.data["count"], 2)
 
     def test_post_multisig_confirmation(self):
-        random_safe_tx_hash = fast_keccak_text("enxebre").hex()
+        random_safe_tx_hash = to_0x_hex_str(fast_keccak_text("enxebre"))
         data = {
-            "signature": Account.create()
-            .signHash(random_safe_tx_hash)["signature"]
-            .hex()  # Not valid signature
+            "signature": to_0x_hex_str(
+                Account.create().unsafe_sign_hash(random_safe_tx_hash)["signature"]
+            )  # Not valid signature
         }
         response = self.client.post(
             reverse(
@@ -782,9 +783,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
 
         random_account = Account.create()
         data = {
-            "signature": random_account.signHash(safe_tx_hash)[
-                "signature"
-            ].hex()  # Not valid signature
+            "signature": to_0x_hex_str(
+                random_account.unsafe_sign_hash(safe_tx_hash)["signature"]
+            )  # Not valid signature
         }
         # Transaction was executed, confirmations cannot be added
         response = self.client.post(
@@ -816,7 +817,11 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             response.data["signature"][0],
         )
 
-        data = {"signature": owner_account_1.signHash(safe_tx_hash)["signature"].hex()}
+        data = {
+            "signature": to_0x_hex_str(
+                owner_account_1.unsafe_sign_hash(safe_tx_hash)["signature"]
+            )
+        }
         self.assertEqual(MultisigConfirmation.objects.count(), 0)
         response = self.client.post(
             reverse(
@@ -836,10 +841,10 @@ class TestViews(SafeTestCaseMixin, APITestCase):
 
         # Add multiple signatures
         data = {
-            "signature": (
-                owner_account_1.signHash(safe_tx_hash)["signature"]
-                + owner_account_2.signHash(safe_tx_hash)["signature"]
-            ).hex()
+            "signature": to_0x_hex_str(
+                owner_account_1.unsafe_sign_hash(safe_tx_hash)["signature"]
+                + owner_account_2.unsafe_sign_hash(safe_tx_hash)["signature"]
+            )
         }
         self.assertEqual(MultisigConfirmation.objects.count(), 1)
         response = self.client.post(
@@ -853,7 +858,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         self.assertEqual(MultisigConfirmation.objects.count(), 2)
 
     def test_get_multisig_transaction(self):
-        safe_tx_hash = fast_keccak_text("gnosis").hex()
+        safe_tx_hash = to_0x_hex_str(fast_keccak_text("gnosis"))
         response = self.client.get(
             reverse("v1:history:multisig-transaction", args=(safe_tx_hash,)),
             format="json",
@@ -950,7 +955,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
 
     def test_delete_multisig_transaction(self):
         owner_account = Account.create()
-        safe_tx_hash = fast_keccak_text("random-tx").hex()
+        safe_tx_hash = to_0x_hex_str(fast_keccak_text("random-tx"))
         url = reverse("v1:history:multisig-transaction", args=(safe_tx_hash,))
         data = {"signature": "0x" + "1" * (130 * 2)}  # 2 signatures of 65 bytes
         response = self.client.delete(url, format="json", data=data)
@@ -1032,9 +1037,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         multisig_transaction.proposer = owner_account.address
         multisig_transaction.save(update_fields=["proposer"])
         data = {
-            "signature": owner_account.signHash(safe_tx_hash)[
-                "signature"
-            ].hex()  # Random signature
+            "signature": to_0x_hex_str(
+                owner_account.unsafe_sign_hash(safe_tx_hash)["signature"]
+            )  # Random signature
         }
         response = self.client.delete(url, format="json", data=data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -1069,7 +1074,11 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         multisig_transaction.proposer = owner_account.address
         multisig_transaction.proposed_by_delegate = safe_delegate.address
         multisig_transaction.save(update_fields=["proposer", "proposed_by_delegate"])
-        data = {"signature": safe_delegate.signHash(message_hash)["signature"].hex()}
+        data = {
+            "signature": to_0x_hex_str(
+                safe_delegate.unsafe_sign_hash(message_hash)["signature"]
+            )
+        }
         response = self.client.delete(url, format="json", data=data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertDictEqual(
@@ -1089,7 +1098,11 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         multisig_transaction.proposer = owner_account.address
         multisig_transaction.proposed_by_delegate = safe_delegate.address
         multisig_transaction.save(update_fields=["proposer", "proposed_by_delegate"])
-        data = {"signature": safe_delegate.signHash(message_hash)["signature"].hex()}
+        data = {
+            "signature": to_0x_hex_str(
+                safe_delegate.unsafe_sign_hash(message_hash)["signature"]
+            )
+        }
         response = self.client.delete(url, format="json", data=data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertDictEqual(
@@ -1113,7 +1126,11 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         multisig_transaction.proposer = owner_account.address
         multisig_transaction.proposed_by_delegate = safe_delegate.address
         multisig_transaction.save(update_fields=["proposer", "proposed_by_delegate"])
-        data = {"signature": safe_delegate.signHash(message_hash)["signature"].hex()}
+        data = {
+            "signature": to_0x_hex_str(
+                safe_delegate.unsafe_sign_hash(message_hash)["signature"]
+            )
+        }
         self.assertEqual(MultisigTransaction.objects.count(), 3)
         self.assertTrue(
             MultisigTransaction.objects.filter(safe_tx_hash=safe_tx_hash).exists()
@@ -1131,7 +1148,11 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         )
         multisig_transaction.proposer = owner_account.address
         multisig_transaction.save(update_fields=["proposer"])
-        data = {"signature": owner_account.signHash(message_hash)["signature"].hex()}
+        data = {
+            "signature": to_0x_hex_str(
+                owner_account.unsafe_sign_hash(message_hash)["signature"]
+            )
+        }
         self.assertEqual(MultisigTransaction.objects.count(), 3)
         self.assertTrue(
             MultisigTransaction.objects.filter(safe_tx_hash=safe_tx_hash).exists()
@@ -1452,7 +1473,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             data["refundReceiver"],
             safe_nonce=data["nonce"],
         )
-        data["contractTransactionHash"] = safe_tx.safe_tx_hash.hex()
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe_address,)),
             format="json",
@@ -1512,7 +1533,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             data["refundReceiver"],
             safe_nonce=data["nonce"],
         )
-        data["contractTransactionHash"] = safe_tx.safe_tx_hash.hex()
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe_address,)),
             format="json",
@@ -1536,9 +1557,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         self.assertIsNone(response.data["proposed_by_delegate"])
 
         # Test confirmation with signature
-        data["signature"] = safe_owner_1.signHash(safe_tx.safe_tx_hash)[
-            "signature"
-        ].hex()
+        data["signature"] = to_0x_hex_str(
+            safe_owner_1.unsafe_sign_hash(safe_tx.safe_tx_hash)["signature"]
+        )
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe_address,)),
             format="json",
@@ -1567,9 +1588,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
 
         # Sign with a different user that sender
         random_user_account = Account.create()
-        data["signature"] = random_user_account.signHash(safe_tx.safe_tx_hash)[
-            "signature"
-        ].hex()
+        data["signature"] = to_0x_hex_str(
+            random_user_account.unsafe_sign_hash(safe_tx.safe_tx_hash)["signature"]
+        )
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe_address,)),
             format="json",
@@ -1633,7 +1654,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             data["refundReceiver"],
             safe_nonce=data["nonce"],
         )
-        data["contractTransactionHash"] = safe_tx.safe_tx_hash.hex()
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe_address,)),
             format="json",
@@ -1677,7 +1698,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         safe_tx_hash_preimage = safe_tx.safe_tx_hash_preimage
 
         safe_owner_message_hash = safe_owner.get_message_hash(safe_tx_hash_preimage)
-        safe_owner_signature = account.signHash(safe_owner_message_hash)["signature"]
+        safe_owner_signature = account.unsafe_sign_hash(safe_owner_message_hash)[
+            "signature"
+        ]
         signature_1271 = (
             signature_to_bytes(
                 0, int.from_bytes(HexBytes(safe_owner.address), byteorder="big"), 65
@@ -1685,8 +1708,8 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             + eth_abi.encode(["bytes"], [safe_owner_signature])[32:]
         )
 
-        data["contractTransactionHash"] = safe_tx_hash.hex()
-        data["signature"] = signature_1271.hex()
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx_hash)
+        data["signature"] = to_0x_hex_str(signature_1271)
 
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe.address,)),
@@ -1706,7 +1729,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         response = self.client.post(
             reverse(
                 "v1:history:multisig-transaction-confirmations",
-                args=(safe_tx_hash.hex(),),
+                args=(to_0x_hex_str(safe_tx_hash),),
             ),
             format="json",
             data=confirmation_data,
@@ -1744,7 +1767,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             data["refundReceiver"],
             safe_nonce=data["nonce"],
         )
-        data["contractTransactionHash"] = safe_tx.safe_tx_hash.hex()
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
 
         factory = APIRequestFactory()
         request = factory.post(
@@ -1827,7 +1850,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             data["refundReceiver"],
             safe_nonce=data["nonce"],
         )
-        data["contractTransactionHash"] = safe_tx.safe_tx_hash.hex()
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe_address,)),
             format="json",
@@ -1872,7 +1895,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             data["refundReceiver"],
             safe_nonce=data["nonce"],
         )
-        data["contractTransactionHash"] = safe_tx.safe_tx_hash.hex()
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe_address,)),
             format="json",
@@ -1899,7 +1922,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             data["refundReceiver"],
             safe_nonce=data["nonce"],
         )
-        data["contractTransactionHash"] = safe_tx.safe_tx_hash.hex()
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe_address,)),
             format="json",
@@ -1949,7 +1972,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             data["refundReceiver"],
             safe_nonce=data["nonce"],
         )
-        data["contractTransactionHash"] = safe_tx.safe_tx_hash.hex()
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe_address,)),
             format="json",
@@ -1981,7 +2004,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             data["refundReceiver"],
             safe_nonce=data["nonce"],
         )
-        data["contractTransactionHash"] = safe_tx.safe_tx_hash.hex()
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe_address,)),
             format="json",
@@ -2036,13 +2059,15 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             safe_nonce=data["nonce"],
         )
         safe_tx_hash = safe_tx.safe_tx_hash
-        data["contractTransactionHash"] = safe_tx_hash.hex()
-        data["signature"] = b"".join(
-            [
-                safe_owner.signHash(safe_tx_hash)["signature"]
-                for safe_owner in safe_owners
-            ]
-        ).hex()
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx_hash)
+        data["signature"] = to_0x_hex_str(
+            b"".join(
+                [
+                    safe_owner.unsafe_sign_hash(safe_tx_hash)["signature"]
+                    for safe_owner in safe_owners
+                ]
+            )
+        )
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe_address,)),
             format="json",
@@ -2107,8 +2132,10 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             safe_nonce=data["nonce"],
         )
         safe_tx_hash = safe_tx.safe_tx_hash
-        data["contractTransactionHash"] = safe_tx_hash.hex()
-        data["signature"] = safe_delegate.signHash(safe_tx_hash)["signature"].hex()
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx_hash)
+        data["signature"] = to_0x_hex_str(
+            safe_delegate.unsafe_sign_hash(safe_tx_hash)["signature"]
+        )
 
         response = self.client.post(
             reverse("v1:history:multisig-transactions", args=(safe_address,)),
@@ -2303,7 +2330,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             # Create delegate
             self.assertEqual(SafeContractDelegate.objects.count(), 0)
             hash_to_sign = DelegateSignatureHelper.calculate_hash(delegate.address)
-            data["signature"] = delegator.signHash(hash_to_sign)["signature"].hex()
+            data["signature"] = to_0x_hex_str(
+                delegator.unsafe_sign_hash(hash_to_sign)["signature"]
+            )
             response = self.client.post(url, format="json", data=data)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             safe_contract_delegate = SafeContractDelegate.objects.get()
@@ -2329,9 +2358,13 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             "label": another_label,
             "delegate": delegate.address,
             "delegator": delegator.address,
-            "signature": delegator.signHash(
-                DelegateSignatureHelper.calculate_hash(delegate.address, eth_sign=True)
-            )["signature"].hex(),
+            "signature": to_0x_hex_str(
+                delegator.unsafe_sign_hash(
+                    DelegateSignatureHelper.calculate_hash(
+                        delegate.address, eth_sign=True
+                    )
+                )["signature"]
+            ),
         }
         response = self.client.post(url, format="json", data=data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -2341,7 +2374,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         signature = signature_to_bytes(0, int(delegator.address, 16), 65) + HexBytes(
             "0" * 65
         )
-        data["signature"] = signature.hex()
+        data["signature"] = to_0x_hex_str(signature)
         response = self.client.post(url, format="json", data=data)
         self.assertIn(
             f"Signature of type=CONTRACT_SIGNATURE for delegator={delegator.address} is not valid",
@@ -2444,7 +2477,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
                     delegate=delegate.address,  # random delegator, should not be deleted
                 )
                 data = {
-                    "signature": signer.signHash(hash_to_sign)["signature"].hex(),
+                    "signature": to_0x_hex_str(
+                        signer.unsafe_sign_hash(hash_to_sign)["signature"]
+                    ),
                     "delegator": delegator.address,
                 }
                 self.assertEqual(SafeContractDelegate.objects.count(), 3)
@@ -2469,7 +2504,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         )
         signer = Account.create()
         data = {
-            "signature": signer.signHash(hash_to_sign)["signature"].hex(),
+            "signature": to_0x_hex_str(
+                signer.unsafe_sign_hash(hash_to_sign)["signature"]
+            ),
             "delegator": delegator.address,
         }
         self.assertEqual(SafeContractDelegate.objects.count(), 1)
@@ -2552,7 +2589,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         hash_to_sign = DelegateSignatureHelper.calculate_hash(
             delegate_address, eth_sign=True
         )
-        data["signature"] = owner_account.signHash(hash_to_sign)["signature"].hex()
+        data["signature"] = to_0x_hex_str(
+            owner_account.unsafe_sign_hash(hash_to_sign)["signature"]
+        )
         response = self.client.delete(
             reverse("v1:history:safe-delegate", args=(safe_address, delegate_address)),
             format="json",
@@ -2567,7 +2606,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         hash_to_sign = DelegateSignatureHelper.calculate_hash(
             delegate_address, previous_totp=True
         )
-        data["signature"] = owner_account.signHash(hash_to_sign)["signature"].hex()
+        data["signature"] = to_0x_hex_str(
+            owner_account.unsafe_sign_hash(hash_to_sign)["signature"]
+        )
         response = self.client.delete(
             reverse("v1:history:safe-delegate", args=(safe_address, delegate_address)),
             format="json",
@@ -2579,7 +2620,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         )
 
         hash_to_sign = DelegateSignatureHelper.calculate_hash(delegate_address)
-        data["signature"] = owner_account.signHash(hash_to_sign)["signature"].hex()
+        data["signature"] = to_0x_hex_str(
+            owner_account.unsafe_sign_hash(hash_to_sign)["signature"]
+        )
         response = self.client.delete(
             reverse("v1:history:safe-delegate", args=(safe_address, delegate_address)),
             format="json",
@@ -2612,7 +2655,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             safe_contract=safe_contract, delegate=delegate_account.address
         )
         hash_to_sign = DelegateSignatureHelper.calculate_hash(delegate_account.address)
-        data["signature"] = delegate_account.signHash(hash_to_sign)["signature"].hex()
+        data["signature"] = to_0x_hex_str(
+            delegate_account.unsafe_sign_hash(hash_to_sign)["signature"]
+        )
         response = self.client.delete(
             reverse(
                 "v1:history:safe-delegate",
@@ -3397,7 +3442,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             ),
             "paymaster": safe_operation.user_operation.paymaster,
             "paymaster_data": "0x",
-            "signature": "0x" + safe_operation.user_operation.signature.hex(),
+            "signature": to_0x_hex_str(safe_operation.user_operation.signature),
             "entry_point": safe_operation.user_operation.entry_point,
             "safe_operation": {
                 "created": datetime_to_str(safe_operation.created),
@@ -3407,7 +3452,9 @@ class TestViews(SafeTestCaseMixin, APITestCase):
                 "valid_until": datetime_to_str(safe_operation.valid_until),
                 "module_address": safe_operation.module_address,
                 "confirmations": [],
-                "prepared_signature": HexBytes(safe_operation.build_signature()).hex(),
+                "prepared_signature": to_0x_hex_str(
+                    HexBytes(safe_operation.build_signature())
+                ),
             },
         }
 
@@ -3745,7 +3792,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         response = self.client.post(
             reverse("v1:history:data-decoder"),
             format="json",
-            data={"data": add_owner_with_threshold_data.hex()},
+            data={"data": to_0x_hex_str(add_owner_with_threshold_data)},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/safe_transaction_service/history/tests/test_views_v2.py
+++ b/safe_transaction_service/history/tests/test_views_v2.py
@@ -11,6 +11,7 @@ from rest_framework.test import APITestCase
 from safe_eth.eth.constants import NULL_ADDRESS
 from safe_eth.safe.signatures import signature_to_bytes
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
+from safe_eth.util.util import to_0x_hex_str
 
 from ...tokens.models import Token
 from ...utils.utils import datetime_to_str
@@ -211,7 +212,9 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
             hash_to_sign = DelegateSignatureHelperV2.calculate_hash(
                 delegate.address, chain_id, False
             )
-            data["signature"] = delegator.signHash(hash_to_sign)["signature"].hex()
+            data["signature"] = to_0x_hex_str(
+                delegator.unsafe_sign_hash(hash_to_sign)["signature"]
+            )
             response = self.client.post(url, format="json", data=data)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             safe_contract_delegate = SafeContractDelegate.objects.get()
@@ -250,7 +253,9 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
             "label": "Kim Wexler",
             "delegate": delegate.address,
             "delegator": delegator.address,
-            "signature": delegator.signHash(hash_to_sign)["signature"].hex(),
+            "signature": to_0x_hex_str(
+                delegator.unsafe_sign_hash(hash_to_sign)["signature"]
+            ),
         }
         response = self.client.post(url, format="json", data=data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -260,7 +265,7 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
         signature = signature_to_bytes(0, int(delegator.address, 16), 65) + HexBytes(
             "0" * 65
         )
-        data["signature"] = signature.hex()
+        data["signature"] = to_0x_hex_str(signature)
         response = self.client.post(url, format="json", data=data)
         self.assertIn(
             f"Signature of type=CONTRACT_SIGNATURE for signer={delegator.address} is not valid",
@@ -279,7 +284,9 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
             "label": "Kim Wexler",
             "delegate": delegate.address,
             "delegator": delegator.address,
-            "signature": delegator.signHash(hash_to_sign)["signature"].hex(),
+            "signature": to_0x_hex_str(
+                delegator.unsafe_sign_hash(hash_to_sign)["signature"]
+            ),
         }
 
         response = self.client.post(
@@ -302,7 +309,9 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
             "safe": safe.address,
             "delegate": delegate.address,
             "delegator": delegator.address,
-            "signature": delegator.signHash(hash_to_sign)["signature"].hex(),
+            "signature": to_0x_hex_str(
+                delegator.unsafe_sign_hash(hash_to_sign)["signature"]
+            ),
         }
 
         with mock.patch(
@@ -418,7 +427,9 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
                 self.assertEqual(SafeContractDelegate.objects.count(), 3)
 
                 data = {
-                    "signature": signer.signHash(hash_to_sign)["signature"].hex(),
+                    "signature": to_0x_hex_str(
+                        signer.unsafe_sign_hash(hash_to_sign)["signature"]
+                    ),
                     "delegator": delegator.address,
                 }
                 response = self.client.delete(
@@ -452,7 +463,9 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
             self.assertEqual(SafeContractDelegate.objects.count(), 2)
             data = {
                 "safe": safe_address,
-                "signature": delegator.signHash(hash_to_sign)["signature"].hex(),
+                "signature": to_0x_hex_str(
+                    delegator.unsafe_sign_hash(hash_to_sign)["signature"]
+                ),
                 "delegator": delegator.address,
             }
             response = self.client.delete(
@@ -470,7 +483,9 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
             get_safe_owners_mock.return_value = [delegator.address]
             data = {
                 "safe": safe_address,
-                "signature": delegator.signHash(hash_to_sign)["signature"].hex(),
+                "signature": to_0x_hex_str(
+                    delegator.unsafe_sign_hash(hash_to_sign)["signature"]
+                ),
                 "delegator": delegator.address,
             }
             response = self.client.delete(
@@ -484,7 +499,9 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
         # Try an invalid signer
         signer = Account.create()
         data = {
-            "signature": signer.signHash(hash_to_sign)["signature"].hex(),
+            "signature": to_0x_hex_str(
+                signer.unsafe_sign_hash(hash_to_sign)["signature"]
+            ),
             "delegator": delegator.address,
         }
         response = self.client.delete(
@@ -497,7 +514,9 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
         )
         self.assertEqual(SafeContractDelegate.objects.count(), 1)
         data = {
-            "signature": delegator.signHash(hash_to_sign)["signature"].hex(),
+            "signature": to_0x_hex_str(
+                delegator.unsafe_sign_hash(hash_to_sign)["signature"]
+            ),
             "delegator": delegator.address,
         }
         response = self.client.delete(

--- a/safe_transaction_service/history/utils.py
+++ b/safe_transaction_service/history/utils.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
 
 from hexbytes import HexBytes
+from safe_eth.util.util import to_0x_hex_str
 from web3.types import LogReceipt
 
 
@@ -36,7 +37,7 @@ class HexField(forms.CharField):
         return value
 
     def prepare_value(self, value: memoryview) -> str:
-        return "0x" + bytes(value).hex() if value else ""
+        return to_0x_hex_str(bytes(value)) if value else ""
 
 
 def clean_receipt_log(receipt_log: LogReceipt) -> Optional[Dict[str, Any]]:
@@ -49,8 +50,8 @@ def clean_receipt_log(receipt_log: LogReceipt) -> Optional[Dict[str, Any]]:
 
     parsed_log = {
         "address": receipt_log["address"],
-        "data": receipt_log["data"].hex(),
-        "topics": [topic.hex() for topic in receipt_log["topics"]],
+        "data": to_0x_hex_str(receipt_log["data"]),
+        "topics": [to_0x_hex_str(topic) for topic in receipt_log["topics"]],
     }
     return parsed_log
 

--- a/safe_transaction_service/notifications/serializers.py
+++ b/safe_transaction_service/notifications/serializers.py
@@ -122,7 +122,7 @@ class FirebaseDeviceSerializer(serializers.Serializer):
                 else:
                     owners_to_not_register.append(owner)
                     # raise ValidationError(f'Owner={owner} is not an owner of any of the safes={data["safes"]}. '
-                    #                       f'Expected hash to sign {hash_to_sign.hex()}')
+                    #                       f'Expected hash to sign {to_0x_hex_str(hash_to_sign)}')
         return owners_to_register, owners_to_not_register
 
     def validate(self, attrs: Dict[str, Any]):

--- a/safe_transaction_service/notifications/tests/test_tasks.py
+++ b/safe_transaction_service/notifications/tests/test_tasks.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 
 from eth_account import Account
 from safe_eth.eth.utils import fast_keccak_text
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.history.models import (
     EthereumTxCallType,
@@ -91,7 +92,7 @@ class TestViews(TestCase):
         safe_address = safe_contract.address
         threshold = 2
         owners = [Account.create().address for _ in range(2)]
-        safe_tx_hash = fast_keccak_text("hola").hex()
+        safe_tx_hash = to_0x_hex_str(fast_keccak_text("hola"))
         with self.assertLogs(logger=task_logger) as cm:
             self.assertEqual(
                 send_notification_owner_task.delay(safe_address, safe_tx_hash).result,
@@ -183,7 +184,7 @@ class TestViews(TestCase):
                 self.assertIn("does not require more confirmations", cm.output[0])
 
     def test_send_notification_owner_delegate_task(self):
-        safe_tx_hash = fast_keccak_text("aloha").hex()
+        safe_tx_hash = to_0x_hex_str(fast_keccak_text("aloha"))
         safe_contract = SafeContractFactory()
         safe_address = safe_contract.address
         safe_status = SafeLastStatusFactory(address=safe_address, threshold=3)
@@ -218,7 +219,7 @@ class TestViews(TestCase):
 
     def test_send_notification_owner_task_called(self):
         safe_address = Account.create().address
-        safe_tx_hash = fast_keccak_text("hola").hex()
+        safe_tx_hash = to_0x_hex_str(fast_keccak_text("hola"))
         payload = {
             "address": safe_address,
             "type": TransactionServiceEventType.PENDING_MULTISIG_TRANSACTION.name,

--- a/safe_transaction_service/notifications/tests/test_views.py
+++ b/safe_transaction_service/notifications/tests/test_views.py
@@ -9,6 +9,7 @@ from eth_account.messages import encode_defunct
 from rest_framework import status
 from rest_framework.test import APITestCase
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.history.tests.factories import (
     SafeContractDelegateFactory,
@@ -131,7 +132,9 @@ class TestNotificationViews(SafeTestCaseMixin, APITestCase):
         hash_to_sign = calculate_device_registration_hash(
             timestamp, unique_id, cloud_messaging_token, safes
         )
-        signatures = [owner_account.signHash(hash_to_sign)["signature"].hex()]
+        signatures = [
+            to_0x_hex_str(owner_account.unsafe_sign_hash(hash_to_sign)["signature"])
+        ]
         data = {
             "uuid": unique_id,
             "safes": safes,
@@ -168,7 +171,11 @@ class TestNotificationViews(SafeTestCaseMixin, APITestCase):
             )
 
             # Add another signature
-            signatures.append(owner_account_2.signHash(hash_to_sign)["signature"].hex())
+            signatures.append(
+                to_0x_hex_str(
+                    owner_account_2.unsafe_sign_hash(hash_to_sign)["signature"]
+                )
+            )
             response = self.client.post(
                 reverse("v1:notifications:devices"), format="json", data=data
             )
@@ -215,7 +222,9 @@ class TestNotificationViews(SafeTestCaseMixin, APITestCase):
             timestamp, unique_id, cloud_messaging_token, safes
         )
         message_to_sign = encode_defunct(hash_to_sign)
-        signatures = [owner_account.sign_message(message_to_sign)["signature"].hex()]
+        signatures = [
+            to_0x_hex_str(owner_account.sign_message(message_to_sign)["signature"])
+        ]
         data = {
             "uuid": unique_id,
             "safes": safes,
@@ -256,7 +265,9 @@ class TestNotificationViews(SafeTestCaseMixin, APITestCase):
         hash_to_sign = calculate_device_registration_hash(
             timestamp, unique_id, cloud_messaging_token, safes
         )
-        signatures = [delegate.signHash(hash_to_sign)["signature"].hex()]
+        signatures = [
+            to_0x_hex_str(delegate.unsafe_sign_hash(hash_to_sign)["signature"])
+        ]
         data = {
             "uuid": unique_id,
             "safes": [safe_address],

--- a/safe_transaction_service/safe_messages/models.py
+++ b/safe_transaction_service/safe_messages/models.py
@@ -11,6 +11,7 @@ from safe_eth.eth.django.models import (
     Keccak256Field,
 )
 from safe_eth.safe.safe_signature import SafeSignatureType
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.utils.constants import SIGNATURE_LENGTH
 
@@ -39,7 +40,7 @@ class SafeMessage(TimeStampedModel):
         message = message_str[:message_size]
         if len(message_str) > message_size:
             message += "..."
-        message_hash = HexBytes(self.message_hash).hex()
+        message_hash = to_0x_hex_str(HexBytes(self.message_hash))
         return f"Safe Message {message_hash} - {message}"
 
     def build_signature(self) -> bytes:

--- a/safe_transaction_service/safe_messages/serializers.py
+++ b/safe_transaction_service/safe_messages/serializers.py
@@ -9,6 +9,7 @@ from rest_framework.exceptions import ValidationError
 from safe_eth.eth import get_auto_ethereum_client
 from safe_eth.eth.eip712 import eip712_encode_hash
 from safe_eth.safe.safe_signature import SafeSignature, SafeSignatureType
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.utils.serializers import get_safe_owners
 
@@ -40,7 +41,7 @@ class SafeMessageSignatureParserMixin:
         for safe_signature in safe_signatures:
             if not safe_signature.is_valid(ethereum_client, safe_address):
                 raise ValidationError(
-                    f"Signature={safe_signature.signature.hex()} for owner={safe_signature.owner} is not valid"
+                    f"Signature={to_0x_hex_str(safe_signature.signature)} for owner={safe_signature.owner} is not valid"
                 )
 
         owner = safe_signatures[0].owner
@@ -108,7 +109,7 @@ class SafeMessageSerializer(SafeMessageSignatureParserMixin, serializers.Seriali
 
         if SafeMessage.objects.filter(message_hash=safe_message_hash).exists():
             raise ValidationError(
-                f"Message with hash {safe_message_hash.hex()} for safe {safe_address} already exists in DB"
+                f"Message with hash {to_0x_hex_str(safe_message_hash)} for safe {safe_address} already exists in DB"
             )
 
         safe_signatures = SafeSignature.parse_signature(
@@ -218,7 +219,7 @@ class SafeMessageResponseSerializer(serializers.Serializer):
         :return: Serialized queryset
         """
         signature = HexBytes(obj.build_signature())
-        return HexBytes(signature).hex() if signature else None
+        return to_0x_hex_str(HexBytes(signature)) if signature else None
 
     def get_origin(self, obj: SafeMessage) -> str:
         return obj.origin if isinstance(obj.origin, str) else json.dumps(obj.origin)

--- a/safe_transaction_service/safe_messages/tests/test_models.py
+++ b/safe_transaction_service/safe_messages/tests/test_models.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from eth_account import Account
 from hexbytes import HexBytes
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
+from safe_eth.util.util import to_0x_hex_str
 
 from ..utils import get_hash_for_message, get_safe_message_hash_for_message
 from .factories import SafeMessageConfirmationFactory, SafeMessageFactory
@@ -59,9 +60,11 @@ class TestSafeMessage(SafeTestCaseMixin, TestCase):
         message_hash = safe_message.message_hash
         self.assertEqual(
             message_hash,
-            get_safe_message_hash_for_message(
-                safe_message.safe, get_hash_for_message(message)
-            ).hex(),
+            to_0x_hex_str(
+                get_safe_message_hash_for_message(
+                    safe_message.safe, get_hash_for_message(message)
+                )
+            ),
         )
         recovered_owner = Account._recover_hash(
             safe_message.message_hash,

--- a/safe_transaction_service/safe_messages/tests/test_views.py
+++ b/safe_transaction_service/safe_messages/tests/test_views.py
@@ -16,6 +16,7 @@ from safe_eth.eth.eip712 import eip712_encode_hash
 from safe_eth.safe.safe_signature import SafeSignatureEOA
 from safe_eth.safe.signatures import signature_to_bytes
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
+from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.safe_messages.models import (
     SafeMessage,
@@ -84,13 +85,13 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                 "proposedBy": safe_message.proposed_by,
                 "safeAppId": safe_message.safe_app_id,
                 "origin": json.dumps(safe_message.origin),
-                "preparedSignature": safe_message_confirmation.signature.hex(),
+                "preparedSignature": to_0x_hex_str(safe_message_confirmation.signature),
                 "confirmations": [
                     {
                         "created": datetime_to_str(safe_message_confirmation.created),
                         "modified": datetime_to_str(safe_message_confirmation.modified),
                         "owner": safe_message_confirmation.owner,
-                        "signature": safe_message_confirmation.signature.hex(),
+                        "signature": to_0x_hex_str(safe_message_confirmation.signature),
                         "signatureType": "EOA",
                     }
                 ],
@@ -121,13 +122,13 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                 "proposedBy": safe_message.proposed_by,
                 "safeAppId": safe_message.safe_app_id,
                 "origin": json.dumps(safe_message.origin),
-                "preparedSignature": safe_message_confirmation.signature.hex(),
+                "preparedSignature": to_0x_hex_str(safe_message_confirmation.signature),
                 "confirmations": [
                     {
                         "created": datetime_to_str(safe_message_confirmation.created),
                         "modified": datetime_to_str(safe_message_confirmation.modified),
                         "owner": safe_message_confirmation.owner,
-                        "signature": safe_message_confirmation.signature.hex(),
+                        "signature": to_0x_hex_str(safe_message_confirmation.signature),
                         "signatureType": "EOA",
                     }
                 ],
@@ -151,7 +152,7 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
             safe.get_message_hash(message_hash) for message_hash in message_hashes
         ]
         signatures = [
-            account.signHash(safe_message_hash)["signature"].hex()
+            to_0x_hex_str(account.unsafe_sign_hash(safe_message_hash)["signature"])
             for safe_message_hash in safe_message_hashes
         ]
 
@@ -255,7 +256,7 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                     {
                         "non_field_errors": [
                             ErrorDetail(
-                                string=f"Message with hash {safe_message_hash.hex()} for safe {safe_address} already exists in DB",
+                                string=f"Message with hash {to_0x_hex_str(safe_message_hash)} for safe {safe_address} already exists in DB",
                                 code="invalid",
                             )
                         ]
@@ -272,7 +273,9 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
         description = "Testing EIP712 message signing"
         message_hash = eip712_encode_hash(message)
         safe_owner_message_hash = safe_owner.get_message_hash(message_hash)
-        safe_owner_signature = account.signHash(safe_owner_message_hash)["signature"]
+        safe_owner_signature = account.unsafe_sign_hash(safe_owner_message_hash)[
+            "signature"
+        ]
 
         # Build EIP1271 signature v=0 r=safe v=dynamic_part dynamic_part=size+owner_signature
         signature_1271 = (
@@ -285,7 +288,7 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
         data = {
             "message": message,
             "description": description,
-            "signature": HexBytes(signature_1271).hex(),
+            "signature": to_0x_hex_str(HexBytes(signature_1271)),
         }
         response = self.client.post(
             reverse("v1:safe_messages:safe-messages", args=(safe_address,)),
@@ -337,7 +340,7 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
         )
 
         # Test same signature
-        data["signature"] = safe_message_confirmation.signature.hex()
+        data["signature"] = to_0x_hex_str(safe_message_confirmation.signature)
         response = self.client.post(
             reverse("v1:safe_messages:signatures", args=(safe_message.message_hash,)),
             format="json",
@@ -358,9 +361,9 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
 
         # Test not existing owner
         owner_account = Account.create()
-        data["signature"] = owner_account.signHash(safe_message.message_hash)[
-            "signature"
-        ].hex()
+        data["signature"] = to_0x_hex_str(
+            owner_account.unsafe_sign_hash(safe_message.message_hash)["signature"]
+        )
         response = self.client.post(
             reverse("v1:safe_messages:signatures", args=(safe_message.message_hash,)),
             format="json",
@@ -470,7 +473,9 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                         "proposedBy": safe_message.proposed_by,
                         "safeAppId": safe_message.safe_app_id,
                         "origin": json.dumps(safe_message.origin),
-                        "preparedSignature": safe_message_confirmation.signature.hex(),
+                        "preparedSignature": to_0x_hex_str(
+                            safe_message_confirmation.signature
+                        ),
                         "confirmations": [
                             {
                                 "created": datetime_to_str(
@@ -480,7 +485,9 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                                     safe_message_confirmation.modified
                                 ),
                                 "owner": safe_message_confirmation.owner,
-                                "signature": safe_message_confirmation.signature.hex(),
+                                "signature": to_0x_hex_str(
+                                    safe_message_confirmation.signature
+                                ),
                                 "signatureType": "EOA",
                             }
                         ],
@@ -518,7 +525,9 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                         "proposedBy": safe_message.proposed_by,
                         "safeAppId": safe_message.safe_app_id,
                         "origin": json.dumps(safe_message.origin),
-                        "preparedSignature": safe_message_confirmation.signature.hex(),
+                        "preparedSignature": to_0x_hex_str(
+                            safe_message_confirmation.signature
+                        ),
                         "confirmations": [
                             {
                                 "created": datetime_to_str(
@@ -528,7 +537,9 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                                     safe_message_confirmation.modified
                                 ),
                                 "owner": safe_message_confirmation.owner,
-                                "signature": safe_message_confirmation.signature.hex(),
+                                "signature": to_0x_hex_str(
+                                    safe_message_confirmation.signature
+                                ),
                                 "signatureType": "EOA",
                             }
                         ],
@@ -588,13 +599,13 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                 "proposedBy": safe_message.proposed_by,
                 "safeAppId": safe_message.safe_app_id,
                 "origin": json.dumps(safe_message.origin),
-                "preparedSignature": safe_message_confirmation.signature.hex(),
+                "preparedSignature": to_0x_hex_str(safe_message_confirmation.signature),
                 "confirmations": [
                     {
                         "created": datetime_to_str(safe_message_confirmation.created),
                         "modified": datetime_to_str(safe_message_confirmation.modified),
                         "owner": safe_message_confirmation.owner,
-                        "signature": safe_message_confirmation.signature.hex(),
+                        "signature": to_0x_hex_str(safe_message_confirmation.signature),
                         "signatureType": "EOA",
                     }
                 ],

--- a/scripts/benchmark_keccak.py
+++ b/scripts/benchmark_keccak.py
@@ -3,15 +3,16 @@ import os
 import sha3
 from Crypto.Hash import keccak as crypto_keccak
 from eth_hash.auto import keccak as eth_hash_keccak
+from safe_eth.util.util import to_0x_hex_str
 from web3 import Web3
 
 
 def eth_hash_benchmark() -> str:
-    return eth_hash_keccak(os.urandom(32)).hex()
+    return to_0x_hex_str(eth_hash_keccak(os.urandom(32)))
 
 
 def web3_benchmark() -> str:
-    return Web3.keccak(os.urandom(32)).hex()
+    return to_0x_hex_str(Web3.keccak(os.urandom(32)))
 
 
 def cryptodome_benchmark() -> str:


### PR DESCRIPTION
- Update safe-eth-py
- Fix some method names
- Refactor `.hex()` calls to don't depend on `HexBytes`
