### PR TITLE
Fix typing warnings

### DIFF
--- a/safe_transaction_service/account_abstraction/helpers.py
+++ b/safe_transaction_service/account_abstraction/helpers.py
@@ -1,5 +1,4 @@
 import dataclasses
-from typing import List
 
 from eth_typing import ChecksumAddress
 from safe_eth.eth import EthereumClient
@@ -19,7 +18,7 @@ class DecodedInitCode:
     salt_nonce: int
     expected_address: ChecksumAddress  # Expected Safe deployment address
     # Safe creation data
-    owners: List[ChecksumAddress]
+    owners: list[ChecksumAddress]
     threshold: int
     to: ChecksumAddress
     data: bytes

--- a/safe_transaction_service/account_abstraction/serializers.py
+++ b/safe_transaction_service/account_abstraction/serializers.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from django.conf import settings
 from django.db import transaction
@@ -39,9 +39,9 @@ class SafeOperationSignatureValidatorMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.ethereum_client = get_auto_ethereum_client()
-        self._deployment_owners: List[ChecksumAddress] = []
+        self._deployment_owners: list[ChecksumAddress] = []
 
-    def _get_owners(self, safe_address: ChecksumAddress) -> List[ChecksumAddress]:
+    def _get_owners(self, safe_address: ChecksumAddress) -> list[ChecksumAddress]:
         """
         :param safe_address:
         :return:  `init_code` decoded owners if Safe is not deployed or current blockchain owners if Safe is deployed
@@ -59,7 +59,7 @@ class SafeOperationSignatureValidatorMixin:
         safe_operation_hash: bytes,
         safe_operation_hash_preimage: bytes,
         signature: bytes,
-    ) -> List[SafeSignature]:
+    ) -> list[SafeSignature]:
         safe_owners = self._get_owners(safe_address)
         parsed_signatures = SafeSignature.parse_signature(
             signature,
@@ -375,7 +375,7 @@ class SafeOperationConfirmationSerializer(
     @transaction.atomic
     def save(self, **kwargs):
         safe_signatures = self.validated_data["safe_signatures"]
-        safe_operation_confirmations: List[SafeOperationConfirmation] = []
+        safe_operation_confirmations: list[SafeOperationConfirmation] = []
         for safe_signature in safe_signatures:
             safe_operation_confirmation, created = (
                 SafeOperationConfirmation.objects.get_or_create(
@@ -438,7 +438,7 @@ class SafeOperationResponseSerializer(serializers.Serializer):
     confirmations = serializers.SerializerMethodField()
     prepared_signature = serializers.SerializerMethodField()
 
-    def get_confirmations(self, obj: SafeOperationModel) -> Dict[str, Any]:
+    def get_confirmations(self, obj: SafeOperationModel) -> dict[str, Any]:
         """
         Filters confirmations queryset
 

--- a/safe_transaction_service/analytics/services/analytics_service.py
+++ b/safe_transaction_service/analytics/services/analytics_service.py
@@ -1,6 +1,5 @@
 import json
 from functools import cache
-from typing import List
 
 from safe_transaction_service.utils.redis import get_redis
 
@@ -13,7 +12,7 @@ def get_analytics_service() -> "AnalyticsService":
 class AnalyticsService:
     REDIS_TRANSACTIONS_PER_SAFE_APP = "analytics_transactions_per_safe_app"
 
-    def get_safe_transactions_per_safe_app(self) -> List:
+    def get_safe_transactions_per_safe_app(self) -> list[dict]:
         redis = get_redis()
         analytic_result = redis.get(self.REDIS_TRANSACTIONS_PER_SAFE_APP)
         if analytic_result:

--- a/safe_transaction_service/contracts/management/commands/setup_safe_contracts.py
+++ b/safe_transaction_service/contracts/management/commands/setup_safe_contracts.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List, Tuple
 
 from django.core.files import File
 from django.core.management import BaseCommand, CommandError
@@ -108,8 +107,8 @@ class Command(BaseCommand):
 
     @staticmethod
     def _get_deployments_by_chain_and_version(
-        versions: List[str], chain_id: str
-    ) -> List[Tuple[str, str, str]]:
+        versions: list[str], chain_id: str
+    ) -> list[tuple[str, str, str]]:
         """
         Get the list of contracts for the given versions and chain.
 
@@ -117,7 +116,7 @@ class Command(BaseCommand):
         :param chain_id: chain id
         :return: list of (version, contract_name, contract_address)
         """
-        chain_deployments: List[Tuple[str, str, str]] = []
+        chain_deployments: list[tuple[str, str, str]] = []
         for version in versions:
             for contract_name, addresses in safe_deployments[version].items():
                 for contract_address in addresses.get(chain_id, []):
@@ -127,8 +126,8 @@ class Command(BaseCommand):
 
     @staticmethod
     def _get_default_deployments_by_version_on_chain(
-        versions: List[str], ethereum_client: EthereumClient
-    ) -> List[Tuple[str, str, str]]:
+        versions: list[str], ethereum_client: EthereumClient
+    ) -> list[tuple[str, str, str]]:
         """
         Get the default deployments by version actually deployed on chain.
 
@@ -136,7 +135,7 @@ class Command(BaseCommand):
         :param ethereum_client: Ethereum client
         :return: list of (version, contract_name, contract_address)
         """
-        chain_deployments: List[Tuple[str, str, str]] = []
+        chain_deployments: list[tuple[str, str, str]] = []
         for version in versions:
             for contract_name, addresses in default_safe_deployments[version].items():
                 for contract_address in addresses:
