### PR TITLE
Fix `test_recover_from_reorg` test

### DIFF
--- a/safe_transaction_service/history/services/reorg_service.py
+++ b/safe_transaction_service/history/services/reorg_service.py
@@ -43,7 +43,6 @@ class ReorgServiceProvider:
             del cls.instance
 
 
-# TODO Test ReorgService
 class ReorgService:
     def __init__(
         self,
@@ -72,7 +71,9 @@ class ReorgService:
                 tx_block_number__gt=block_number
             ).update(tx_block_number=block_number),
             lambda block_number: int(
-                IndexingStatus.objects.set_erc20_721_indexing_status(block_number)
+                IndexingStatus.objects.set_erc20_721_indexing_status(
+                    block_number, from_block_number=block_number
+                )
             ),
         ]
 


### PR DESCRIPTION
- Test was flaky. Probably due to not sort multisig txs. Added `.order_by("created")`
- Add more test cases and improve the tests
- Also fix a bug that reset `ERC20 Indexing` to the reorg block even if ERC20 indexing was behind
