### PR TITLE
Add flag to disable download collectibles

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -590,6 +590,11 @@ ETH_ERC20_LOAD_ADDRESSES_CHUNK_SIZE = env.int(
     "ETH_ERC20_LOAD_ADDRESSES_CHUNK_SIZE", default=500_000
 )  # Load Safe addresses for the ERC20 indexer with a database iterator with the defined `chunk_size`
 
+# ENABLE/DISABLE COLLECTIBLES DOWNLOAD METADATA, enable=True, disabled by default
+COLLECTIBLES_ENABLE_DOWNLOAD_METADATA = env.bool(
+    "COLLECTIBLES_ENABLE_DOWNLOAD_METADATA", default=False
+)
+
 # Events processing
 # ------------------------------------------------------------------------------
 PROCESSING_ENABLE_OUT_OF_ORDER_CHECK = env.bool(

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -311,7 +311,7 @@ class CollectiblesService:
         :param collectible
         """
         if not settings.COLLECTIBLES_ENABLE_DOWNLOAD_METADATA:
-            logger.warning("Download collectibles metadata is disabled")
+            logger.warning("Downloading collectibles metadata is disabled")
             return None
         if tld := ENS_CONTRACTS_WITH_TLD.get(
             collectible.address

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -310,6 +310,9 @@ class CollectiblesService:
         Return metadata for a collectible
         :param collectible
         """
+        if not settings.COLLECTIBLES_ENABLE_DOWNLOAD_METADATA:
+            logger.warning("Download collectibles metadata is disabled")
+            return None
         if tld := ENS_CONTRACTS_WITH_TLD.get(
             collectible.address
         ):  # Special case for ENS

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -5,6 +5,7 @@ import json
 import random
 from typing import Optional, Tuple
 
+from django.conf import settings
 from django.utils import timezone
 
 from celery import app
@@ -450,6 +451,9 @@ def retry_get_metadata_task(
     :param address: collectible address
     :param token_id: collectible id
     """
+    if not settings.COLLECTIBLES_ENABLE_DOWNLOAD_METADATA:
+        logger.warning("Download collectibles metadata is disabled")
+        return None
 
     collectibles_service = CollectiblesServiceProvider()
     redis_key = collectibles_service.get_metadata_cache_key(address, token_id)

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -452,7 +452,7 @@ def retry_get_metadata_task(
     :param token_id: collectible id
     """
     if not settings.COLLECTIBLES_ENABLE_DOWNLOAD_METADATA:
-        logger.warning("Download collectibles metadata is disabled")
+        logger.warning("Downloading collectibles metadata is disabled")
         return None
 
     collectibles_service = CollectiblesServiceProvider()

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -266,76 +266,81 @@ class TestTasks(TestCase):
 
     @patch.object(CollectiblesService, "get_metadata", autospec=True, return_value={})
     def test_retry_get_metadata_task(self, get_metadata_mock: MagicMock):
-        redis = get_redis()
-        collectibles_service = CollectiblesServiceProvider()
-
         collectible_address = Account.create().address
         collectible_id = 16
-        metadata_cache_key = collectibles_service.get_metadata_cache_key(
-            collectible_address, collectible_id
-        )
 
-        metadata = {
-            "name": "Octopus",
-            "description": "Atlantic Octopus",
-            "image": "http://random-address.org/logo-28.png",
-        }
-
+        # Shouldn't call get_metadata and return None with COLLECTIBLES_ENABLE_DOWNLOAD_METADATA by default
+        self.assertIsNone(retry_get_metadata_task(collectible_address, collectible_id))
         # Check metadata cannot be retrieved
         get_metadata_mock.assert_not_called()
-        self.assertEqual(
-            retry_get_metadata_task(collectible_address, collectible_id), None
-        )
-        # Collectible needs to be cached so metadata can be fetched
-        get_metadata_mock.assert_not_called()
 
-        get_metadata_mock.return_value = metadata
-        expected = CollectibleWithMetadata(
-            "Octopus",
-            "OCT",
-            "http://random-address.org/logo.png",
-            collectible_address,
-            collectible_id,
-            "http://random-address.org/info-28.json",
-            metadata,
-        )
-        redis.set(
-            metadata_cache_key,
-            json.dumps(dataclasses.asdict(expected)),
-            ex=300,
-        )
+        with self.settings(COLLECTIBLES_ENABLE_DOWNLOAD_METADATA=True):
+            redis = get_redis()
+            collectibles_service = CollectiblesServiceProvider()
 
-        self.assertEqual(
-            retry_get_metadata_task(collectible_address, collectible_id), expected
-        )
-        # As metadata was set, task is not requesting it
-        get_metadata_mock.assert_not_called()
+            metadata_cache_key = collectibles_service.get_metadata_cache_key(
+                collectible_address, collectible_id
+            )
 
-        collectible_without_metadata = CollectibleWithMetadata(
-            "Octopus",
-            "OCT",
-            "http://random-address.org/logo.png",
-            collectible_address,
-            collectible_id,
-            "http://random-address.org/info-28.json",
-            {},
-        )
-        redis.set(
-            metadata_cache_key,
-            json.dumps(dataclasses.asdict(collectible_without_metadata)),
-            ex=300,
-        )
+            metadata = {
+                "name": "Octopus",
+                "description": "Atlantic Octopus",
+                "image": "http://random-address.org/logo-28.png",
+            }
 
-        self.assertEqual(
-            retry_get_metadata_task(collectible_address, collectible_id), expected
-        )
-        # As metadata was not set, task requested it
-        get_metadata_mock.assert_called_once()
+            self.assertEqual(
+                retry_get_metadata_task(collectible_address, collectible_id), None
+            )
+            # Collectible needs to be cached so metadata can be fetched
+            get_metadata_mock.assert_not_called()
 
-        self.assertEqual(
-            json.loads(redis.get(metadata_cache_key)), dataclasses.asdict(expected)
-        )
-        redis.delete(metadata_cache_key)
+            get_metadata_mock.return_value = metadata
+            expected = CollectibleWithMetadata(
+                "Octopus",
+                "OCT",
+                "http://random-address.org/logo.png",
+                collectible_address,
+                collectible_id,
+                "http://random-address.org/info-28.json",
+                metadata,
+            )
+            redis.set(
+                metadata_cache_key,
+                json.dumps(dataclasses.asdict(expected)),
+                ex=300,
+            )
+
+            self.assertEqual(
+                retry_get_metadata_task(collectible_address, collectible_id), expected
+            )
+            # As metadata was set, task is not requesting it
+            get_metadata_mock.assert_not_called()
+
+            collectible_without_metadata = CollectibleWithMetadata(
+                "Octopus",
+                "OCT",
+                "http://random-address.org/logo.png",
+                collectible_address,
+                collectible_id,
+                "http://random-address.org/info-28.json",
+                {},
+            )
+            redis.set(
+                metadata_cache_key,
+                json.dumps(dataclasses.asdict(collectible_without_metadata)),
+                ex=300,
+            )
+
+            self.assertEqual(
+                retry_get_metadata_task(collectible_address, collectible_id), expected
+            )
+            # As metadata was not set, task requested it
+            get_metadata_mock.assert_called_once()
+
+            self.assertEqual(
+                json.loads(redis.get(metadata_cache_key)), dataclasses.asdict(expected)
+            )
+            redis.delete(metadata_cache_key)
 
     def test_remove_not_trusted_multisig_txs_task(self):
         self.assertEqual(remove_not_trusted_multisig_txs_task.delay().result, 0)


### PR DESCRIPTION
# Description
Add COLLECTIBLES_ENABLE_DOWNLOAD_METADATA to enable or disable the metadata download with False (disabled) by default.