@@ -149,7 +148,7 @@ class Command(BaseCommand):
 
     @staticmethod
     def _create_or_update_contracts_from_deployments(
-        deployments: List[Tuple[str, str, str]],
+        deployments: list[tuple[str, str, str]],
         queryset,
         force_update_contracts: bool,
         logo_file: File,

--- a/safe_transaction_service/contracts/models.py
+++ b/safe_transaction_service/contracts/models.py
@@ -2,7 +2,7 @@ import json
 import operator
 import os
 from logging import getLogger
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -38,7 +38,7 @@ def get_file_storage():
         return default_storage
 
 
-def validate_abi(value: Dict[str, Any]):
+def validate_abi(value: dict[str, Any]):
     try:
         if not value:
             raise ValueError("Empty ABI not allowed")
@@ -66,7 +66,7 @@ class ContractAbi(models.Model):
     def __str__(self):
         return f"ContractABI {self.relevance} - {self.description}"
 
-    def abi_functions(self) -> List[str]:
+    def abi_functions(self) -> list[str]:
         return [x["name"] for x in self.abi if x["type"] == "function"]
 
     def save(self, *args, **kwargs) -> None:

--- a/safe_transaction_service/contracts/tx_decoder.py
+++ b/safe_transaction_service/contracts/tx_decoder.py
@@ -5,12 +5,9 @@ from logging import getLogger
 from threading import Lock
 from typing import (
     Any,
-    Dict,
     Iterable,
-    List,
     Optional,
     Sequence,
-    Tuple,
     Type,
     TypedDict,
     Union,
@@ -108,7 +105,7 @@ class ParameterDecoded(TypedDict):
 
 class DataDecoded(TypedDict):
     method: str
-    parameters: List[ParameterDecoded]
+    parameters: list[ParameterDecoded]
 
 
 class MultisendDecoded(TypedDict):
@@ -171,7 +168,7 @@ class SafeTxDecoder:
 
     def __init__(self):
         logger.info("%s: Loading contract ABIs for decoding", self.__class__.__name__)
-        self.fn_selectors_with_abis: Dict[bytes, ABIFunction] = (
+        self.fn_selectors_with_abis: dict[bytes, ABIFunction] = (
             self._generate_selectors_with_abis_from_abis(self.get_supported_abis())
         )
         logger.info(
@@ -193,7 +190,7 @@ class SafeTxDecoder:
 
     def _decode_data(
         self, data: Union[bytes, str], address: Optional[ChecksumAddress] = None
-    ) -> Tuple[str, List[Tuple[str, str, Any]]]:
+    ) -> tuple[str, list[tuple[str, str, Any]]]:
         """
         Decode tx data
 
@@ -230,7 +227,7 @@ class SafeTxDecoder:
 
     def _generate_selectors_with_abis_from_abi(
         self, abi: Sequence[ABIFunction]
-    ) -> Dict[bytes, ABIFunction]:
+    ) -> dict[bytes, ABIFunction]:
         """
         :param abi: ABI
         :return: Dictionary with function selector as bytes and the ContractFunction
@@ -243,7 +240,7 @@ class SafeTxDecoder:
 
     def _generate_selectors_with_abis_from_abis(
         self, abis: Sequence[Sequence[ABIFunction]]
-    ) -> Dict[bytes, ABIFunction]:
+    ) -> dict[bytes, ABIFunction]:
         """
         :param abis: Contract ABIs. Last ABIs on the Sequence have preference if there's a collision on the
         selector
@@ -263,7 +260,7 @@ class SafeTxDecoder:
         prevent problems when deserializing in another languages like JavaScript
 
         :param value_decoded:
-        :return: Dict[str, Any]
+        :return: dict[str, Any]
         """
         if isinstance(value_decoded, bytes):
             value_decoded = to_0x_hex_str(HexBytes(value_decoded))
@@ -285,8 +282,8 @@ class SafeTxDecoder:
         return updated
 
     def decode_parameters_data(
-        self, data: bytes, parameters: Sequence[Dict[str, Any]]
-    ) -> Sequence[Dict[str, Any]]:
+        self, data: bytes, parameters: Sequence[dict[str, Any]]
+    ) -> Sequence[dict[str, Any]]:
         """
         Decode inner data for function parameters, e.g. Multisend `data` or `data` in Gnosis Safe `execTransaction`
 
@@ -298,7 +295,7 @@ class SafeTxDecoder:
 
     def decode_transaction_with_types(
         self, data: Union[bytes, str], address: Optional[ChecksumAddress] = None
-    ) -> Tuple[str, List[ParameterDecoded]]:
+    ) -> tuple[str, list[ParameterDecoded]]:
         """
         Decode tx data and return a list of dictionaries
 
@@ -321,7 +318,7 @@ class SafeTxDecoder:
 
     def decode_transaction(
         self, data: Union[bytes, str], address: Optional[ChecksumAddress] = None
-    ) -> Tuple[str, Dict[str, Any]]:
+    ) -> tuple[str, dict[str, Any]]:
         """
         Decode tx data and return all the parameters in the same dictionary
 
@@ -339,7 +336,7 @@ class SafeTxDecoder:
         }
         return fn_name, decoded_transactions
 
-    def get_supported_abis(self) -> List[Sequence[ABIFunction]]:
+    def get_supported_abis(self) -> list[Sequence[ABIFunction]]:
         safe_abis = [
             get_safe_V0_0_1_contract(self.dummy_w3).abi,
             get_safe_V1_0_0_contract(self.dummy_w3).abi,
@@ -379,14 +376,14 @@ class TxDecoder(SafeTxDecoder):
     """
 
     @cached_property
-    def multisend_abis(self) -> List[Sequence[ABIFunction]]:
+    def multisend_abis(self) -> list[Sequence[ABIFunction]]:
         return [get_multi_send_contract(self.dummy_w3).abi]
 
     @cached_property
-    def multisend_fn_selectors_with_abis(self) -> Dict[bytes, ABIFunction]:
+    def multisend_fn_selectors_with_abis(self) -> dict[bytes, ABIFunction]:
         return self._generate_selectors_with_abis_from_abis(self.multisend_abis)
 
-    def decode_multisend_data(self, data: Union[bytes, str]) -> List[MultisendDecoded]:
+    def decode_multisend_data(self, data: Union[bytes, str]) -> list[MultisendDecoded]:
         """
         Decodes Multisend raw data to Multisend dictionary
 
@@ -518,8 +515,8 @@ class TxDecoder(SafeTxDecoder):
         )
 
     def decode_parameters_data(
-        self, data: bytes, parameters: Sequence[Dict[str, Any]]
-    ) -> Sequence[Dict[str, Any]]:
+        self, data: bytes, parameters: Sequence[dict[str, Any]]
+    ) -> Sequence[dict[str, Any]]:
         """
         Decode inner data for function parameters, in this case Multisend `data` and
         `data` in Gnosis Safe `execTransaction`
@@ -561,7 +558,7 @@ class DbTxDecoder(TxDecoder):
     )  # 5 minutes of caching
 
     @cachedmethod(cache=operator.attrgetter("cache_abis_by_address"))
-    def get_contract_abi(self, address: ChecksumAddress) -> Optional[List[ABIFunction]]:
+    def get_contract_abi(self, address: ChecksumAddress) -> Optional[list[ABIFunction]]:
         """
         Retrieves the ABI for the contract at the given address.
 
@@ -595,7 +592,7 @@ class DbTxDecoder(TxDecoder):
     )
     def get_contract_abi_selectors_with_functions(
         self, address: ChecksumAddress
-    ) -> Optional[Dict[bytes, ABIFunction]]:
+    ) -> Optional[dict[bytes, ABIFunction]]:
         """
         :param address: Contract address
         :return: Dictionary of function selects with ABIFunction if found, `None` otherwise

--- a/safe_transaction_service/events/services/queue_service.py
+++ b/safe_transaction_service/events/services/queue_service.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from functools import cache
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from django.conf import settings
 
@@ -75,9 +75,9 @@ def get_queue_service():
 
 class QueueService:
     def __init__(self):
-        self._connection_pool: List[BrokerConnection] = []
+        self._connection_pool: list[BrokerConnection] = []
         self._total_connections: int = 0
-        self.unsent_events: List = []
+        self.unsent_events: list[str] = []
 
     def get_connection(self) -> Optional[BrokerConnection]:
         """
@@ -114,13 +114,13 @@ class QueueService:
         if broker_connection:
             self._connection_pool.insert(0, broker_connection)
 
-    def send_event(self, payload: Dict[str, Any]) -> int:
+    def send_event(self, payload: dict[str, Any]) -> int:
         """
         Publish event using the `BrokerConnection`
 
         :param payload: Number of events published
         """
-        event = json.dumps(payload)
+        event: str = json.dumps(payload)
         if not (broker_connection := self.get_connection()):
             # No available connections in the pool, store event to send it later
             self.unsent_events.append(event)
@@ -176,5 +176,5 @@ class MockedQueueService:
     Mocked class to use in case that there is not rabbitMq queue to send events
     """
 
-    def send_event(self, event: Dict[str, Any]):
+    def send_event(self, event: dict[str, Any]):
         logger.debug("MockedQueueService: Not sending event with payload %s", event)

--- a/safe_transaction_service/history/cache.py
+++ b/safe_transaction_service/history/cache.py
@@ -1,6 +1,6 @@
 import json
 from functools import cached_property, wraps
-from typing import List, Optional, Union
+from typing import Optional, Union
 from urllib.parse import urlencode
 
 from django.conf import settings
