### PR TITLE
Use hashes instead of full message for 1271

### DIFF
--- a/safe_transaction_service/safe_messages/serializers.py
+++ b/safe_transaction_service/safe_messages/serializers.py
@@ -114,11 +114,9 @@ class SafeMessageSerializer(SafeMessageSignatureParserMixin, serializers.Seriali
         signature = attrs["signature"]
         # Encode EIP-191 or EIP-712 original message as bytes
         # Use fast_keccak to maintain compatibility with the old version
-        message_encoded = fast_keccak(get_message_encoded(message))
+        message_hash = fast_keccak(get_message_encoded(message))
         safe_message_hash, safe_message_preimage = (
-            get_safe_message_hash_and_preimage_for_message(
-                safe_address, message_encoded
-            )
+            get_safe_message_hash_and_preimage_for_message(safe_address, message_hash)
         )
         attrs["message_hash"] = safe_message_hash
 
@@ -169,11 +167,9 @@ class SafeMessageSignatureSerializer(
         attrs["safe_message"] = safe_message
         signature: HexStr = attrs["signature"]
         safe_address = safe_message.safe
-        message_encoded = fast_keccak(get_message_encoded(safe_message.message))
+        message_hash = fast_keccak(get_message_encoded(safe_message.message))
         safe_message_hash, safe_message_preimage = (
-            get_safe_message_hash_and_preimage_for_message(
-                safe_address, message_encoded
-            )
+            get_safe_message_hash_and_preimage_for_message(safe_address, message_hash)
         )
         assert to_0x_hex_str(safe_message_hash) == safe_message.message_hash
 

--- a/safe_transaction_service/safe_messages/serializers.py
+++ b/safe_transaction_service/safe_messages/serializers.py
@@ -10,6 +10,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from safe_eth.eth import get_auto_ethereum_client
 from safe_eth.eth.eip712 import eip712_encode
+from safe_eth.eth.utils import fast_keccak
 from safe_eth.safe.safe_signature import SafeSignature, SafeSignatureType
 from safe_eth.util.util import to_0x_hex_str
 
@@ -112,7 +113,8 @@ class SafeMessageSerializer(SafeMessageSignatureParserMixin, serializers.Seriali
         message = attrs["message"]
         signature = attrs["signature"]
         # Encode EIP-191 or EIP-712 original message as bytes
-        message_encoded = get_message_encoded(message)
+        # Use fast_keccak to maintain compatibility with the old version
+        message_encoded = fast_keccak(get_message_encoded(message))
         safe_message_hash, safe_message_preimage = (
             get_safe_message_hash_and_preimage_for_message(
                 safe_address, message_encoded
@@ -167,7 +169,7 @@ class SafeMessageSignatureSerializer(
         attrs["safe_message"] = safe_message
         signature: HexStr = attrs["signature"]
         safe_address = safe_message.safe
-        message_encoded = get_message_encoded(safe_message.message)
+        message_encoded = fast_keccak(get_message_encoded(safe_message.message))
         safe_message_hash, safe_message_preimage = (
             get_safe_message_hash_and_preimage_for_message(
                 safe_address, message_encoded

--- a/safe_transaction_service/safe_messages/tests/factories.py
+++ b/safe_transaction_service/safe_messages/tests/factories.py
@@ -1,6 +1,7 @@
 import factory
 from eth_account import Account
 from factory.django import DjangoModelFactory
+from safe_eth.eth.utils import fast_keccak
 from safe_eth.safe.safe_signature import SafeSignatureType
 from safe_eth.util.util import to_0x_hex_str
 
@@ -22,7 +23,7 @@ class SafeMessageFactory(DjangoModelFactory):
     def message_hash(self) -> str:
         return to_0x_hex_str(
             get_safe_message_hash_and_preimage_for_message(
-                self.safe, get_message_encoded(self.message)
+                self.safe, fast_keccak(get_message_encoded(self.message))
             )[0]
         )
 

--- a/safe_transaction_service/safe_messages/tests/test_models.py
+++ b/safe_transaction_service/safe_messages/tests/test_models.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 
 from eth_account import Account
 from hexbytes import HexBytes
+from safe_eth.eth.utils import fast_keccak
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 from safe_eth.util.util import to_0x_hex_str
 
@@ -22,15 +23,15 @@ class TestSafeMessage(SafeTestCaseMixin, TestCase):
         for input, expected in [
             (
                 "TestMessage",
-                "Safe Message 0x95a89792bad17115e101b4d8fbdcd517dd13d085e815287d7fe791078182bf9e - TestMessage",
+                "Safe Message 0xb04a24aa07a51d1d8c3913e9493b3b1f88ed6a8a75430a9a8eda3ed3ce1897bc - TestMessage",
             ),
             (
                 "TestMessageVeryLong",
-                "Safe Message 0xb7783fde9060e75b61298c14cbc2a987f0e0800d1bb08b4a2b24ce3544b9b144 - TestMessageVery...",
+                "Safe Message 0xe3db816540ce371e2703b8ec59bdd6fec32e0c6078f2e204a205fd6d81564f28 - TestMessageVery...",
             ),
             (
                 get_eip712_payload_mock(),
-                "Safe Message 0x632db20317ce8e467d17e941d209fc1173ff1cad83b0c072c008385a566ddd80 - {'types': {'EIP...",
+                "Safe Message 0xbabb22f5c02a24db447b8f0136d6e26bb58cd6d068ebe8ab25c2221cfdf53e18 - {'types': {'EIP...",
             ),
         ]:
             with self.subTest(input=input):
@@ -62,7 +63,7 @@ class TestSafeMessage(SafeTestCaseMixin, TestCase):
             message_hash,
             to_0x_hex_str(
                 get_safe_message_hash_and_preimage_for_message(
-                    safe_message.safe, get_message_encoded(message)
+                    safe_message.safe, fast_keccak(get_message_encoded(message))
                 )[0]
             ),
         )

--- a/safe_transaction_service/safe_messages/tests/test_views.py
+++ b/safe_transaction_service/safe_messages/tests/test_views.py
@@ -12,6 +12,7 @@ from rest_framework import status
 from rest_framework.exceptions import ErrorDetail
 from rest_framework.test import APITestCase
 from safe_eth.eth.eip712 import eip712_encode
+from safe_eth.eth.utils import fast_keccak
 from safe_eth.safe.safe_signature import SafeSignatureEOA
 from safe_eth.safe.signatures import signature_to_bytes
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
@@ -149,7 +150,7 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
             encode_eip712_message(messages[1]),
         ]
         safe_message_hashes = [
-            safe.get_message_hash(message_encoded)
+            safe.get_message_hash(fast_keccak(message_encoded))
             for message_encoded in messages_encoded
         ]
         signatures = [
@@ -291,7 +292,7 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
         description = "Testing EIP712 message signing"
         message_encoded = b"".join(eip712_encode(message))
         safe_message_hash, safe_message_preimage = safe.get_message_hash_and_preimage(
-            message_encoded
+            fast_keccak(message_encoded)
         )
         safe_owner_message_hash, _ = safe_owner.get_message_hash_and_preimage(
             safe_message_preimage


### PR DESCRIPTION
- Revert to the old behaviour, so we don't break the frontend
- For 1271 `isValid` accepts hashes instead of full data
