### PR TITLE
Add doc for deprecated decoding endpoints

### DIFF
--- a/safe_transaction_service/contracts/views.py
+++ b/safe_transaction_service/contracts/views.py
@@ -1,6 +1,7 @@
 from django.core.cache import cache as django_cache
 
 import django_filters
+from drf_spectacular.utils import extend_schema
 from rest_framework.filters import OrderingFilter
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 
@@ -9,6 +10,10 @@ from .models import Contract
 from .signals import get_contract_cache_key
 
 
+@extend_schema(
+    deprecated=True,
+    description="Please migrate to the new [safe-decoder-service](https://docs.safe.global/core-api/safe-decoder-service-overview)",
+)
 class ContractView(RetrieveAPIView):
     """
     Returns the relevant information of a known smart contract
@@ -35,6 +40,10 @@ class ContractView(RetrieveAPIView):
         return response
 
 
+@extend_schema(
+    deprecated=True,
+    description="Please migrate to the new [safe-decoder-service](https://docs.safe.global/core-api/safe-decoder-service-overview)",
+)
 class ContractsView(ListAPIView):
     """
     Returns the list of known smart contracts with their ABI’s

--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -681,6 +681,13 @@ class SafeModuleTransactionResponseSerializer(GnosisBaseModelSerializer):
             "module_transaction_id",
         )
 
+    @extend_schema_field(
+        {
+            "type": "string",
+            "deprecated": True,
+            "description": "This field is deprecated and will be removed in future versions. Refer to decoder service [documentation](https://docs.safe.global/core-api/safe-decoder-service-reference#Data-decoder) for decoding guidance.",
+        }
+    )
     def get_data_decoded(self, obj: ModuleTransaction) -> dict[str, Any]:
         return get_data_decoded_from_data(obj.data if obj.data else b"", address=obj.to)
 
@@ -786,6 +793,13 @@ class SafeMultisigTransactionResponseSerializer(SafeMultisigTxSerializer):
     def get_origin(self, obj: MultisigTransaction) -> str:
         return obj.origin if isinstance(obj.origin, str) else json.dumps(obj.origin)
 
+    @extend_schema_field(
+        {
+            "type": "string",
+            "deprecated": True,
+            "description": "This field is deprecated and will be removed in future versions. Refer to decoder service [documentation](https://docs.safe.global/core-api/safe-decoder-service-reference#Data-decoder) for decoding guidance.",
+        }
+    )
     def get_data_decoded(self, obj: MultisigTransaction) -> dict[str, Any]:
         # If delegate call contract must be whitelisted (security)
         if obj.data_should_be_decoded():

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -1198,6 +1198,10 @@ class OwnersView(GenericAPIView):
         return Response(status=status.HTTP_200_OK, data=serializer.data)
 
 
+@extend_schema(
+    deprecated=True,
+    description="Please migrate to the new [safe-decoder-service](https://docs.safe.global/core-api/safe-decoder-service-overview)",
+)
 class DataDecoderView(GenericAPIView):
     serializer_class = serializers.DataDecoderSerializer
 


### PR DESCRIPTION
# Description
Mark as deprecated and add documentation guidance for migration for every decoding endpoint or field.

closes #2601