@@ -190,7 +190,7 @@ def remove_cache_view_by_instance(
         remove_cache_view_for_addresses(cache_tag, addresses)
 
 
-def remove_cache_view_for_addresses(cache_tag: str, addresses: List[ChecksumAddress]):
+def remove_cache_view_for_addresses(cache_tag: str, addresses: list[ChecksumAddress]):
     """
     Remove several cache for the provided cache_tag and addresses
 

--- a/safe_transaction_service/history/helpers.py
+++ b/safe_transaction_service/history/helpers.py
@@ -1,6 +1,6 @@
 import re
 import time
-from typing import List, Optional
+from typing import Optional
 
 from eth_typing import ChecksumAddress, Hash32, HexStr
 from eth_utils import keccak
@@ -192,7 +192,7 @@ class DelegateSignatureHelper(TemporarySignatureHelper):
             return keccak(text=message)
 
     @classmethod
-    def calculate_all_possible_hashes(cls, delegate: ChecksumAddress) -> List[bytes]:
+    def calculate_all_possible_hashes(cls, delegate: ChecksumAddress) -> list[bytes]:
         return [
             cls.calculate_hash(delegate),
             cls.calculate_hash(delegate, eth_sign=True),

--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -1,7 +1,7 @@
 import datetime
 from collections import OrderedDict
 from logging import getLogger
-from typing import Iterator, List, NamedTuple, Optional, Sequence
+from typing import Iterator, NamedTuple, Optional, Sequence
 
 from django.db.models import QuerySet
 from django.db.models.query import EmptyQuerySet
@@ -73,7 +73,7 @@ class Erc20EventsIndexer(EventsIndexer):
         )
 
     @property
-    def contract_events(self) -> List[ContractEvent]:
+    def contract_events(self) -> list[ContractEvent]:
         """
         :return: Web3 ContractEvent to listen to
         """
@@ -92,7 +92,7 @@ class Erc20EventsIndexer(EventsIndexer):
         addresses: set[ChecksumAddress],
         from_block_number: int,
         to_block_number: int,
-    ) -> List[LogReceipt]:
+    ) -> list[LogReceipt]:
         """
         Override function to call custom `get_total_transfer_history` function
 
@@ -173,7 +173,7 @@ class Erc20EventsIndexer(EventsIndexer):
 
     def process_elements(
         self, log_receipts: Sequence[EventData]
-    ) -> List[TokenTransfer]:
+    ) -> list[TokenTransfer]:
         """
         Process all events found by `find_relevant_elements`
 

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -2,7 +2,7 @@ import time
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from logging import getLogger
-from typing import Any, List, Optional, Sequence, Tuple
+from typing import Any, Optional, Sequence
 
 from django.db.models import Min
 
@@ -105,7 +105,7 @@ class EthereumIndexer(ABC):
         :return: Set of relevant elements
         """
 
-    def process_element(self, element: Any) -> List[Any]:
+    def process_element(self, element: Any) -> list[Any]:
         """
         Process provided `element` to retrieve relevant data (internal txs, events...)
 
@@ -131,7 +131,7 @@ class EthereumIndexer(ABC):
         self,
         addresses: set[ChecksumAddress],
         current_block_number: Optional[int] = None,
-    ) -> Optional[Tuple[int, int]]:
+    ) -> Optional[tuple[int, int]]:
         """
         :param addresses:
         :param current_block_number: To prevent fetching it again
@@ -379,7 +379,7 @@ class EthereumIndexer(ABC):
         self,
         addresses: set[ChecksumAddress],
         current_block_number: Optional[int] = None,
-    ) -> Tuple[Sequence[Any], Optional[int], int, bool]:
+    ) -> tuple[Sequence[Any], Optional[int], int, bool]:
         """
         Find and process relevant data for `addresses`, then store and return it
 
@@ -432,7 +432,7 @@ class EthereumIndexer(ABC):
 
         return processed_elements, from_block_number, to_block_number, updated
 
-    def start(self) -> Tuple[int, int]:
+    def start(self) -> tuple[int, int]:
         """
         Find and process relevant data for existing database addresses
 

--- a/safe_transaction_service/history/indexers/events_indexer.py
+++ b/safe_transaction_service/history/indexers/events_indexer.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from functools import cached_property
 from logging import getLogger
-from typing import Any, Dict, List, Optional, OrderedDict, Sequence
+from typing import Any, Optional, OrderedDict, Sequence
 
 from django.conf import settings
 
@@ -60,13 +60,13 @@ class EventsIndexer(EthereumIndexer):
 
     @property
     @abstractmethod
-    def contract_events(self) -> List[ContractEvent]:
+    def contract_events(self) -> list[ContractEvent]:
         """
         :return: List of Web3.py `ContractEvent` to listen to
         """
 
     @cached_property
-    def events_to_listen(self) -> Dict[HexStr, List[ContractEvent]]:
+    def events_to_listen(self) -> dict[HexStr, list[ContractEvent]]:
         """
         Build a dictionary with a `topic` and a list of ABIs to use for decoding. One single topic can have
         multiple ways of decoding as events with different `indexed` parameters must be decoded
@@ -85,7 +85,7 @@ class EventsIndexer(EthereumIndexer):
         addresses: set[ChecksumAddress],
         from_block_number: int,
         to_block_number: int,
-    ) -> List[LogReceipt]:
+    ) -> list[LogReceipt]:
         """
         Perform query to the node
 
@@ -137,7 +137,7 @@ class EventsIndexer(EthereumIndexer):
         addresses: set[ChecksumAddress],
         from_block_number: int,
         to_block_number: int,
-    ) -> List[LogReceipt]:
+    ) -> list[LogReceipt]:
         """
         It will get Safe events using all the Safe topics for filtering.
 
@@ -181,7 +181,7 @@ class EventsIndexer(EthereumIndexer):
         from_block_number: int,
         to_block_number: int,
         current_block_number: Optional[int] = None,
-    ) -> List[LogReceipt]:
+    ) -> list[LogReceipt]:
         """
         Search for log receipts for Safe events
 
@@ -237,7 +237,7 @@ class EventsIndexer(EthereumIndexer):
         )
         return None
 
-    def decode_elements(self, log_receipts: Sequence[LogReceipt]) -> List[EventData]:
+    def decode_elements(self, log_receipts: Sequence[LogReceipt]) -> list[EventData]:
         """
         :param log_receipts:
         :return: Decode `log_receipts` and return a list of `EventData`. If a `log_receipt` cannot be decoded
@@ -249,14 +249,14 @@ class EventsIndexer(EthereumIndexer):
                 decoded_elements.append(decoded_element)
         return decoded_elements
 
-    def _process_decoded_elements(self, decoded_elements: List[EventData]) -> List[Any]:
+    def _process_decoded_elements(self, decoded_elements: list[EventData]) -> list[Any]:
         processed_elements = []
         for decoded_element in decoded_elements:
             if processed_element := self._process_decoded_element(decoded_element):
                 processed_elements.append(processed_element)
         return processed_elements
 
-    def process_elements(self, log_receipts: Sequence[LogReceipt]) -> List[Any]:
+    def process_elements(self, log_receipts: Sequence[LogReceipt]) -> list[Any]:
         """
         Process all events found by `find_relevant_elements`
 
@@ -278,7 +278,7 @@ class EventsIndexer(EthereumIndexer):
             )
         ]
         logger.debug("Decoding `log_receipts` of the events")
-        decoded_elements: List[EventData] = self.decode_elements(
+        decoded_elements: list[EventData] = self.decode_elements(
             not_processed_log_receipts
         )
         logger.debug("Decoded `log_receipts` of the events")

--- a/safe_transaction_service/history/indexers/internal_tx_indexer.py
+++ b/safe_transaction_service/history/indexers/internal_tx_indexer.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from logging import getLogger
-from typing import Generator, Iterable, List, Optional, Sequence, Set
+from typing import Generator, Iterable, Optional, Sequence, Set
 
 from django.conf import settings
 from django.db import transaction
@@ -260,7 +260,7 @@ class InternalTxIndexer(EthereumIndexer):
 
     def trace_transactions(
         self, tx_hashes: Sequence[HexStr], batch_size: int
-    ) -> Iterable[List[FilterTrace]]:
+    ) -> Iterable[list[FilterTrace]]:
         batch_size = batch_size or len(tx_hashes)  # If `0`, don't use batches
         for tx_hash_chunk in chunks(list(tx_hashes), batch_size):
             tx_hash_chunk = list(tx_hash_chunk)
