### PR TITLE
Fix 1271 signatures for delegates

### DIFF
--- a/safe_transaction_service/history/helpers.py
+++ b/safe_transaction_service/history/helpers.py
@@ -93,7 +93,7 @@ class DelegateSignatureHelperV2(TemporarySignatureHelper):
 
         :param delegate_address:
         :param chain_id:
-        :param previous_totp:
+        :param previous_totp: if true calculate previous totp interval
         :return: Hash for the EIP712 generated object from the provided parameters with the preimage
         """
         totp = cls.calculate_totp(previous=previous_totp)

--- a/safe_transaction_service/history/helpers.py
+++ b/safe_transaction_service/history/helpers.py
@@ -4,7 +4,8 @@ from typing import Optional
 
 from eth_typing import ChecksumAddress, Hash32, HexStr
 from eth_utils import keccak
-from safe_eth.eth.eip712 import eip712_encode_hash
+from safe_eth.eth.eip712 import eip712_encode, eip712_encode_hash
+from safe_eth.eth.utils import fast_keccak
 
 from safe_transaction_service.history.models import TransferDict
 from safe_transaction_service.tokens.models import Token
@@ -81,19 +82,19 @@ class DeleteMultisigTxSignatureHelper(TemporarySignatureHelper):
 
 class DelegateSignatureHelperV2(TemporarySignatureHelper):
     @classmethod
-    def calculate_hash(
+    def calculate_hash_and_preimage(
         cls,
         delegate_address: ChecksumAddress,
         chain_id: Optional[int],
         previous_totp: bool = False,
-    ) -> Hash32:
+    ) -> tuple[Hash32, bytes]:
         """
         Builds a EIP712 object and calculates its hash
 
         :param delegate_address:
         :param chain_id:
         :param previous_totp:
-        :return: Hash for the EIP712 generated object from the provided parameters
+        :return: Hash for the EIP712 generated object from the provided parameters with the preimage
         """
         totp = cls.calculate_totp(previous=previous_totp)
 
@@ -125,7 +126,8 @@ class DelegateSignatureHelperV2(TemporarySignatureHelper):
             )
             payload["domain"]["chainId"] = chain_id
 
-        return eip712_encode_hash(payload)
+        preimage = b"".join(eip712_encode(payload))
+        return fast_keccak(preimage), preimage
 
 
 def is_valid_unique_transfer_id(unique_transfer_id: str) -> bool:

--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -456,10 +456,14 @@ class DelegateSerializerMixin:
         for previous_totp, chain_id in list(
             itertools.product((True, False), (chain_id, None))
         ):
-            message_hash = DelegateSignatureHelperV2.calculate_hash(
-                delegate, chain_id, previous_totp=previous_totp
+            message_hash, preimage = (
+                DelegateSignatureHelperV2.calculate_hash_and_preimage(
+                    delegate, chain_id, previous_totp=previous_totp
+                )
             )
-            safe_signatures = SafeSignature.parse_signature(signature, message_hash)
+            safe_signatures = SafeSignature.parse_signature(
+                signature, message_hash, safe_hash_preimage=preimage
+            )
             if not safe_signatures:
                 raise ValidationError("Signature is not valid")
 

--- a/safe_transaction_service/history/tests/test_helpers.py
+++ b/safe_transaction_service/history/tests/test_helpers.py
@@ -24,7 +24,7 @@ class TestDelegateSignatureHelperV2(SafeTestCaseMixin, TestCase):
             "0x40ef28feb993bf127265260d48ab1a427d5b852aa8b38f511fcd368bfc9cbfdf"
         )
 
-        result_hash = DelegateSignatureHelperV2.calculate_hash(
+        result_hash, _ = DelegateSignatureHelperV2.calculate_hash_and_preimage(
             delegate_address, chain_id, False
         )
 
@@ -36,7 +36,7 @@ class TestDelegateSignatureHelperV2(SafeTestCaseMixin, TestCase):
             "0x37fe1c77d467e92109ef91637e30a4053bab963de2ea74f9d6c4ba1918ff32e6"
         )
 
-        result_hash = DelegateSignatureHelperV2.calculate_hash(
+        result_hash, _ = DelegateSignatureHelperV2.calculate_hash_and_preimage(
             delegate_address, chain_id, True
         )
 

--- a/safe_transaction_service/history/tests/test_views_v2.py
+++ b/safe_transaction_service/history/tests/test_views_v2.py
@@ -232,7 +232,7 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
             # Create delegate
             self.assertEqual(SafeContractDelegate.objects.count(), 0)
             chain_id = self.ethereum_client.get_chain_id()
-            hash_to_sign = DelegateSignatureHelperV2.calculate_hash(
+            hash_to_sign, _ = DelegateSignatureHelperV2.calculate_hash_and_preimage(
                 delegate.address, chain_id, False
             )
             data["signature"] = to_0x_hex_str(
@@ -271,7 +271,7 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
             self.assertIsNone(safe_contract_delegate.expiry_date)
 
         # Create delegate without a Safe
-        hash_to_sign = DelegateSignatureHelperV2.calculate_hash(
+        hash_to_sign, _ = DelegateSignatureHelperV2.calculate_hash_and_preimage(
             delegate.address, chain_id, False
         )
         data = {
@@ -302,7 +302,7 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
         chain_id = None
         delegate = Account.create()
         delegator = Account.create()
-        hash_to_sign = DelegateSignatureHelperV2.calculate_hash(
+        hash_to_sign, _ = DelegateSignatureHelperV2.calculate_hash_and_preimage(
             delegate.address, chain_id, False
         )
         data = {
@@ -326,7 +326,7 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
         chain_id = None
         delegate = Account.create()
         delegator = Account.create()
-        hash_to_sign = DelegateSignatureHelperV2.calculate_hash(
+        hash_to_sign, _ = DelegateSignatureHelperV2.calculate_hash_and_preimage(
             delegate.address, chain_id, False
         )
         data = {
@@ -432,7 +432,7 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
         delegate = Account.create()
         delegator = Account.create()
         chain_id = self.ethereum_client.get_chain_id()
-        hash_to_sign = DelegateSignatureHelperV2.calculate_hash(
+        hash_to_sign, _ = DelegateSignatureHelperV2.calculate_hash_and_preimage(
             delegate.address, chain_id, False
         )
         # Test delete using delegate signature and then delegator signature


### PR DESCRIPTION
- Related with #2472 

Fixed the validation of EIP-1271 signatures so a nested safe can add a delegate user for its Safe owner using a 1271 signature.

Added a test case where the scenario described in the open issue is validated.