### PR TITLE
Optimize `last_valid_transaction` query

### DIFF
--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -1690,7 +1690,10 @@ class TestMultisigTransactions(TestCase):
         self.assertIsNone(
             MultisigTransaction.objects.last_valid_transaction(safe_address)
         )
-        SafeStatusFactory(address=safe_address, owners=[multisig_confirmation.owner])
+        SafeStatusFactory(
+            address=safe_address,
+            owners=[multisig_confirmation.owner, Account.create().address],
+        )
         self.assertEqual(
             MultisigTransaction.objects.last_valid_transaction(safe_address),
             multisig_transaction,


### PR DESCRIPTION
- Use subquery instead of 2 queries
