### PR TITLE
Fix zksync chains duplicated transactions for native transfers

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -553,6 +553,9 @@ ETH_INTERNAL_TX_DECODED_PROCESS_BATCH = env.int(
 ETH_L2_NETWORK = env.bool(
     "ETH_L2_NETWORK", default=not ETHEREUM_TRACING_NODE_URL
 )  # Use L2 event indexing
+ETH_ZKSYNC_COMPATIBLE_NETWORK = env.bool(
+    "ETH_ZKSYNC_COMPATIBLE_NETWORK", default=False
+)  # Fix some issues regarding zkSync compatible networks
 ETH_EVENTS_BLOCK_PROCESS_LIMIT = env.int(
     "ETH_EVENTS_BLOCK_PROCESS_LIMIT", default=50
 )  # Initial number of blocks to process together when searching for events. It will be auto increased. 0 == no limit.


### PR DESCRIPTION
- zkSync derived chains deal withthe native currency as an ERC20, so service indexes it twice, as a ERC20 transfer and as a native transfer.
- With this PR, when `ETH_ZKSYNC_COMPATIBLE_NETWORK` environment variable is set to `True`, native transfers are ignored.
