### PR TITLE
Add V2 for multisigtransaction and all-transactions endpoints

### DIFF
--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -675,9 +675,6 @@ class SafeMultisigTransactionResponseSerializer(SafeMultisigTxSerializer):
     value = serializers.CharField()
     is_executed = serializers.BooleanField(source="executed")
     is_successful = serializers.SerializerMethodField()
-    nonce = serializers.CharField()
-    base_gas = serializers.CharField()
-    safe_tx_gas = serializers.CharField()
     gas_price = serializers.CharField()
     eth_gas_price = serializers.SerializerMethodField()
     max_fee_per_gas = serializers.SerializerMethodField()
@@ -742,6 +739,14 @@ class SafeMultisigTransactionResponseSerializer(SafeMultisigTxSerializer):
             return get_data_decoded_from_data(
                 obj.data if obj.data else b"", address=obj.to
             )
+
+
+class SafeMultisigTransactionResponseSerializerV2(
+    SafeMultisigTransactionResponseSerializer
+):
+    nonce = serializers.CharField()
+    base_gas = serializers.CharField()
+    safe_tx_gas = serializers.CharField()
 
 
 class IndexingStatusSerializer(serializers.Serializer):

--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -968,6 +968,16 @@ class SafeMultisigTransactionWithTransfersResponseSerializer(
         return TxType.MULTISIG_TRANSACTION.name
 
 
+class SafeMultisigTransactionWithTransfersResponseSerializerV2(
+    SafeMultisigTransactionResponseSerializerV2
+):
+    transfers = TransferWithTokenInfoResponseSerializer(many=True)
+    tx_type = serializers.SerializerMethodField()
+
+    def get_tx_type(self, obj):
+        return TxType.MULTISIG_TRANSACTION.name
+
+
 class EthereumTxWithTransfersResponseSerializer(serializers.Serializer):
     class Meta:
         model = EthereumTx
@@ -1006,6 +1016,16 @@ class AllTransactionsSchemaSerializer(serializers.Serializer):
 
     tx_type_1 = SafeModuleTransactionWithTransfersResponseSerializer()
     tx_type_2 = SafeMultisigTransactionWithTransfersResponseSerializer()
+    tx_type_3 = EthereumTxWithTransfersResponseSerializer()
+
+
+class AllTransactionsSchemaSerializerV2(serializers.Serializer):
+    """
+    Just for the purpose of documenting, don't use it
+    """
+
+    tx_type_1 = SafeModuleTransactionWithTransfersResponseSerializer()
+    tx_type_2 = SafeMultisigTransactionWithTransfersResponseSerializerV2()
     tx_type_3 = EthereumTxWithTransfersResponseSerializer()
 
 

--- a/safe_transaction_service/history/services/transaction_service.py
+++ b/safe_transaction_service/history/services/transaction_service.py
@@ -30,6 +30,7 @@ from ..serializers import (
     EthereumTxWithTransfersResponseSerializer,
     SafeModuleTransactionWithTransfersResponseSerializer,
     SafeMultisigTransactionWithTransfersResponseSerializer,
+    SafeMultisigTransactionWithTransfersResponseSerializerV2,
 )
 
 logger = logging.getLogger(__name__)
@@ -340,6 +341,28 @@ class TransactionService:
                 serializer = SafeModuleTransactionWithTransfersResponseSerializer
             elif model_type == MultisigTransaction:
                 serializer = SafeMultisigTransactionWithTransfersResponseSerializer
+            else:
+                raise ValueError(f"Type={model_type} not expected, cannot serialize")
+            serialized = serializer(model)
+            # serialized.is_valid(raise_exception=True)
+            results.append(serialized.data)
+
+        logger.debug("Serialized all transactions")
+        return results
+
+    def serialize_all_txs_v2(
+        self, models: List[AnySafeTransaction]
+    ) -> List[Dict[str, Any]]:
+        logger.debug("Serializing all transactions")
+        results = []
+        for model in models:
+            model_type = type(model)
+            if model_type == EthereumTx:
+                serializer = EthereumTxWithTransfersResponseSerializer
+            elif model_type == ModuleTransaction:
+                serializer = SafeModuleTransactionWithTransfersResponseSerializer
+            elif model_type == MultisigTransaction:
+                serializer = SafeMultisigTransactionWithTransfersResponseSerializerV2
             else:
                 raise ValueError(f"Type={model_type} not expected, cannot serialize")
             serialized = serializer(model)

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -889,6 +889,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         self.assertIsNone(response.data["max_priority_fee_per_gas"])
         self.assertIsNone(response.data["proposer"])
         self.assertIsNone(response.data["proposed_by_delegate"])
+        self.assertIsInstance(response.data["nonce"], int)
 
         self.assertEqual(
             response.data["data_decoded"],
@@ -1200,6 +1201,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             response.data["results"][0]["transaction_hash"],
             multisig_tx.ethereum_tx.tx_hash,
         )
+        self.assertIsInstance(response.data["results"][0]["nonce"], int)
         # Test camelCase
         self.assertEqual(
             response.json()["results"][0]["transactionHash"],

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -369,6 +369,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 6)
         self.assertEqual(len(response.data["results"]), 3)
+        self.assertIsInstance(response.data["results"][0]["nonce"], int)
 
         response = self.client.get(
             reverse("v1:history:all-transactions", args=(safe_address,))

--- a/safe_transaction_service/history/tests/test_views_v2.py
+++ b/safe_transaction_service/history/tests/test_views_v2.py
@@ -1,18 +1,24 @@
+import datetime
 import json
-from datetime import timedelta
 from unittest import mock
 from unittest.mock import MagicMock
 
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.urls import reverse
 from django.utils import timezone
 
+import eth_abi
 from eth_account import Account
 from hexbytes import HexBytes
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.exceptions import ErrorDetail
+from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
 from safe_eth.eth.constants import NULL_ADDRESS
 from safe_eth.eth.utils import fast_is_checksum_address, fast_keccak_text
 from safe_eth.safe.enums import SafeOperationEnum
+from safe_eth.safe.safe import Safe
+from safe_eth.safe.safe_signature import SafeSignature, SafeSignatureType
 from safe_eth.safe.signatures import signature_to_bytes
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 from safe_eth.util.util import to_0x_hex_str
@@ -21,13 +27,18 @@ from ...contracts.models import ContractQuerySet
 from ...contracts.tests.factories import ContractFactory
 from ...contracts.tx_decoder import DbTxDecoder
 from ...tokens.models import Token
+from ...tokens.tests.factories import TokenFactory
 from ...utils.utils import datetime_to_str
-from ..helpers import DelegateSignatureHelperV2
-from ..models import MultisigTransaction, SafeContractDelegate
+from ..helpers import DelegateSignatureHelperV2, DeleteMultisigTxSignatureHelper
+from ..models import MultisigConfirmation, MultisigTransaction, SafeContractDelegate
+from ..serializers import TransferType
 from ..views_v2 import SafeMultisigTransactionListView
 from .factories import (
     ERC20TransferFactory,
     ERC721TransferFactory,
+    EthereumTxFactory,
+    InternalTxFactory,
+    ModuleTransactionFactory,
     MultisigConfirmationFactory,
     MultisigTransactionFactory,
     SafeContractDelegateFactory,
@@ -183,7 +194,9 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
             "delegator": delegator.address,
             "label": label,
             "signature": "0x" + "1" * 130,
-            "expiry_date": datetime_to_str(timezone.now() + timedelta(minutes=30)),
+            "expiry_date": datetime_to_str(
+                timezone.now() + datetime.timedelta(minutes=30)
+            ),
         }
         response = self.client.post(url, format="json", data=data)
         self.assertIn(
@@ -243,7 +256,9 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
             self.assertEqual(safe_contract_delegate.label, label)
 
             # Create expired delegate
-            data["expiry_date"] = datetime_to_str(timezone.now() - timedelta(hours=1))
+            data["expiry_date"] = datetime_to_str(
+                timezone.now() - datetime.timedelta(hours=1)
+            )
             response = self.client.post(url, format="json", data=data)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -1148,3 +1163,1273 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
         )
         self.assertEqual(response.data["proposer"], proposer)
         self.assertEqual(response.data["proposed_by_delegate"], delegate)
+
+    def test_post_multisig_transactions_null_signature(self):
+        safe_owner_1 = Account.create()
+        safe = self.deploy_test_safe(owners=[safe_owner_1.address])
+        safe_address = safe.address
+        safe = Safe(safe_address, self.ethereum_client)
+
+        response = self.client.get(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+        to = Account.create().address
+        data = {
+            "to": to,
+            "value": 100000000000000000,
+            "data": None,
+            "operation": 0,
+            "nonce": 0,
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": 0,
+            "gasToken": "0x0000000000000000000000000000000000000000",
+            "refundReceiver": "0x0000000000000000000000000000000000000000",
+            # "contractTransactionHash": "0x1c2c77b29086701ccdda7836c399112a9b715c6a153f6c8f75c84da4297f60d3",
+            "sender": safe_owner_1.address,
+            "signature": None,
+        }
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        multisig_transaction_db = MultisigTransaction.objects.first()
+        self.assertFalse(multisig_transaction_db.trusted)
+
+        response = self.client.get(
+            reverse(
+                "v2:history:multisig-transaction",
+                args=(data["contractTransactionHash"],),
+            ),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data["executor"])
+        self.assertEqual(len(response.data["confirmations"]), 0)
+
+    def test_post_multisig_transactions(self):
+        safe_owner_1 = Account.create()
+        safe = self.deploy_test_safe(owners=[safe_owner_1.address])
+        safe_address = safe.address
+
+        response = self.client.get(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+        to = Account.create().address
+        data = {
+            "to": to,
+            "value": 100000000000000000,
+            "data": None,
+            "operation": 0,
+            "nonce": 0,
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": 0,
+            "gasToken": "0x0000000000000000000000000000000000000000",
+            "refundReceiver": "0x0000000000000000000000000000000000000000",
+            # "contractTransactionHash": "0x1c2c77b29086701ccdda7836c399112a9b715c6a153f6c8f75c84da4297f60d3",
+            "sender": safe_owner_1.address,
+        }
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        multisig_transaction_db = MultisigTransaction.objects.first()
+        self.assertFalse(multisig_transaction_db.trusted)
+
+        response = self.client.get(
+            reverse(
+                "v2:history:multisig-transaction",
+                args=(data["contractTransactionHash"],),
+            ),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data["executor"])
+        self.assertEqual(len(response.data["confirmations"]), 0)
+        self.assertEqual(response.data["proposer"], data["sender"])
+        self.assertIsNone(response.data["proposed_by_delegate"])
+
+        # Test confirmation with signature
+        data["signature"] = to_0x_hex_str(
+            safe_owner_1.unsafe_sign_hash(safe_tx.safe_tx_hash)["signature"]
+        )
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        modified = multisig_transaction_db.modified
+        multisig_transaction_db.refresh_from_db()
+        self.assertTrue(multisig_transaction_db.trusted)  # Now it should be trusted
+        self.assertGreater(
+            multisig_transaction_db.modified, modified
+        )  # Modified should be updated
+
+        response = self.client.get(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(len(response.data["results"][0]["confirmations"]), 1)
+        self.assertEqual(
+            response.data["results"][0]["confirmations"][0]["signature"],
+            data["signature"],
+        )
+        self.assertTrue(response.data["results"][0]["trusted"])
+
+        # Sign with a different user that sender
+        random_user_account = Account.create()
+        data["signature"] = to_0x_hex_str(
+            random_user_account.unsafe_sign_hash(safe_tx.safe_tx_hash)["signature"]
+        )
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertIn(
+            f"Signer={random_user_account.address} is not an owner",
+            response.data["non_field_errors"][0],
+        )
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+
+        # Use random user as sender (not owner)
+        del data["signature"]
+        data["sender"] = random_user_account.address
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertIn(
+            f"Sender={random_user_account.address} is not an owner",
+            response.data["non_field_errors"][0],
+        )
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+
+    def test_post_multisig_transaction_with_zero_to(self):
+        safe_owner_1 = Account.create()
+        safe = self.deploy_test_safe(owners=[safe_owner_1.address])
+        safe_address = safe.address
+
+        response = self.client.get(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+        data = {
+            "to": NULL_ADDRESS,
+            "value": 100000000000000000,
+            "data": None,
+            "operation": 0,
+            "nonce": 0,
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": 0,
+            "gasToken": "0x0000000000000000000000000000000000000000",
+            "refundReceiver": "0x0000000000000000000000000000000000000000",
+            # "contractTransactionHash": "0x1c2c77b29086701ccdda7836c399112a9b715c6a153f6c8f75c84da4297f60d3",
+            "sender": safe_owner_1.address,
+        }
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        multisig_transaction_db = MultisigTransaction.objects.first()
+        self.assertFalse(multisig_transaction_db.trusted)
+
+    def test_post_multisig_transaction_with_1271_signature(self):
+        account = Account.create()
+        safe_owner = self.deploy_test_safe(owners=[account.address])
+        safe = self.deploy_test_safe(owners=[safe_owner.address])
+
+        data = {
+            "to": account.address,
+            "value": 100000000000000000,
+            "data": None,
+            "operation": 0,
+            "nonce": 0,
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": 0,
+            "gasToken": "0x0000000000000000000000000000000000000000",
+            "refundReceiver": "0x0000000000000000000000000000000000000000",
+            "sender": safe_owner.address,
+        }
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        safe_tx_hash = safe_tx.safe_tx_hash
+        safe_tx_hash_preimage = safe_tx.safe_tx_hash_preimage
+
+        safe_owner_message_hash = safe_owner.get_message_hash(safe_tx_hash_preimage)
+        safe_owner_signature = account.unsafe_sign_hash(safe_owner_message_hash)[
+            "signature"
+        ]
+        signature_1271 = (
+            signature_to_bytes(
+                0, int.from_bytes(HexBytes(safe_owner.address), byteorder="big"), 65
+            )
+            + eth_abi.encode(["bytes"], [safe_owner_signature])[32:]
+        )
+
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx_hash)
+        data["signature"] = to_0x_hex_str(signature_1271)
+
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe.address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        multisig_transaction_db = MultisigTransaction.objects.get(
+            safe_tx_hash=safe_tx_hash
+        )
+        self.assertTrue(multisig_transaction_db.trusted)
+        self.assertEqual(MultisigConfirmation.objects.count(), 1)
+
+        # Test MultisigConfirmation endpoint
+        confirmation_data = {"signature": data["signature"]}
+        MultisigConfirmation.objects.all().delete()
+        response = self.client.post(
+            reverse(
+                "v1:history:multisig-transaction-confirmations",
+                args=(to_0x_hex_str(safe_tx_hash),),
+            ),
+            format="json",
+            data=confirmation_data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(MultisigConfirmation.objects.count(), 1)
+
+    def test_post_multisig_transaction_with_trusted_user(self):
+        safe_owner_1 = Account.create()
+        safe = self.deploy_test_safe(owners=[safe_owner_1.address])
+        safe_address = safe.address
+        data = {
+            "to": Account.create().address,
+            "value": 100000000000000000,
+            "data": None,
+            "operation": 0,
+            "nonce": 0,
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": 0,
+            "gasToken": "0x0000000000000000000000000000000000000000",
+            "refundReceiver": "0x0000000000000000000000000000000000000000",
+            # "contractTransactionHash": "0x1c2c77b29086701ccdda7836c399112a9b715c6a153f6c8f75c84da4297f60d3",
+            "sender": safe_owner_1.address,
+        }
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
+
+        factory = APIRequestFactory()
+        request = factory.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        response = SafeMultisigTransactionListView.as_view()(request, safe_address)
+        response.render()
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        multisig_transaction_db = MultisigTransaction.objects.first()
+        self.assertFalse(multisig_transaction_db.trusted)
+
+        # Create user
+        user = get_user_model().objects.create(
+            username="batman", password="very-private"
+        )
+        request = factory.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        force_authenticate(request, user=user)
+        response = SafeMultisigTransactionListView.as_view()(request, safe_address)
+        response.render()
+        multisig_transaction_db = MultisigTransaction.objects.first()
+        self.assertFalse(multisig_transaction_db.trusted)
+
+        # Assign permissions to user
+        permission = Permission.objects.get(codename="create_trusted")
+        user.user_permissions.add(permission)
+        request = factory.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        user = get_user_model().objects.get()  # Flush permissions cache
+        force_authenticate(request, user=user)
+        response = SafeMultisigTransactionListView.as_view()(request, safe_address)
+        response.render()
+        multisig_transaction_db = MultisigTransaction.objects.first()
+        self.assertTrue(multisig_transaction_db.trusted)
+
+    def test_post_multisig_transaction_executed(self):
+        safe_owner_1 = Account.create()
+        safe = self.deploy_test_safe(owners=[safe_owner_1.address])
+        safe_address = safe.address
+
+        response = self.client.get(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+        to = Account.create().address
+        data = {
+            "to": to,
+            "value": 100000000000000000,
+            "data": None,
+            "operation": 0,
+            "nonce": 0,
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": 0,
+            "gasToken": "0x0000000000000000000000000000000000000000",
+            "refundReceiver": "0x0000000000000000000000000000000000000000",
+            # "contractTransactionHash": "0x1c2c77b29086701ccdda7836c399112a9b715c6a153f6c8f75c84da4297f60d3",
+            "sender": safe_owner_1.address,
+        }
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        multisig_transaction = MultisigTransaction.objects.first()
+        multisig_transaction.ethereum_tx = EthereumTxFactory()
+        multisig_transaction.save(update_fields=["ethereum_tx"])
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn(
+            f'Tx with safe-tx-hash={data["contractTransactionHash"]} '
+            f"for safe={safe.address} was already executed in "
+            f"tx-hash={multisig_transaction.ethereum_tx_id}",
+            response.data["non_field_errors"],
+        )
+
+        # Check another tx with same nonce
+        data["to"] = Account.create().address
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn(
+            f"Tx with nonce={safe_tx.safe_nonce} for safe={safe.address} "
+            f"already executed in tx-hash={multisig_transaction.ethereum_tx_id}",
+            response.data["non_field_errors"],
+        )
+
+        # Successfully insert tx with nonce=1
+        data["nonce"] = 1
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_post_multisig_transactions_with_origin(self):
+        safe_owner_1 = Account.create()
+        safe = self.deploy_test_safe(owners=[safe_owner_1.address])
+        safe_address = safe.address
+
+        response = self.client.get(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+        origin_max_len = 200  # Origin field limit
+        to = Account.create().address
+        data = {
+            "to": to,
+            "value": 100000000000000000,
+            "data": None,
+            "operation": 0,
+            "nonce": 0,
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": 0,
+            "gasToken": "0x0000000000000000000000000000000000000000",
+            "refundReceiver": "0x0000000000000000000000000000000000000000",
+            # "contractTransactionHash": "0x1c2c77b29086701ccdda7836c399112a9b715c6a153f6c8f75c84da4297f60d3",
+            "sender": safe_owner_1.address,
+            "origin": "A" * (origin_max_len + 1),
+        }
+
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        data["origin"] = "A" * origin_max_len
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        multisig_tx_db = MultisigTransaction.objects.get(
+            safe_tx_hash=safe_tx.safe_tx_hash
+        )
+        self.assertEqual(multisig_tx_db.origin, data["origin"])
+        data["origin"] = '{"url": "test", "name":"test"}'
+        data["nonce"] = 1
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx.safe_tx_hash)
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        multisig_tx_db = MultisigTransaction.objects.get(
+            safe_tx_hash=safe_tx.safe_tx_hash
+        )
+        self.assertEqual(multisig_tx_db.origin, json.loads(data["origin"]))
+
+    def test_post_multisig_transactions_with_multiple_signatures(self):
+        safe_owners = [Account.create() for _ in range(4)]
+        safe_owner_addresses = [s.address for s in safe_owners]
+        safe = self.deploy_test_safe(owners=safe_owner_addresses, threshold=3)
+        safe_address = safe.address
+
+        response = self.client.get(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+        to = Account.create().address
+        data = {
+            "to": to,
+            "value": 100000000000000000,
+            "data": None,
+            "operation": 0,
+            "nonce": 0,
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": 0,
+            "gasToken": "0x0000000000000000000000000000000000000000",
+            "refundReceiver": "0x0000000000000000000000000000000000000000",
+            # "contractTransactionHash": "0x1c2c77b29086701ccdda7836c399112a9b715c6a153f6c8f75c84da4297f60d3",
+            "sender": safe_owners[0].address,
+            "origin": "Testing origin field",
+        }
+
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        safe_tx_hash = safe_tx.safe_tx_hash
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx_hash)
+        data["signature"] = to_0x_hex_str(
+            b"".join(
+                [
+                    safe_owner.unsafe_sign_hash(safe_tx_hash)["signature"]
+                    for safe_owner in safe_owners
+                ]
+            )
+        )
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        multisig_tx_db = MultisigTransaction.objects.get(
+            safe_tx_hash=safe_tx.safe_tx_hash
+        )
+        self.assertEqual(multisig_tx_db.origin, data["origin"])
+
+        multisig_confirmations = MultisigConfirmation.objects.filter(
+            multisig_transaction_hash=safe_tx_hash
+        )
+        self.assertEqual(len(multisig_confirmations), len(safe_owners))
+        for multisig_confirmation in multisig_confirmations:
+            safe_signatures = SafeSignature.parse_signature(
+                multisig_confirmation.signature, safe_tx_hash
+            )
+            self.assertEqual(len(safe_signatures), 1)
+            safe_signature = safe_signatures[0]
+            self.assertEqual(safe_signature.signature_type, SafeSignatureType.EOA)
+            self.assertIn(safe_signature.owner, safe_owner_addresses)
+            safe_owner_addresses.remove(safe_signature.owner)
+
+    def test_post_multisig_transactions_with_delegate(self):
+        safe_owners = [Account.create() for _ in range(4)]
+        safe_owner_addresses = [s.address for s in safe_owners]
+        safe_delegate = Account.create()
+        safe = self.deploy_test_safe(owners=safe_owner_addresses, threshold=3)
+        safe_address = safe.address
+
+        self.assertEqual(MultisigTransaction.objects.count(), 0)
+
+        to = Account.create().address
+        data = {
+            "to": to,
+            "value": 100000000000000000,
+            "data": None,
+            "operation": 0,
+            "nonce": 0,
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": 0,
+            "gasToken": "0x0000000000000000000000000000000000000000",
+            "refundReceiver": "0x0000000000000000000000000000000000000000",
+            # "contractTransactionHash": "0x1c2c77b29086701ccdda7836c399112a9b715c6a153f6c8f75c84da4297f60d3",
+            "sender": safe_owners[0].address,
+            "origin": "Testing origin field",
+        }
+
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        safe_tx_hash = safe_tx.safe_tx_hash
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx_hash)
+        data["signature"] = to_0x_hex_str(
+            safe_delegate.unsafe_sign_hash(safe_tx_hash)["signature"]
+        )
+
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn(
+            f"Signer={safe_delegate.address} is not an owner or delegate",
+            response.data["non_field_errors"][0],
+        )
+
+        data["sender"] = safe_delegate.address
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn(
+            f"Sender={safe_delegate.address} is not an owner or delegate",
+            response.data["non_field_errors"][0],
+        )
+
+        # Add delegates (to check there's no issue with delegating twice to the same account)
+        safe_contract_delegate = SafeContractDelegateFactory(
+            safe_contract__address=safe_address,
+            delegate=safe_delegate.address,
+            delegator=safe_owners[0].address,
+        )
+        SafeContractDelegateFactory(
+            safe_contract=safe_contract_delegate.safe_contract,
+            delegate=safe_delegate.address,
+            delegator=safe_owners[1].address,
+        )
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(MultisigTransaction.objects.count(), 1)
+        self.assertEqual(MultisigConfirmation.objects.count(), 0)
+        multisig_transaction = MultisigTransaction.objects.first()
+        self.assertTrue(multisig_transaction.trusted)
+        # Proposer should be the owner address not the delegate
+        self.assertNotEqual(multisig_transaction.proposer, safe_delegate.address)
+        self.assertEqual(multisig_transaction.proposer, safe_owners[0].address)
+        self.assertEqual(
+            multisig_transaction.proposed_by_delegate, safe_delegate.address
+        )
+
+        data["signature"] = data["signature"] + data["signature"][2:]
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn(
+            "Just one signature is expected if using delegates",
+            response.data["non_field_errors"][0],
+        )
+
+    def test_delete_multisig_transaction(self):
+        owner_account = Account.create()
+        safe_tx_hash = to_0x_hex_str(fast_keccak_text("random-tx"))
+        url = reverse("v2:history:multisig-transaction", args=(safe_tx_hash,))
+        data = {"signature": "0x" + "1" * (130 * 2)}  # 2 signatures of 65 bytes
+        response = self.client.delete(url, format="json", data=data)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # Add our test MultisigTransaction to the database
+        safe = SafeContractFactory()
+        multisig_transaction = MultisigTransactionFactory(
+            safe_tx_hash=safe_tx_hash, safe=safe.address
+        )
+
+        # Add other MultisigTransactions to the database to make sure they are not deleted
+        MultisigTransactionFactory()
+        MultisigTransactionFactory()
+
+        response = self.client.delete(url, format="json", data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(
+            response.data,
+            {
+                "non_field_errors": [
+                    ErrorDetail(
+                        string="Executed transactions cannot be deleted", code="invalid"
+                    )
+                ]
+            },
+        )
+
+        multisig_transaction.ethereum_tx = None
+        multisig_transaction.save(update_fields=["ethereum_tx"])
+        response = self.client.delete(url, format="json", data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(
+            response.data,
+            {
+                "non_field_errors": [
+                    ErrorDetail(
+                        string="Old transactions without proposer cannot be deleted",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+        # Set a random proposer for the transaction
+        multisig_transaction.proposer = Account.create().address
+        multisig_transaction.save(update_fields=["proposer"])
+        response = self.client.delete(url, format="json", data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(
+            response.data,
+            {
+                "non_field_errors": [
+                    ErrorDetail(
+                        string="1 owner signature was expected, 2 received",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+        # Use a contract signature
+        data = {"signature": "0x" + "0" * 130}  # 1 signature of 65 bytes
+        response = self.client.delete(url, format="json", data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(
+            response.data,
+            {
+                "non_field_errors": [
+                    ErrorDetail(
+                        string="Only EOA and ETH_SIGN signatures are supported",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+        # Use a real not valid signature and set the right proposer
+        multisig_transaction.proposer = owner_account.address
+        multisig_transaction.save(update_fields=["proposer"])
+        data = {
+            "signature": to_0x_hex_str(
+                owner_account.unsafe_sign_hash(safe_tx_hash)["signature"]
+            )  # Random signature
+        }
+        response = self.client.delete(url, format="json", data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(
+            response.data,
+            {
+                "non_field_errors": [
+                    ErrorDetail(
+                        string="Provided signer is not the proposer or the delegate user who proposed the transaction",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+        # Calculate a valid message_hash
+        message_hash = DeleteMultisigTxSignatureHelper.calculate_hash(
+            safe.address,
+            safe_tx_hash,
+            self.ethereum_client.get_chain_id(),
+            previous_totp=False,
+        )
+
+        # Use an expired user delegate
+        safe_delegate = Account.create()
+        safe_contract_delegate = SafeContractDelegateFactory(
+            safe_contract_id=multisig_transaction.safe,
+            delegate=safe_delegate.address,
+            delegator=owner_account.address,
+            expiry_date=timezone.now() - datetime.timedelta(minutes=1),
+        )
+        multisig_transaction.proposer = owner_account.address
+        multisig_transaction.proposed_by_delegate = safe_delegate.address
+        multisig_transaction.save(update_fields=["proposer", "proposed_by_delegate"])
+        data = {
+            "signature": to_0x_hex_str(
+                safe_delegate.unsafe_sign_hash(message_hash)["signature"]
+            )
+        }
+        response = self.client.delete(url, format="json", data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(
+            response.data,
+            {
+                "non_field_errors": [
+                    ErrorDetail(
+                        string="Provided signer is not the proposer or the delegate user who proposed the transaction",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+        # Use a deleted user delegate
+        safe_contract_delegate.delete()
+        multisig_transaction.proposer = owner_account.address
+        multisig_transaction.proposed_by_delegate = safe_delegate.address
+        multisig_transaction.save(update_fields=["proposer", "proposed_by_delegate"])
+        data = {
+            "signature": to_0x_hex_str(
+                safe_delegate.unsafe_sign_hash(message_hash)["signature"]
+            )
+        }
+        response = self.client.delete(url, format="json", data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(
+            response.data,
+            {
+                "non_field_errors": [
+                    ErrorDetail(
+                        string="Provided signer is not the proposer or the delegate user who proposed the transaction",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+        # Use a proper signature of an user delegate
+        SafeContractDelegateFactory(
+            safe_contract_id=multisig_transaction.safe,
+            delegate=safe_delegate.address,
+            delegator=owner_account.address,
+        )
+        multisig_transaction.proposer = owner_account.address
+        multisig_transaction.proposed_by_delegate = safe_delegate.address
+        multisig_transaction.save(update_fields=["proposer", "proposed_by_delegate"])
+        data = {
+            "signature": to_0x_hex_str(
+                safe_delegate.unsafe_sign_hash(message_hash)["signature"]
+            )
+        }
+        self.assertEqual(MultisigTransaction.objects.count(), 3)
+        self.assertTrue(
+            MultisigTransaction.objects.filter(safe_tx_hash=safe_tx_hash).exists()
+        )
+        response = self.client.delete(url, format="json", data=data)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(MultisigTransaction.objects.count(), 2)
+        self.assertFalse(
+            MultisigTransaction.objects.filter(safe_tx_hash=safe_tx_hash).exists()
+        )
+
+        # Use a proper signature of a proposer user
+        multisig_transaction = MultisigTransactionFactory(
+            safe_tx_hash=safe_tx_hash, safe=safe.address, ethereum_tx=None
+        )
+        multisig_transaction.proposer = owner_account.address
+        multisig_transaction.save(update_fields=["proposer"])
+        data = {
+            "signature": to_0x_hex_str(
+                owner_account.unsafe_sign_hash(message_hash)["signature"]
+            )
+        }
+        self.assertEqual(MultisigTransaction.objects.count(), 3)
+        self.assertTrue(
+            MultisigTransaction.objects.filter(safe_tx_hash=safe_tx_hash).exists()
+        )
+        response = self.client.delete(url, format="json", data=data)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(MultisigTransaction.objects.count(), 2)
+        self.assertFalse(
+            MultisigTransaction.objects.filter(safe_tx_hash=safe_tx_hash).exists()
+        )
+
+        # Trying to do the query again should raise a 404
+        response = self.client.delete(url, format="json", data=data)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_all_transactions_view(self):
+        safe_address = Account.create().address
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+        self.assertEqual(response.data["results"], [])
+
+        # Factories create the models using current datetime, so as the txs are returned sorted they should be
+        # in the reverse order that they were created
+        multisig_transaction = MultisigTransactionFactory(safe=safe_address)
+        module_transaction = ModuleTransactionFactory(safe=safe_address)
+        internal_tx_in = InternalTxFactory(to=safe_address, value=4)
+        internal_tx_out = InternalTxFactory(
+            _from=safe_address, value=5
+        )  # Should not appear
+        erc20_transfer_in = ERC20TransferFactory(to=safe_address)
+        erc20_transfer_out = ERC20TransferFactory(_from=safe_address)
+        another_multisig_transaction = MultisigTransactionFactory(safe=safe_address)
+        another_safe_multisig_transaction = (
+            MultisigTransactionFactory()
+        )  # Should not appear, it's for another Safe
+
+        # Should not appear as they are not executed
+        for _ in range(2):
+            MultisigTransactionFactory(safe=safe_address, ethereum_tx=None)
+
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 6)
+        self.assertEqual(len(response.data["results"]), 6)
+        transfers_not_empty = [
+            False,  # Multisig transaction, no transfer
+            True,  # Erc transfer out
+            True,  # Erc transfer in
+            True,  # internal tx in
+            False,  # Module transaction
+            False,  # Multisig transaction
+        ]
+        for transfer_not_empty, transaction in zip(
+            transfers_not_empty, response.data["results"]
+        ):
+            self.assertEqual(bool(transaction["transfers"]), transfer_not_empty)
+            self.assertTrue(transaction["tx_type"])
+
+        # Test pagination
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,)) + "?limit=3"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 6)
+        self.assertEqual(len(response.data["results"]), 3)
+        self.assertIsInstance(response.data["results"][0]["nonce"], str)
+
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+            + "?limit=4&offset=4"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 6)
+        self.assertEqual(len(response.data["results"]), 2)
+
+        # Add transfer out for the module transaction and transfer in for the multisig transaction
+        erc20_transfer_out = ERC20TransferFactory(
+            _from=safe_address, ethereum_tx=module_transaction.internal_tx.ethereum_tx
+        )
+        # Add token info for that transfer
+        token = TokenFactory(address=erc20_transfer_out.address)
+        internal_tx_in = InternalTxFactory(
+            to=safe_address, value=8, ethereum_tx=multisig_transaction.ethereum_tx
+        )
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 6)
+        self.assertEqual(len(response.data["results"]), 6)
+        self.assertEqual(
+            response.data["results"][4]["transfers"][0]["token_info"],
+            {
+                "type": "ERC20",
+                "address": token.address,
+                "name": token.name,
+                "symbol": token.symbol,
+                "decimals": token.decimals,
+                "logo_uri": token.get_full_logo_uri(),
+                "trusted": token.trusted,
+            },
+        )
+        transfers_not_empty = [
+            False,  # Multisig transaction, no transfer
+            True,  # Erc transfer out
+            True,  # Erc transfer in
+            True,  # internal tx in
+            True,  # Module transaction
+            True,  # Multisig transaction
+        ]
+        for transfer_not_empty, transaction in zip(
+            transfers_not_empty, response.data["results"]
+        ):
+            self.assertEqual(bool(transaction["transfers"]), transfer_not_empty)
+
+    def test_all_transactions_executed(self):
+        safe_address = Account.create().address
+
+        # No mined
+        MultisigTransactionFactory(safe=safe_address, ethereum_tx=None)
+        MultisigTransactionFactory(safe=safe_address, ethereum_tx=None)
+        # Mined
+        MultisigTransactionFactory(safe=safe_address)
+
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+    def test_all_transactions_ordering(self):
+        safe_address = Account.create().address
+
+        # Older transaction
+        erc20_transfer = ERC20TransferFactory(to=safe_address)
+        # Newer transaction
+        multisig_transaction = MultisigTransactionFactory(safe=safe_address)
+
+        # Nonce is not allowed as a sorting parameter
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+            + "?ordering=nonce"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # By default, newer transactions first
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(
+            response.data["results"][0]["transaction_hash"],
+            multisig_transaction.ethereum_tx_id,
+        )
+        self.assertEqual(
+            response.data["results"][1]["tx_hash"], erc20_transfer.ethereum_tx_id
+        )
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+            + "?ordering=timestamp"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(
+            response.data["results"][0]["tx_hash"], erc20_transfer.ethereum_tx_id
+        )
+        self.assertEqual(
+            response.data["results"][1]["transaction_hash"],
+            multisig_transaction.ethereum_tx_id,
+        )
+
+    def test_all_transactions_wrong_transfer_type_view(self):
+        # No token in database, so we must trust the event
+        safe_address = Account.create().address
+        erc20_transfer_out = ERC20TransferFactory(
+            _from=safe_address
+        )  # ERC20 event (with `value`)
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+            + "?queued=False&trusted=True"
+        )
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["transfers"][0]["type"],
+            TransferType.ERC20_TRANSFER.name,
+        )
+        self.assertIsNone(response.data["results"][0]["transfers"][0]["token_id"])
+        self.assertIsNotNone(response.data["results"][0]["transfers"][0]["value"])
+
+        # Result should be the same, as we are adding an ERC20 token
+        token = TokenFactory(address=erc20_transfer_out.address, decimals=18)
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+            + "?queued=False&trusted=True"
+        )
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["transfers"][0]["type"],
+            TransferType.ERC20_TRANSFER.name,
+        )
+        self.assertIsNone(response.data["results"][0]["transfers"][0]["token_id"])
+        self.assertIsNotNone(response.data["results"][0]["transfers"][0]["value"])
+
+        # Result should change if we set the token as an ERC721
+        token.decimals = None
+        token.save(update_fields=["decimals"])
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+            + "?queued=False&trusted=True"
+        )
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["transfers"][0]["type"],
+            TransferType.ERC721_TRANSFER.name,
+        )
+        # TokenId and Value must be swapped now
+        self.assertIsNone(response.data["results"][0]["transfers"][0]["value"])
+        self.assertIsNotNone(response.data["results"][0]["transfers"][0]["token_id"])
+
+        # It should work with value=0
+        safe_address = Account.create().address
+        erc20_transfer_out = ERC20TransferFactory(
+            _from=safe_address, value=0
+        )  # ERC20 event (with `value`)
+        token = TokenFactory(address=erc20_transfer_out.address, decimals=18)
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+            + "?queued=False&trusted=True"
+        )
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["transfers"][0]["type"],
+            TransferType.ERC20_TRANSFER.name,
+        )
+        self.assertIsNone(response.data["results"][0]["transfers"][0]["token_id"])
+        self.assertEqual(response.data["results"][0]["transfers"][0]["value"], "0")
+
+    def test_all_transactions_duplicated_multisig_tx_view(self):
+        """
+        Test 2 module transactions with the same tx_hash
+        """
+        safe_address = Account.create().address
+        multisig_transaction_1 = MultisigTransactionFactory(safe=safe_address)
+        multisig_transaction_2 = MultisigTransactionFactory(
+            safe=safe_address,
+            ethereum_tx=multisig_transaction_1.ethereum_tx,
+        )
+
+        self.assertEqual(
+            multisig_transaction_1.ethereum_tx,
+            multisig_transaction_2.ethereum_tx,
+        )
+
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 2)
+        # We are aware of this. Pagination is done by `tx_hash`, so 2 transactions
+        # with the same `tx_hash` will return a `count` of 1
+        self.assertEqual(response.data["count"], 1)
+        # Even if they have the same `tx_hash`, tx with higher nonce will come first
+        self.assertEqual(
+            [multisig_transaction_2.safe_tx_hash, multisig_transaction_1.safe_tx_hash],
+            [multisig_tx["safe_tx_hash"] for multisig_tx in response.data["results"]],
+        )
+
+    def test_all_transactions_duplicated_module_view(self):
+        """
+        Test 2 module transactions with the same tx_hash
+        """
+        safe_address = Account.create().address
+        module_transaction_1 = ModuleTransactionFactory(safe=safe_address)
+        module_transaction_2 = ModuleTransactionFactory(
+            safe=safe_address,
+            internal_tx__ethereum_tx=module_transaction_1.internal_tx.ethereum_tx,
+        )
+
+        self.assertEqual(
+            module_transaction_1.internal_tx.ethereum_tx,
+            module_transaction_2.internal_tx.ethereum_tx,
+        )
+
+        response = self.client.get(
+            reverse("v2:history:all-transactions", args=(safe_address,))
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 2)
+        # We are aware of this. Pagination is done by `tx_hash`, so 2 transactions
+        # with the same `tx_hash` will return a `count` of 1
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            {module_transaction_1.module, module_transaction_2.module},
+            {module_tx["module"] for module_tx in response.data["results"]},
+        )

--- a/safe_transaction_service/history/urls_v2.py
+++ b/safe_transaction_service/history/urls_v2.py
@@ -31,4 +31,9 @@ urlpatterns = [
         views_v2.SafeMultisigTransactionDetailView.as_view(),
         name="multisig-transaction",
     ),
+    path(
+        "safes/<str:address>/all-transactions/",
+        views_v2.AllTransactionsListView.as_view(),
+        name="all-transactions",
+    ),
 ]

--- a/safe_transaction_service/history/urls_v2.py
+++ b/safe_transaction_service/history/urls_v2.py
@@ -21,4 +21,14 @@ urlpatterns = [
         views_v2.SafeBalanceView.as_view(),
         name="safe-balances",
     ),
+    path(
+        "safes/<str:address>/multisig-transactions/",
+        views_v2.SafeMultisigTransactionListView.as_view(),
+        name="multisig-transactions",
+    ),
+    path(
+        "multisig-transactions/<str:safe_tx_hash>/",
+        views_v2.SafeMultisigTransactionDetailView.as_view(),
+        name="multisig-transaction",
+    ),
 ]

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -271,6 +271,7 @@ class SafeDeploymentsView(ListAPIView):
         ),
     },
 )
+@extend_schema(deprecated=True)
 class AllTransactionsListView(ListAPIView):
     filter_backends = (
         django_filters.rest_framework.DjangoFilterBackend,
@@ -569,6 +570,9 @@ class SafeMultisigConfirmationsView(ListCreateAPIView):
         },
     ),
 )
+@extend_schema(
+    deprecated=True,
+)
 class SafeMultisigTransactionDetailView(RetrieveAPIView):
     """
     Returns a multi-signature transaction given its Safe transaction hash
@@ -676,6 +680,7 @@ class SafeMultisigTransactionListView(ListAPIView):
             return serializers.SafeMultisigTransactionSerializer
 
     @extend_schema(
+        deprecated=True,
         tags=["transactions"],
         responses={
             200: OpenApiResponse(
@@ -712,6 +717,7 @@ class SafeMultisigTransactionListView(ListAPIView):
         return response
 
     @extend_schema(
+        deprecated=True,
         tags=["transactions"],
         request=serializers.SafeMultisigTransactionSerializer,
         responses={


### PR DESCRIPTION
# Description
Add V2 endpoint for the new return types on multisigtransaction. 

# Marking as deprecated the following endpoints
- GET `/api/v1/multisig-transactions/{safe_tx_hash}/`
- DELETE `/api/v1/multisig-transactions/{safe_tx_hash}/`
- GET `/api/v1/safes/{address}/multisig-transactions/`
- POST `/api/v1/safes/{address}/multisig-transactions/`
- GET `/api/v1/safes/{address}/all-transactions/`

# V2 of new endpoints
- GET `/api/v2/multisig-transactions/{safe_tx_hash}/`
- DELETE `/api/v2/multisig-transactions/{safe_tx_hash}/`
- GET `/api/v2/safes/{address}/multisig-transactions/`
- POST `/api/v2/safes/{address}/multisig-transactions/`
- GET `/api/v2/safes/{address}/all-transactions/`

# Version2 types
The endpoints behind version two modify the types int for string for the following properties. 
   ```
    nonce : <String>
    base_gas : <String>
    safe_tx_gas : <String>
```