@@ -294,7 +294,7 @@ class InternalTxIndexer(EthereumIndexer):
 
     def process_elements(
         self, tx_hash_with_traces: OrderedDict[bytes, Optional[FilterTrace]]
-    ) -> List[HexBytes]:
+    ) -> list[HexBytes]:
         """
         :param tx_hash_with_traces:
         :return: Inserted `InternalTx` objects

--- a/safe_transaction_service/history/indexers/proxy_factory_indexer.py
+++ b/safe_transaction_service/history/indexers/proxy_factory_indexer.py
@@ -1,6 +1,6 @@
 from functools import cached_property
 from logging import getLogger
-from typing import List, Optional, Sequence
+from typing import Optional, Sequence
 
 from safe_eth.eth import EthereumClient
 from safe_eth.eth.constants import NULL_ADDRESS
@@ -40,7 +40,7 @@ class ProxyFactoryIndexerProvider:
 
 class ProxyFactoryIndexer(EventsIndexer):
     @cached_property
-    def contract_events(self) -> List[ContractEvent]:
+    def contract_events(self) -> list[ContractEvent]:
         proxy_factory_v1_1_1_contract = get_proxy_factory_V1_1_1_contract(
             self.ethereum_client.w3
         )
@@ -87,7 +87,7 @@ class ProxyFactoryIndexer(EventsIndexer):
 
     def process_elements(
         self, log_receipts: Sequence[LogReceipt]
-    ) -> List[SafeContract]:
+    ) -> list[SafeContract]:
         """
         Process all logs
 

--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -1,6 +1,6 @@
 from functools import cached_property
 from logging import getLogger
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from django.conf import settings
 from django.db import IntegrityError, transaction
@@ -69,7 +69,7 @@ class SafeEventsIndexer(EventsIndexer):
         super().__init__(*args, **kwargs)
 
     @cached_property
-    def contract_events(self) -> List[ContractEvent]:
+    def contract_events(self) -> list[ContractEvent]:
         """
         Safe v1.3.0 L2 Events
         ------------------
@@ -299,7 +299,7 @@ class SafeEventsIndexer(EventsIndexer):
         ).exists()
 
     @transaction.atomic
-    def decode_elements(self, *args) -> List[EventData]:
+    def decode_elements(self, *args) -> list[EventData]:
         return super().decode_elements(*args)
 
     def _get_internal_tx_from_decoded_event(
@@ -498,15 +498,15 @@ class SafeEventsIndexer(EventsIndexer):
         return internal_tx
 
     def _get_safe_creation_events(
-        self, decoded_elements: List[EventData]
-    ) -> Dict[ChecksumAddress, List[EventData]]:
+        self, decoded_elements: list[EventData]
+    ) -> dict[ChecksumAddress, list[EventData]]:
         """
         Get the creation events (ProxyCreation and SafeSetup) from decoded elements and generates a dictionary that groups these events by Safe address.
 
         :param decoded_elements:
         :return:
         """
-        safe_creation_events: Dict[ChecksumAddress, List[Dict]] = {}
+        safe_creation_events: dict[ChecksumAddress, list[dict]] = {}
         for decoded_element in decoded_elements:
             event_name = decoded_element["event"]
             if event_name == "SafeSetup":
@@ -524,8 +524,8 @@ class SafeEventsIndexer(EventsIndexer):
 
     def _process_safe_creation_events(
         self,
-        safe_addresses_with_creation_events: Dict[ChecksumAddress, List[EventData]],
-    ) -> List[InternalTx]:
+        safe_addresses_with_creation_events: dict[ChecksumAddress, list[EventData]],
+    ) -> list[InternalTx]:
         """
         Process creation events (ProxyCreation and SafeSetup).
 
@@ -618,7 +618,7 @@ class SafeEventsIndexer(EventsIndexer):
                     logger.error(f"Event is not a Safe creation event {event['event']}")
 
         # Store which internal txs where inserted into database
-        stored_internal_txs: List[InternalTx] = []
+        stored_internal_txs: list[InternalTx] = []
         with transaction.atomic():
             try:
                 InternalTx.objects.bulk_create(internal_txs)

--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -4,7 +4,7 @@ Contains classes for processing indexed data and store Safe related models in da
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, Iterator, List, Optional, Sequence, Union
+from typing import Iterator, Optional, Sequence, Union
 
 from django.db import transaction
 
@@ -99,7 +99,7 @@ class TxProcessor(ABC):
 
     def process_decoded_transactions(
         self, internal_txs_decoded: Sequence[InternalTxDecoded]
-    ) -> List[bool]:
+    ) -> list[bool]:
         return [
             self.process_decoded_transaction(decoded_transaction)
             for decoded_transaction in internal_txs_decoded
@@ -146,7 +146,7 @@ class SafeTxProcessor(TxProcessor):
             event_abi_to_log_topic(event.abi)
             for event in self.safe_tx_module_failure_events
         }
-        self.safe_last_status_cache: Dict[str, SafeLastStatus] = {}
+        self.safe_last_status_cache: dict[str, SafeLastStatus] = {}
         self.signature_breaking_versions = (  # Versions where signing changed
             Version("1.0.0"),  # Safes >= 1.0.0 Renamed `baseGas` to `dataGas`
             Version("1.3.0"),  # ChainId was included
@@ -377,7 +377,7 @@ class SafeTxProcessor(TxProcessor):
     @transaction.atomic
     def process_decoded_transactions(
         self, internal_txs_decoded: Iterator[InternalTxDecoded]
-    ) -> List[bool]:
+    ) -> list[bool]:
         """
         Optimize to process multiple transactions in a batch
         :param internal_txs_decoded:

--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Sequence, Tuple
+from typing import Sequence
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -36,7 +36,7 @@ class CeleryTaskConfiguration:
     cron: CronDefinition = None
     enabled: bool = True
 
-    def create_task(self) -> Tuple[PeriodicTask, bool]:
+    def create_task(self) -> tuple[PeriodicTask, bool]:
         assert self.period or self.cron, "Task must define period or cron"
         if self.period:
             interval_schedule, _ = IntervalSchedule.objects.get_or_create(
@@ -241,7 +241,7 @@ class Command(BaseCommand):
             )
 
     def _setup_safe_singleton_addresses(
-        self, safe_singleton_addresses: Sequence[Tuple[str, int, str]]
+        self, safe_singleton_addresses: Sequence[tuple[str, int, str]]
     ):
         for address, initial_block_number, version in safe_singleton_addresses:
             safe_singleton_address, _ = SafeMasterCopy.objects.get_or_create(
@@ -264,7 +264,7 @@ class Command(BaseCommand):
                 )
 
     def _setup_safe_proxy_factories(
-        self, safe_proxy_factories: Sequence[Tuple[str, int]]
+        self, safe_proxy_factories: Sequence[tuple[str, int]]
     ):
         for address, initial_block_number in safe_proxy_factories:
             ProxyFactory.objects.get_or_create(

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -6,14 +6,11 @@ from itertools import islice
 from logging import getLogger
 from typing import (
     Any,
-    Dict,
     Iterator,
-    List,
     Optional,
     Self,
     Sequence,
     Set,
-    Tuple,
     Type,
     TypedDict,
     Union,
@@ -227,14 +224,14 @@ class Chain(models.Model):
 
 
 class EthereumBlockManager(models.Manager):
-    def get_or_create_from_block(self, block: Dict[str, Any], confirmed: bool = False):
+    def get_or_create_from_block(self, block: dict[str, Any], confirmed: bool = False):
         try:
             return self.get(block_hash=block["hash"])
         except self.model.DoesNotExist:
             return self.create_from_block(block, confirmed=confirmed)
 
     def create_from_block(
-        self, block: Dict[str, Any], confirmed: bool = False
+        self, block: dict[str, Any], confirmed: bool = False
     ) -> "EthereumBlock":
         """
         :param block: Block Dict returned by Web3
@@ -345,8 +342,8 @@ class EthereumBlock(models.Model):
 class EthereumTxManager(models.Manager):
     def create_from_tx_dict(
         self,
-        tx: Dict[str, Any],
-        tx_receipt: Optional[Dict[str, Any]] = None,
+        tx: dict[str, Any],
+        tx_receipt: Optional[dict[str, Any]] = None,
         ethereum_block: Optional[EthereumBlock] = None,
     ) -> "EthereumTx":
         data = HexBytes(tx.get("data") or tx.get("input"))
@@ -435,7 +432,7 @@ class EthereumTx(TimeStampedModel):
             return self.status == 1
 
     def update_with_block_and_receipt(
-        self, ethereum_block: "EthereumBlock", tx_receipt: Dict[str, Any]
+        self, ethereum_block: "EthereumBlock", tx_receipt: dict[str, Any]
     ):
         if self.block is None:
             self.block = ethereum_block
