### PR TITLE
Remove firebase from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ djangorestframework==3.15.2
 djangorestframework-camel-case==1.4.2
 docutils==0.21.2
 drf-spectacular==0.28.0
-firebase-admin==6.6.0
 flower==2.0.1
 gunicorn[gevent]==23.0.0
 hiredis==3.1.0


### PR DESCRIPTION
Because we don't have mobile notifications, firebase is not more needed. 