### PR TITLE
feat: support configuring the base path

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -49,6 +49,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.2/ref/settings/#force-script-name
 FORCE_SCRIPT_NAME = env("FORCE_SCRIPT_NAME", default=None)
 
+BASE_PATH = env("DJANGO_BASE_PATH", default="")
+
 # SSO
 SSO_ENABLED = False
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -111,4 +111,6 @@ if settings.DEBUG:
             path("__debug__/", include(debug_toolbar.urls)),
         ] + urlpatterns
 
+urlpatterns = [path(settings.BASE_PATH, include(urlpatterns))]
+
 admin.autodiscover()


### PR DESCRIPTION
### Make sure these boxes are checked! 📦✅

- [x] You ran `./run_tests.sh`
- [x] You ran `pre-commit run -a`
- [x] If you want to add your network to `setup_service.py`, provide a link to your
    [safe-deployments PR](https://github.com/safe-global/safe-deployments/pulls) and check network name
    exists in [safe-eth-py](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py)

### What was wrong? 👾

We are looking to proxy many transaction services behind a single domain - because there are redirects (swagger functionality, Django appending slashes and redirecting by default, etc.), we need to change the base path of the app. We experimented with the `FORCE_SCRIPT_NAME` option added in #400, but it did not solve the problem for us. Changing the script name adjusted the base domain rather than solely the base path Django expects to use.

### How was it fixed? 🎯
I simply added a new environment variable called `DJANGO_BASE_PATH` that fills out the `BASE_PATH` setting, and ensured that all URLs were prefixed by the base path. By default the base path is empty, and nothing changes.