@@ -565,7 +562,7 @@ class TokenTransfer(models.Model):
         return f"Token Transfer from={self._from} to={self.to}"
 
     @staticmethod
-    def _prepare_parameters_from_decoded_event(event_data: EventData) -> Dict[str, Any]:
+    def _prepare_parameters_from_decoded_event(event_data: EventData) -> dict[str, Any]:
         topic = HexBytes(event_data["topics"][0])
         expected_topic = HexBytes(ERC20_721_TRANSFER_TOPIC)
         if topic != expected_topic:
@@ -672,7 +669,7 @@ class ERC721TransferManager(TokenTransferManager):
         address: ChecksumAddress,
         only_trusted: Optional[bool] = None,
         exclude_spam: Optional[bool] = None,
-    ) -> List[Tuple[ChecksumAddress, int]]:
+    ) -> list[tuple[ChecksumAddress, int]]:
         """
         Returns erc721 owned by address, removing the ones sent
 
@@ -796,7 +793,7 @@ class InternalTxManager(BulkCreateSignalMixin, models.Manager):
         return ",".join([str(address) for address in trace_address])
 
     def build_from_trace(
-        self, trace: Dict[str, Any], ethereum_tx: EthereumTx
+        self, trace: dict[str, Any], ethereum_tx: EthereumTx
     ) -> "InternalTx":
         """
         Build a InternalTx object from trace, but it doesn't insert it on database
@@ -829,8 +826,8 @@ class InternalTxManager(BulkCreateSignalMixin, models.Manager):
         )
 
     def get_or_create_from_trace(
-        self, trace: Dict[str, Any], ethereum_tx: EthereumTx
-    ) -> Tuple["InternalTx", bool]:
+        self, trace: dict[str, Any], ethereum_tx: EthereumTx
+    ) -> tuple["InternalTx", bool]:
         tx_type = InternalTxType.parse(trace["type"])
         call_type = EthereumTxCallType.parse_call_type(trace["action"].get("callType"))
         trace_address_str = self._trace_address_to_str(trace["traceAddress"])
@@ -1114,7 +1111,7 @@ class InternalTx(models.Model):
         return self.can_be_decoded or self.is_ether_transfer or self.contract_address
 
     @property
-    def trace_address_as_list(self) -> List[int]:
+    def trace_address_as_list(self) -> list[int]:
         if not self.trace_address:
             return []
         else:
@@ -1565,7 +1562,7 @@ class MultisigTransaction(TimeStampedModel):
         return bool(self.ethereum_tx_id and (self.ethereum_tx.block_id is not None))
 
     @property
-    def owners(self) -> Optional[List[str]]:
+    def owners(self) -> Optional[list[str]]:
         if not self.signatures:
             return []
         else:
@@ -1969,7 +1966,7 @@ class SafeRelevantTransaction(models.Model):
     @classmethod
     def from_erc20_721_event(
         cls, event_data: EventData
-    ) -> List["SafeRelevantTransaction"]:
+    ) -> list["SafeRelevantTransaction"]:
         """
         Does not create the model, as it requires that `ethereum_tx` exists
 

--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -3,7 +3,7 @@ import itertools
 import json
 import logging
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from django.conf import settings
 from django.http import Http404
@@ -673,7 +673,7 @@ class SafeModuleTransactionResponseSerializer(GnosisBaseModelSerializer):
             "module_transaction_id",
         )
 
-    def get_data_decoded(self, obj: ModuleTransaction) -> Dict[str, Any]:
+    def get_data_decoded(self, obj: ModuleTransaction) -> dict[str, Any]:
         return get_data_decoded_from_data(obj.data if obj.data else b"", address=obj.to)
 
     def get_is_successful(self, obj: ModuleTransaction) -> bool:
@@ -735,7 +735,7 @@ class SafeMultisigTransactionResponseSerializer(SafeMultisigTxSerializer):
         if obj.ethereum_tx_id:
             return obj.ethereum_tx.block_id
 
-    def get_confirmations(self, obj: MultisigTransaction) -> Dict[str, Any]:
+    def get_confirmations(self, obj: MultisigTransaction) -> dict[str, Any]:
         """
         Validate and check integrity of confirmations queryset
 
@@ -778,7 +778,7 @@ class SafeMultisigTransactionResponseSerializer(SafeMultisigTxSerializer):
     def get_origin(self, obj: MultisigTransaction) -> str:
         return obj.origin if isinstance(obj.origin, str) else json.dumps(obj.origin)
 
-    def get_data_decoded(self, obj: MultisigTransaction) -> Dict[str, Any]:
+    def get_data_decoded(self, obj: MultisigTransaction) -> dict[str, Any]:
         # If delegate call contract must be whitelisted (security)
         if obj.data_should_be_decoded():
             return get_data_decoded_from_data(
@@ -859,7 +859,7 @@ class SafeCreationInfoResponseSerializer(serializers.Serializer):
         allow_null=True
     )
 
-    def get_data_decoded(self, obj: SafeCreationInfo) -> Dict[str, Any]:
+    def get_data_decoded(self, obj: SafeCreationInfo) -> dict[str, Any]:
         return get_data_decoded_from_data(obj.setup_data or b"")
 
 
@@ -1096,7 +1096,7 @@ class SafeDelegateDeleteSerializer(serializers.Serializer):
         ethereum_client: EthereumClient,
         safe_address: ChecksumAddress,
         delegate: ChecksumAddress,
-    ) -> List[ChecksumAddress]:
+    ) -> list[ChecksumAddress]:
         """
         :param ethereum_client:
         :param safe_address:
@@ -1111,7 +1111,7 @@ class SafeDelegateDeleteSerializer(serializers.Serializer):
         safe_address: ChecksumAddress,
         signature: bytes,
         operation_hash: bytes,
-        valid_delegators: List[ChecksumAddress],
+        valid_delegators: list[ChecksumAddress],
     ) -> Optional[ChecksumAddress]:
         """
         Checks signature and returns a valid owner if found, None otherwise

--- a/safe_transaction_service/history/services/balance_service.py
+++ b/safe_transaction_service/history/services/balance_service.py
@@ -1,7 +1,7 @@
 import logging
 import operator
 from dataclasses import dataclass
-from typing import List, Optional, Sequence, Tuple
+from typing import Optional, Sequence
 
 from django.conf import settings
 from django.core.cache import cache as django_cache
@@ -90,7 +90,7 @@ class BalanceService:
         erc20_addresses: Sequence[ChecksumAddress],
         only_trusted: bool,
         exclude_spam: bool,
-    ) -> List[ChecksumAddress]:
+    ) -> list[ChecksumAddress]:
         """
         Filter the provided `erc20_addresses` list and tokens with `events_bugged=True` by spam or trusted.
 
@@ -137,7 +137,7 @@ class BalanceService:
         exclude_spam: bool = False,
         limit: Optional[int] = None,
         offset: int = 0,
-    ) -> Tuple[List[Balance], int]:
+    ) -> tuple[list[Balance], int]:
         """
         Get a list of balances including native token balance.
         For ether, `token_address` is `None`.
@@ -186,7 +186,7 @@ class BalanceService:
         exclude_spam: bool = False,
         limit: Optional[int] = None,
         offset: int = 0,
-    ) -> Tuple[List[ChecksumAddress], int]:
+    ) -> tuple[list[ChecksumAddress], int]:
         """
         :param safe_address:
         :param only_trusted:
@@ -228,7 +228,7 @@ class BalanceService:
         exclude_spam: bool = False,
         limit: Optional[int] = None,
         offset: int = 0,
-    ) -> Tuple[List[Balance], int]:
+    ) -> tuple[list[Balance], int]:
         """
         Get a list of balances including native token balance.
         For ether, `token_address` is `None`.

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -4,7 +4,7 @@ import json
 import logging
 import operator
 import random
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Optional, Sequence
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -95,7 +95,7 @@ class CollectibleWithMetadata(Collectible):
     Collectible with metadata parsed if possible
     """
 
-    metadata: Dict[str, Any]
+    metadata: dict[str, Any]
     name: Optional[str] = dataclasses.field(init=False)
     description: Optional[str] = dataclasses.field(init=False)
     image_uri: Optional[str] = dataclasses.field(init=False)
@@ -207,7 +207,7 @@ class CollectiblesService:
     def get_metadata_cache_key(self, address: str, token_id: int):
         return f"metadata:{address}:{token_id}"
 
-    def _decode_base64_uri(self, uri: str) -> Optional[Dict[str, Any]]:
+    def _decode_base64_uri(self, uri: str) -> Optional[dict[str, Any]]:
         """
         Decodes data:application/json;base64 uris
 
