### PR TITLE
Optimize export count

### DIFF
--- a/safe_transaction_service/history/services/transaction_service.py
+++ b/safe_transaction_service/history/services/transaction_service.py
@@ -802,13 +802,9 @@ class TransactionService:
         ).values("transaction_hash", "_log_index", "_trace_address")
 
         total_count = (
-            ether_transfers.union(erc20_transfers, all=True)
-            .union(erc721_transfers, all=True)
-            .count()
+            ether_transfers.count() + erc20_transfers.count() + erc721_transfers.count()
         )
-
         with connection.cursor() as cursor:
-
             # Get the data
             cursor.execute(main_query, main_params)
             columns = [col[0] for col in cursor.description]


### PR DESCRIPTION
- Postgres runs **3 complete SCANS** and aggregates in memory, not needed for a count. This way is more optimal even if doing 3 calls to the database
