### PR TITLE
Fix/contract message signatures

### DIFF
--- a/safe_transaction_service/safe_messages/serializers.py
+++ b/safe_transaction_service/safe_messages/serializers.py
@@ -16,7 +16,7 @@ from safe_eth.util.util import to_0x_hex_str
 from safe_transaction_service.utils.serializers import get_safe_owners
 
 from .models import SIGNATURE_LENGTH, SafeMessage, SafeMessageConfirmation
-from .utils import get_hash_for_message, get_safe_message_hash_for_message
+from .utils import get_hash_for_message, get_safe_message_hash_and_preimage_for_message
 
 
 # Request serializers
@@ -109,7 +109,7 @@ class SafeMessageSerializer(SafeMessageSignatureParserMixin, serializers.Seriali
         signature = attrs["signature"]
         attrs["safe"] = safe_address
         message_hash = get_hash_for_message(message)
-        safe_message_hash = get_safe_message_hash_for_message(
+        safe_message_hash, safe_message_preimage = get_safe_message_hash_and_preimage_for_message(
             safe_address, message_hash
         )
         attrs["message_hash"] = safe_message_hash
@@ -120,7 +120,7 @@ class SafeMessageSerializer(SafeMessageSignatureParserMixin, serializers.Seriali
             )
 
         safe_signatures = SafeSignature.parse_signature(
-            signature, safe_message_hash, safe_hash_preimage=message_hash
+            signature, safe_message_hash, safe_hash_preimage=safe_message_preimage
         )
         owner, signature_type = self.get_valid_owner_from_signatures(
             safe_signatures, safe_address, None

--- a/safe_transaction_service/safe_messages/utils.py
+++ b/safe_transaction_service/safe_messages/utils.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from eth_account.messages import defunct_hash_message
-from eth_typing import ChecksumAddress, Hash32
+from eth_typing import ChecksumAddress, Hash32, HexStr
 from safe_eth.eth import get_auto_ethereum_client
 from safe_eth.eth.eip712 import eip712_encode_hash
 from safe_eth.safe import Safe
@@ -15,8 +15,8 @@ def get_hash_for_message(message: str | Dict[str, Any]) -> Hash32:
     )
 
 
-def get_safe_message_hash_for_message(
+def get_safe_message_hash_and_preimage_for_message(
     safe_address: ChecksumAddress, message_hash: Hash32
-) -> Hash32:
+) -> Tuple[Hash32, HexStr]:
     safe = Safe(safe_address, get_auto_ethereum_client())
-    return safe.get_message_hash(message_hash)
+    return safe.get_message_hash_and_preimage(message_hash)


### PR DESCRIPTION
### Make sure these boxes are checked! 📦✅

- [ ] You ran `./run_tests.sh`
- [ ] You ran `pre-commit run -a`
- [ ] If you want to add your network to `setup_service.py`, provide a link to your
    [safe-deployments PR](https://github.com/safe-global/safe-deployments/pulls) and check network name
    exists in [safe-eth-py](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py)

### What was wrong? 👾

It looks like the Safe transaction service is not correctly validating contract signatures for Safe messages. It uses the wrong preimage value for simulating the contract `isValidSignature` call which causes invalid signatures to be accepted, but valid signatures to be rejected.

As proof, you can "trick" the transaction service by uploading a signature for `keccak256(keccak256(SafeMessage.message))`. For example, the following signature was accepted by the safe transaction service despite not being valid:

https://app.safe.global/transactions/msg?safe=sep:0x2eB2E943a7877fcbC404351D7c8Ca5853B1a93D6&messageHash=0xe7ad065df60ded50e5c36a69333c2364f7592feeabfbba9ad0a17c74946d02ae

Here is a reverting simulation when trying to use the signature with `isValidSignature`:

https://www.tdly.co/shared/simulation/c58211dd-8e6a-40af-a935-5cb97da878a3

### How was it fixed? 🎯

Using the correct pre-image for the Safe contract signatures. Depends on .

### Notes

I created this as a draft PR, but it is more like an issue :sweat_smile:. I just thought it would be easier to point out where the exact problem is.