@@ -333,7 +333,7 @@ class CollectiblesService:
         exclude_spam: bool = False,
         limit: Optional[int] = None,
         offset: int = 0,
-    ) -> Tuple[List[Collectible], int]:
+    ) -> tuple[list[Collectible], int]:
         """
         :param safe_address:
         :param only_trusted: If True, return balance only for trusted tokens
@@ -376,7 +376,7 @@ class CollectiblesService:
         exclude_spam: bool = False,
         limit: Optional[int] = None,
         offset: int = 0,
-    ) -> Tuple[List[Collectible], int]:
+    ) -> tuple[list[Collectible], int]:
         """
         :param safe_address:
         :param only_trusted: If True, return balance only for trusted tokens
@@ -426,7 +426,7 @@ class CollectiblesService:
         exclude_spam: bool = False,
         limit: Optional[int] = None,
         offset: int = 0,
-    ) -> Tuple[List[CollectibleWithMetadata], int]:
+    ) -> tuple[list[CollectibleWithMetadata], int]:
         """
         Get collectibles using the owner, addresses and the token_ids
 
@@ -441,7 +441,7 @@ class CollectiblesService:
         # Async retry for getting metadata if fetching fails
         from ..tasks import retry_get_metadata_task
 
-        collectibles_with_metadata: List[CollectibleWithMetadata] = []
+        collectibles_with_metadata: list[CollectibleWithMetadata] = []
         collectibles, count = self.get_collectibles(
             safe_address,
             only_trusted=only_trusted,
@@ -541,7 +541,7 @@ class CollectiblesService:
         exclude_spam: bool = False,
         limit: int = 10,
         offset: int = 0,
-    ) -> Tuple[List[CollectibleWithMetadata], int]:
+    ) -> tuple[list[CollectibleWithMetadata], int]:
         """
         Get collectibles paginated
 
@@ -573,8 +573,8 @@ class CollectiblesService:
                 return Erc721InfoWithLogo.from_token(token)
 
     def get_token_uris(
-        self, addresses_with_token_ids: Sequence[Tuple[ChecksumAddress, int]]
-    ) -> List[Optional[str]]:
+        self, addresses_with_token_ids: Sequence[tuple[ChecksumAddress, int]]
+    ) -> list[Optional[str]]:
         """
         Cache token_uris, as they shouldn't change
 
@@ -582,7 +582,7 @@ class CollectiblesService:
         :return: List of token_uris in the same other that `addresses_with_token_ids` were provided
         """
 
-        def get_redis_key(address_with_token_id: Tuple[ChecksumAddress, int]) -> str:
+        def get_redis_key(address_with_token_id: tuple[ChecksumAddress, int]) -> str:
             token_address, token_id = address_with_token_id
             return f"token-uri:{token_address}:{token_id}"
 
@@ -592,8 +592,8 @@ class CollectiblesService:
             for address_with_token_id in addresses_with_token_ids
         )
         # Redis does not allow `None`, so empty string is used for uris searched but not found
-        found_uris: Dict[Tuple[ChecksumAddress, int], Optional[str]] = {}
-        not_found_uris: List[Tuple[ChecksumAddress, int]] = []
+        found_uris: dict[tuple[ChecksumAddress, int], Optional[str]] = {}
+        not_found_uris: list[tuple[ChecksumAddress, int]] = []
 
         for address_with_token_id, token_uri in zip(
             addresses_with_token_ids, redis_token_uris

--- a/safe_transaction_service/history/services/event_service.py
+++ b/safe_transaction_service/history/services/event_service.py
@@ -4,7 +4,7 @@ Build event payloads for the queue
 
 import json
 from datetime import timedelta
-from typing import Any, Dict, List, Optional, Type, TypedDict, Union
+from typing import Any, Optional, Type, TypedDict, Union
 
 from django.db.models import Model
 from django.utils import timezone
@@ -42,14 +42,14 @@ def build_event_payload(
         SafeMessageConfirmation,
     ],
     deleted: bool = False,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     :param sender: Sender type
     :param instance: Sender instance
     :param deleted: If the instance has been deleted
     :return: A list of messages generated from the instance provided
     """
-    payloads: List[Dict[str, Any]] = []
+    payloads: list[dict[str, Any]] = []
     if sender == MultisigConfirmation and instance.multisig_transaction_id:
         payloads = [
             {

--- a/safe_transaction_service/history/services/index_service.py
+++ b/safe_transaction_service/history/services/index_service.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Collection, List, Optional, OrderedDict, Union
+from typing import Collection, Optional, OrderedDict, Union
 
 from django.db import IntegrityError, transaction
 from django.db.models import Min, Q
@@ -252,7 +252,7 @@ class IndexService:
 
     def txs_create_or_update_from_tx_hashes(
         self, tx_hashes: Collection[Union[str, bytes]]
-    ) -> List["EthereumTx"]:
+    ) -> list["EthereumTx"]:
         logger.debug("Don't retrieve existing txs on DB. Find them first")
         # Search first in database
         ethereum_txs_dict = OrderedDict.fromkeys(
@@ -369,7 +369,7 @@ class IndexService:
         return list(ethereum_txs_dict.values())
 
     @transaction.atomic
-    def _reprocess(self, addresses: List[str]):
+    def _reprocess(self, addresses: list[str]):
         """
         Trigger processing of traces again. If addresses is empty, everything is reprocessed
 
@@ -484,7 +484,7 @@ class IndexService:
             )
         return total_processed_txs
 
