### PR TITLE
Fix ethereum indexer RPC calls exceptions

### DIFF
--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -10,6 +10,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 from eth_typing import ChecksumAddress
 from requests import Timeout
 from safe_eth.eth import EthereumClient
+from web3.exceptions import Web3RPCError
 
 from ..services import IndexingException, IndexService, IndexServiceProvider
 
@@ -412,6 +413,7 @@ class EthereumIndexer(ABC):
             SoftTimeLimitExceeded,
             Timeout,
             ValueError,
+            Web3RPCError,
         ) as e:
             self.block_process_limit = 1  # Set back to the very minimum
             logger.info(


### PR DESCRIPTION
Added Web3RPCError exception to avoid errors like `web3.exceptions.Web3RPCError: {'code': -32602, 'message': 'Query returned more than 10000 results. Try with this block range [x, y].'}`


