### PR TITLE
Whitelist `SafeToL2Setup` Contract

### DIFF
--- a/safe_transaction_service/contracts/management/commands/setup_safe_contracts.py
+++ b/safe_transaction_service/contracts/management/commands/setup_safe_contracts.py
@@ -11,6 +11,7 @@ TRUSTED_FOR_DELEGATE_CALL = [
     "MultiSendCallOnly",
     "MultiSend",
     "SafeToL2Migration",
+    "SafeToL2Setup",
     "SignMessageLib",
     "SafeMigration",
 ]


### PR DESCRIPTION
The `SafeToL2Setup` contract is safely `delegatecall`able.