-    def reprocess_addresses(self, addresses: List[ChecksumAddress]):
+    def reprocess_addresses(self, addresses: list[ChecksumAddress]):
         """
         Given a list of safe addresses it will delete all `SafeStatus`, conflicting `MultisigTxs` and will mark
         every `InternalTxDecoded` not processed to be processed again

--- a/safe_transaction_service/history/services/reorg_service.py
+++ b/safe_transaction_service/history/services/reorg_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, List, Optional
+from typing import Callable, Optional
 
 from django.core.paginator import Paginator
 from django.db import transaction
@@ -64,7 +64,7 @@ class ReorgService:
         self.eth_reorg_rewind_blocks = eth_reorg_rewind_blocks
 
         # List with functions for database models to recover from reorgs
-        self.reorg_functions: List[Callable[[int], int]] = [
+        self.reorg_functions: list[Callable[[int], int]] = [
             lambda block_number: ProxyFactory.objects.filter(
                 tx_block_number__gt=block_number
             ).update(tx_block_number=block_number),

--- a/safe_transaction_service/history/services/transaction_service.py
+++ b/safe_transaction_service/history/services/transaction_service.py
@@ -3,7 +3,7 @@ import pickle
 import zlib
 from collections import defaultdict
 from datetime import timedelta
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Optional, Sequence, Union
 
 from django.conf import settings
 from django.db.models import QuerySet
@@ -67,7 +67,7 @@ class TransactionService:
 
     def get_txs_from_cache(
         self, safe_address: str, ids_to_search: Sequence[str]
-    ) -> List[AnySafeTransaction]:
+    ) -> list[AnySafeTransaction]:
         keys_to_search = [
             self.get_cache_key(safe_address, id_to_search)
             for id_to_search in ids_to_search
@@ -80,7 +80,7 @@ class TransactionService:
     def store_txs_in_cache(
         self,
         safe_address: str,
-        ids_with_txs: Tuple[str, List[AnySafeTransaction]],
+        ids_with_txs: tuple[str, list[AnySafeTransaction]],
     ):
         """
         Store executed transactions older than 10 minutes, using `ethereum_tx_hash` as key (for
@@ -135,7 +135,7 @@ class TransactionService:
 
     def get_all_txs_from_identifiers(
         self, safe_address: str, ids_to_search: Sequence[str]
-    ) -> List[AnySafeTransaction]:
+    ) -> list[AnySafeTransaction]:
         """
         Now that we know how to paginate, we retrieve the real transactions
 
@@ -170,7 +170,7 @@ class TransactionService:
             safe_address,
             len(ids_not_cached),
         )
-        ids_with_multisig_txs: Dict[HexStr, List[MultisigTransaction]] = {}
+        ids_with_multisig_txs: dict[HexStr, list[MultisigTransaction]] = {}
         number_multisig_txs = 0
         for multisig_tx in (
             MultisigTransaction.objects.filter(
@@ -191,7 +191,7 @@ class TransactionService:
             number_multisig_txs,
         )
 
-        ids_with_module_txs: Dict[HexStr, List[ModuleTransaction]] = {}
+        ids_with_module_txs: dict[HexStr, list[ModuleTransaction]] = {}
         number_module_txs = 0
         for module_tx in ModuleTransaction.objects.filter(
             safe=safe_address, internal_tx__ethereum_tx__in=ids_not_cached
@@ -206,7 +206,7 @@ class TransactionService:
             number_module_txs,
         )
 
-        ids_with_plain_ethereum_txs: Dict[HexStr, List[EthereumTx]] = {
+        ids_with_plain_ethereum_txs: dict[HexStr, list[EthereumTx]] = {
             ethereum_tx.tx_hash: [ethereum_tx]
             for ethereum_tx in EthereumTx.objects.filter(
                 tx_hash__in=ids_not_cached
@@ -242,7 +242,7 @@ class TransactionService:
 
         # Build dict of transfers for optimizing access
         transfer_dict = defaultdict(list)
-        transfers: List[TransferDict] = InternalTx.objects.union_ether_and_token_txs(
+        transfers: list[TransferDict] = InternalTx.objects.union_ether_and_token_txs(
             erc20_queryset, erc721_queryset, ether_queryset
         )
         for transfer in transfers:
@@ -275,7 +275,7 @@ class TransactionService:
         # Build the list
         def get_the_transactions(
             transaction_id: str,
-        ) -> List[MultisigTransaction | ModuleTransaction | EthereumTx]:
+        ) -> list[MultisigTransaction | ModuleTransaction | EthereumTx]:
             """
             :param transaction_id: SafeTxHash (in case of a ``MultisigTransaction``) or Ethereum ``TxHash`` for the rest
             :return: Transactions for the transaction id, with transfers appended
@@ -329,8 +329,8 @@ class TransactionService:
         )  # Sorted already by execution_date
 
     def serialize_all_txs(
-        self, models: List[AnySafeTransaction]
-    ) -> List[Dict[str, Any]]:
+        self, models: list[AnySafeTransaction]
+    ) -> list[dict[str, Any]]:
         logger.debug("Serializing all transactions")
         results = []
         for model in models:
@@ -351,8 +351,8 @@ class TransactionService:
         return results
 
     def serialize_all_txs_v2(
-        self, models: List[AnySafeTransaction]
-    ) -> List[Dict[str, Any]]:
+        self, models: list[AnySafeTransaction]
+    ) -> list[dict[str, Any]]:
         logger.debug("Serializing all transactions")
         results = []
         for model in models:

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -3,7 +3,7 @@ import dataclasses
 import datetime
 import json
 import random
-from typing import Optional, Tuple
+from typing import Optional
 
 from django.conf import settings
 from django.utils import timezone
@@ -96,7 +96,7 @@ def check_sync_status_task() -> bool:
     retry_kwargs={"max_retries": 3},
 )
 @task_timeout(timeout_seconds=LOCK_TIMEOUT)
-def index_erc20_events_task(self) -> Optional[Tuple[int, int]]:
+def index_erc20_events_task(self) -> Optional[tuple[int, int]]:
     """
     Find and process ERC20/721 events for monitored addresses
 
@@ -182,7 +182,7 @@ def index_erc20_events_out_of_sync_task(
     retry_kwargs={"max_retries": 3},
 )
 @task_timeout(timeout_seconds=LOCK_TIMEOUT)
-def index_internal_txs_task(self) -> Optional[Tuple[int, int]]:
+def index_internal_txs_task(self) -> Optional[tuple[int, int]]:
     """
     Find and process internal txs for monitored addresses
     :return: Tuple of number of addresses processed and number of blocks processed
@@ -209,7 +209,7 @@ def index_internal_txs_task(self) -> Optional[Tuple[int, int]]:
     retry_kwargs={"max_retries": 3},
 )
 @task_timeout(timeout_seconds=LOCK_TIMEOUT)
-def index_new_proxies_task(self) -> Optional[Tuple[int, int]]:
+def index_new_proxies_task(self) -> Optional[tuple[int, int]]:
     """
     :return: Tuple of number of proxies created and number of blocks processed
     """
@@ -231,7 +231,7 @@ def index_new_proxies_task(self) -> Optional[Tuple[int, int]]:
     retry_kwargs={"max_retries": 3},
 )
 @task_timeout(timeout_seconds=LOCK_TIMEOUT)
