### PR TITLE
Ignore errors on tx processing

### DIFF
--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -257,7 +257,7 @@ class SafeMultisigTransactionSerializer(SafeMultisigTxSerializer):
             safe_address, safe_owners
         )
         allowed_senders = set(safe_owners) | delegates
-        if not attrs["sender"] in allowed_senders:
+        if attrs["sender"] not in allowed_senders:
             raise ValidationError(
                 f'Sender={attrs["sender"]} is not an owner or delegate. '
                 f"Current owners={safe_owners}. Delegates={delegates}"

--- a/safe_transaction_service/history/tests/test_tx_processor.py
+++ b/safe_transaction_service/history/tests/test_tx_processor.py
@@ -18,6 +18,7 @@ from safe_transaction_service.safe_messages.tests.factories import (
 )
 
 from ..indexers.tx_processor import (
+    CannotFindPreviousTrace,
     ModuleCannotBeDisabled,
     SafeTxProcessor,
     SafeTxProcessorProvider,
@@ -553,7 +554,9 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         )
 
         self.assertEqual(ModuleTransaction.objects.count(), 0)
-        with self.assertRaises(ValueError):  # trace_transaction not supported
+        with self.assertRaises(
+            CannotFindPreviousTrace
+        ):  # trace_transaction not supported
             safe_tx_processor.process_decoded_transaction(module_internal_tx_decoded)
             self.assertEqual(ModuleTransaction.objects.count(), 0)
 


### PR DESCRIPTION
- Previously, an error could stuck the processor
- Indexing issues can be detected and fixed even if errors are ignored
- Malicious transactions and custom crafted Safes could stuck the indexer
