### PR TITLE
Optimize get pending Safes query

### DIFF
--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -1255,9 +1255,7 @@ class InternalTxDecodedQuerySet(models.QuerySet):
         :return: List of Safe addresses that have transactions pending to be processed
         """
         return (
-            self.not_processed()
-            .values_list("internal_tx___from", flat=True)
-            .distinct("internal_tx___from")
+            self.not_processed().values_list("internal_tx___from", flat=True).distinct()
         )
 
 

--- a/safe_transaction_service/utils/tasks.py
+++ b/safe_transaction_service/utils/tasks.py
@@ -13,7 +13,6 @@ from .utils import close_gevent_db_connection
 logger = get_task_logger(__name__)
 
 LOCK_TIMEOUT = 60 * 15  # 15 minutes
-SOFT_TIMEOUT = 60 * 10  # 10 minutes
 ACTIVE_LOCKS: Set[str] = set()  # Active redis locks, release them when worker stops
 WORKER_STOPPED = set()  # Worker status
 


### PR DESCRIPTION
- `DISTINCT` is way faster compared to `DISTINCT ON`

Old query:
```
EXPLAIN ANALYZE SELECT DISTINCT ON ( history_internaltx._from ) history_internaltx._from FROM history_internaltxdecoded INNER JOIN history_internaltx ON ( history_internaltxdecoded.internal_tx_id = history_internaltx.id ) WHERE NOT history_internaltxdecoded.processed;

----------
QUERY PLAN

----------------------------------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------
 Unique  (cost=27762085.14..34014641.74 rows=82268 width=21) (actual time=1084398.509..1121931.248 rows=6834483 loops=1)
   ->  Gather Merge  (cost=27762085.14..33886761.53 rows=51152084 width=21) (actual time=1084398.508..1117371.946 rows=50270217 loops=1)
         Workers Planned: 4
         Workers Launched: 4
         ->  Sort  (cost=27761085.09..27793055.14 rows=12788021 width=21) (actual time=1084269.502..1090759.046 rows=10054043 loops=5)
               Sort Key: history_internaltx._from
               Sort Method: external merge  Disk: 243336kB
               Worker 0:  Sort Method: external merge  Disk: 252608kB
               Worker 1:  Sort Method: external merge  Disk: 249808kB
               Worker 2:  Sort Method: external merge  Disk: 245864kB
               Worker 3:  Sort Method: external merge  Disk: 238176kB
               ->  Parallel Hash Join  (cost=1997271.69..26086722.56 rows=12788021 width=21) (actual time=814933.040..1077620.142 rows=10054043 loops=5)
                     Hash Cond: (history_internaltx.id = history_internaltxdecoded.internal_tx_id)
                     ->  Parallel Seq Scan on history_internaltx  (cost=0.00..20259409.94 rows=231951594 width=29) (actual time=3.050..445352.402 rows=185560877 loops
=5)
                     ->  Parallel Hash  (cost=1787467.43..1787467.43 rows=12788021 width=8) (actual time=323334.013..323334.015 rows=10054043 loops=5)
                           Buckets: 4194304  Batches: 32  Memory Usage: 94336kB
                           ->  Parallel Index Only Scan using history_decoded_processed_idx on history_internaltxdecoded  (cost=0.56..1787467.43 rows=12788021 width=8
) (actual time=2.510..320743.934 rows=10054043 loops=5)
                                 Heap Fetches: 43072708
 Planning Time: 0.336 ms
 Execution Time: 1122258.638 ms
(20 rows)
```

New query:

```
EXPLAIN ANALYZE SELECT DISTINCT history_internaltx._from FROM history_internaltxdecoded INNER JOIN history_internaltx ON ( history_internaltxdecoded.internal_tx_id = history_internaltx.id ) WHERE NOT history_internaltxdecoded.processed;

                                                                                                             QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=26181791.49..26183436.85 rows=82268 width=21) (actual time=864835.591..873508.322 rows=6832991 loops=1)
   ->  Sort  (cost=26181791.49..26182614.17 rows=329072 width=21) (actual time=864835.588..871533.567 rows=13223227 loops=1)
         Sort Key: history_internaltx._from
         Sort Method: external merge  Disk: 323488kB
         ->  Gather  (cost=26117905.38..26151635.26 rows=329072 width=21) (actual time=855617.931..862449.276 rows=13223227 loops=1)
               Workers Planned: 4
               Workers Launched: 4
               ->  HashAggregate  (cost=26116905.38..26117728.06 rows=82268 width=21) (actual time=855608.550..857405.583 rows=2644645 loops=5)
                     Group Key: history_internaltx._from
                     Batches: 5  Memory Usage: 106545kB  Disk Usage: 101272kB
                     Worker 0:  Batches: 5  Memory Usage: 106545kB  Disk Usage: 101400kB
                     Worker 1:  Batches: 5  Memory Usage: 106545kB  Disk Usage: 97816kB
                     Worker 2:  Batches: 5  Memory Usage: 106545kB  Disk Usage: 97872kB
                     Worker 3:  Batches: 5  Memory Usage: 106545kB  Disk Usage: 105496kB
                     ->  Parallel Hash Join  (cost=1996731.21..26084936.60 rows=12787512 width=21) (actual time=738862.276..851137.989 rows=10049136 loops=5)
                           Hash Cond: (history_internaltx.id = history_internaltxdecoded.internal_tx_id)
                           ->  Parallel Seq Scan on history_internaltx  (cost=0.00..20258361.95 rows=231939595 width=29) (actual time=0.796..376597.687 rows=185551259 loops=5)
                           ->  Parallel Hash  (cost=1786935.31..1786935.31 rows=12787512 width=8) (actual time=312222.359..312222.360 rows=10049136 loops=5)
                                 Buckets: 4194304  Batches: 32  Memory Usage: 94304kB
                                 ->  Parallel Index Only Scan using history_decoded_processed_idx on history_internaltxdecoded  (cost=0.56..1786935.31 rows=12787512 width=8) (actual time=2.996..309599.720 rows=10049136 loops=5)
                                       Heap Fetches: 43048082
 Planning Time: 0.366 ms
 Execution Time: 873916.779 ms
(23 rows)
```