-def index_safe_events_task(self) -> Optional[Tuple[int, int]]:
+def index_safe_events_task(self) -> Optional[tuple[int, int]]:
     """
     Find and process for monitored addresses
     :return: Tuple of number of addresses processed and number of blocks processed

--- a/safe_transaction_service/history/tests/factories.py
+++ b/safe_transaction_service/history/tests/factories.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict
+from typing import Any
 
 from django.utils import timezone
 
@@ -202,7 +202,7 @@ class InternalTxDecodedFactory(DjangoModelFactory):
     processed = False
 
     @factory.lazy_attribute
-    def arguments(self) -> Dict[str, Any]:
+    def arguments(self) -> dict[str, Any]:
         if self.function_name == "addOwnerWithThreshold":
             return {"owner": self.owner, "_threshold": self.threshold}
         elif self.function_name == "approveHash":

--- a/safe_transaction_service/history/tests/test_collectibles_service.py
+++ b/safe_transaction_service/history/tests/test_collectibles_service.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Sequence, Tuple
+from typing import Optional, Sequence
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -360,8 +360,8 @@ class TestCollectiblesService(EthereumTestCaseMixin, TestCase):
         """
 
         def get_token_uris_fn(
-            self, token_addresses_with_token_ids: Sequence[Tuple[str, int]]
-        ) -> List[Optional[str]]:
+            self, token_addresses_with_token_ids: Sequence[tuple[str, int]]
+        ) -> list[Optional[str]]:
             if (
                 "0x9807559b75D5fcCEcf1bbe074FD0890EdDC1bf79",
                 8,

--- a/safe_transaction_service/history/utils.py
+++ b/safe_transaction_service/history/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 from urllib.parse import urlparse
 
 from django import forms
@@ -40,7 +40,7 @@ class HexField(forms.CharField):
         return to_0x_hex_str(bytes(value)) if value else ""
 
 
-def clean_receipt_log(receipt_log: LogReceipt) -> Optional[Dict[str, Any]]:
+def clean_receipt_log(receipt_log: LogReceipt) -> Optional[dict[str, Any]]:
     """
     Clean receipt log and make them JSON compliant
 

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -1,6 +1,6 @@
 import hashlib
 import logging
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 from django.conf import settings
 from django.utils.decorators import method_decorator
@@ -114,7 +114,7 @@ class AboutEthereumRPCView(APIView):
 
     renderer_classes = (JSONRenderer,)
 
-    def _get_info(self, ethereum_client: EthereumClient) -> Dict[str, Any]:
+    def _get_info(self, ethereum_client: EthereumClient) -> dict[str, Any]:
         try:
             client_version = ethereum_client.w3.client_version
         except (IOError, ValueError):
@@ -796,7 +796,7 @@ class SafeBalanceView(GenericAPIView):
     serializer_class = serializers.SafeBalanceResponseSerializer
     pagination_class = None  # Don't show limit/offset in swagger
 
-    def get_parameters(self) -> Tuple[bool, bool]:
+    def get_parameters(self) -> tuple[bool, bool]:
         """
         Parse query parameters:
         :return: Tuple with only_trusted, exclude_spam

--- a/safe_transaction_service/history/views_v2.py
+++ b/safe_transaction_service/history/views_v2.py
@@ -1,6 +1,6 @@
 import hashlib
 import logging
-from typing import List, Optional, Tuple
+from typing import Optional
 
 from django.db.models import Q
 
@@ -235,7 +235,7 @@ class DelegateDeleteView(GenericAPIView):
 class SafeBalanceView(GenericAPIView):
     serializer_class = serializers.SafeBalanceResponseSerializer
 
-    def get_parameters(self) -> Tuple[bool, bool]:
+    def get_parameters(self) -> tuple[bool, bool]:
         """
         Parse query parameters:
         :return: Tuple with only_trusted, exclude_spam
@@ -248,7 +248,7 @@ class SafeBalanceView(GenericAPIView):
         )
         return only_trusted, exclude_spam
 
-    def get_result(self, *args, **kwargs) -> Tuple[List[Balance], int]:
+    def get_result(self, *args, **kwargs) -> tuple[list[Balance], int]:
         return BalanceServiceProvider().get_balances(*args, **kwargs)
 
     @extend_schema(

--- a/safe_transaction_service/safe_messages/serializers.py
+++ b/safe_transaction_service/safe_messages/serializers.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Optional, Sequence, Tuple, Union
+from typing import Any, Optional, Sequence, Union
 
 from django.conf import settings
 
@@ -26,7 +26,7 @@ class SafeMessageSignatureParserMixin:
         safe_signatures: Sequence[SafeSignature],
         safe_address: ChecksumAddress,
         safe_message: Optional[SafeMessage],
-    ) -> Tuple[ChecksumAddress, SafeSignatureType]:
+    ) -> tuple[ChecksumAddress, SafeSignatureType]:
         """
         :param safe_signatures:
         :param safe_address:
@@ -87,7 +87,7 @@ class SafeMessageSerializer(SafeMessageSignatureParserMixin, serializers.Seriali
 
         return origin
 
-    def validate_message(self, value: Union[str, Dict[str, Any]]):
+    def validate_message(self, value: Union[str, dict[str, Any]]):
         if isinstance(value, str):
             return value
 
@@ -207,7 +207,7 @@ class SafeMessageResponseSerializer(serializers.Serializer):
     prepared_signature = serializers.SerializerMethodField()
     origin = serializers.SerializerMethodField()
 
-    def get_confirmations(self, obj: SafeMessage) -> Dict[str, Any]:
+    def get_confirmations(self, obj: SafeMessage) -> dict[str, Any]:
         """
         Filters confirmations queryset
 

--- a/safe_transaction_service/safe_messages/utils.py
+++ b/safe_transaction_service/safe_messages/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from eth_account.messages import defunct_hash_message
 from eth_typing import ChecksumAddress, Hash32
@@ -7,7 +7,7 @@ from safe_eth.eth.eip712 import eip712_encode_hash
 from safe_eth.safe import Safe
 
 
-def get_hash_for_message(message: str | Dict[str, Any]) -> Hash32:
+def get_hash_for_message(message: str | dict[str, Any]) -> Hash32:
     return (
         defunct_hash_message(text=message)
         if isinstance(message, str)

--- a/safe_transaction_service/tokens/clients/coingecko_client.py
+++ b/safe_transaction_service/tokens/clients/coingecko_client.py
@@ -1,6 +1,6 @@
 import logging
 from functools import lru_cache
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 from urllib.parse import urljoin
 
 from eth_typing import ChecksumAddress
@@ -45,7 +45,7 @@ class CoingeckoClient(BaseHTTPClient):
     def supports_network(cls, network: EthereumNetwork):
         return network in cls.ASSET_BY_NETWORK
 
-    def _do_request(self, url: str) -> Dict[str, Any]:
+    def _do_request(self, url: str) -> dict[str, Any]:
         try:
             response = self.http_session.get(url, timeout=self.request_timeout)
             if not response.ok:
@@ -62,7 +62,7 @@ class CoingeckoClient(BaseHTTPClient):
     @lru_cache(maxsize=128)
     def get_token_info(
         self, token_address: ChecksumAddress
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         token_address = token_address.lower()
         url = urljoin(
             self.base_url,

--- a/safe_transaction_service/tokens/clients/coinmarketcap_client.py
+++ b/safe_transaction_service/tokens/clients/coinmarketcap_client.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from urllib.parse import urljoin
 
 from safe_eth.eth.utils import fast_to_checksum_address
@@ -47,7 +47,7 @@ class CoinMarketCapClient(BaseHTTPClient):
                         f.write(chunk)
             return local_filename
 
-    def get_map(self) -> List[Dict[str, Any]]:
+    def get_map(self) -> list[dict[str, Any]]:
         """
         [
             {'id': 1659,
@@ -90,7 +90,7 @@ class CoinMarketCapClient(BaseHTTPClient):
             logger.warning("Problem getting tokens from coinmarketcap", exc_info=True)
             return []
 
-    def get_ethereum_tokens(self) -> List[CoinMarketCapToken]:
+    def get_ethereum_tokens(self) -> list[CoinMarketCapToken]:
         tokens = []
         for token in self.get_map():
             if (

--- a/safe_transaction_service/tokens/clients/kleros_client.py
+++ b/safe_transaction_service/tokens/clients/kleros_client.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Sequence
+from typing import Sequence
 
 from hexbytes import HexBytes
 from safe_eth.eth import EthereumClient
@@ -60,7 +60,7 @@ class KlerosClient:
              */
         """
         token_count = self.get_token_count()
-        token_ids: List[bytes]
+        token_ids: list[bytes]
         has_more: bool
         token_ids, has_more = self.kleros_contract.functions.queryTokens(
             HexBytes("0" * 64),  # bytes32

--- a/safe_transaction_service/tokens/clients/zerion_client.py
+++ b/safe_transaction_service/tokens/clients/zerion_client.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional
 
 from eth_typing import ChecksumAddress
 from safe_eth.eth import EthereumClient
@@ -88,7 +88,7 @@ class ZerionTokenAdapterClient:
 
     def get_components(
         self, token_address: ChecksumAddress
-    ) -> Optional[List[UniswapComponent]]:
+    ) -> Optional[list[UniswapComponent]]:
         try:
             return [
                 UniswapComponent(*component)

--- a/safe_transaction_service/utils/serializers.py
+++ b/safe_transaction_service/utils/serializers.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import List
 
 from eth_typing import ChecksumAddress
 from rest_framework.exceptions import ValidationError
@@ -9,7 +8,7 @@ from safe_eth.safe import Safe
 from web3.exceptions import Web3Exception
 
 
-def get_safe_owners(safe_address: ChecksumAddress) -> List[ChecksumAddress]:
+def get_safe_owners(safe_address: ChecksumAddress) -> list[ChecksumAddress]:
     """
     :param safe_address:
     :return: Current owners for a Safe

--- a/safe_transaction_service/utils/utils.py
+++ b/safe_transaction_service/utils/utils.py
@@ -2,7 +2,7 @@ import datetime
 import socket
 from functools import wraps
 from itertools import islice
-from typing import Any, Iterable, List, Union
+from typing import Any, Iterable, Union
 
 from django.core.signals import request_finished
 from django.db import connection
@@ -28,7 +28,7 @@ class FixedSizeDict(dict):
                 self.pop(next(iter(self)))
 
 
-def chunks(elements: List[Any], n: int) -> Iterable[Any]:
+def chunks(elements: list[Any], n: int) -> Iterable[Any]:
     """
     :param elements: List
     :param n: Number of elements per chunk


### PR DESCRIPTION
- Use builtin types instead of importing from `typing`
- Not all the types were updated
