### PR TITLE
Update to Django 5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,10 @@
-asgiref==3.7.2
 boto3==1.40.16
 cachetools==5.5.2
 celery==5.5.3
-django==5.0.13
+django==5.2.5
 django-cache-memoize==0.2.1
 django-celery-beat==2.8.1
 django-cors-headers==4.7.0
-django-db-geventpool==4.0.8
 django-debug-toolbar
 django-debug-toolbar-force
 django-environ==0.12.0
@@ -27,8 +25,7 @@ hiredis==3.1.0
 packaging>=21.0
 pika==1.3.2
 pillow==11.3.0
-psycogreen==1.0.2
-psycopg[binary]==3.2.9
+psycopg[binary,pool]==3.2.9
 redis==6.2.0
 requests==2.32.4
 safe-eth-py[django]==7.11.0

--- a/safe_transaction_service/contracts/tasks.py
+++ b/safe_transaction_service/contracts/tasks.py
@@ -14,7 +14,6 @@ from safe_transaction_service.history.models import (
     ModuleTransaction,
     MultisigTransaction,
 )
-from safe_transaction_service.utils.utils import close_gevent_db_connection_decorator
 
 from ..utils.celery import task_timeout
 from .models import Contract
@@ -33,7 +32,6 @@ class ContractAction(Enum):
 
 
 @app.shared_task()
-@close_gevent_db_connection_decorator
 @task_timeout(timeout_seconds=TASK_TIME_LIMIT)
 def create_missing_contracts_with_metadata_task() -> int:
     """
@@ -57,7 +55,6 @@ def create_missing_contracts_with_metadata_task() -> int:
 
 
 @app.shared_task()
-@close_gevent_db_connection_decorator
 @task_timeout(timeout_seconds=TASK_TIME_LIMIT)
 def create_missing_multisend_contracts_with_metadata_task() -> int:
     """
@@ -90,7 +87,6 @@ def create_missing_multisend_contracts_with_metadata_task() -> int:
 
 
 @app.shared_task()
-@close_gevent_db_connection_decorator
 @task_timeout(timeout_seconds=TASK_TIME_LIMIT)
 def reindex_contracts_without_metadata_task() -> int:
     """
@@ -118,7 +114,6 @@ def reindex_contracts_without_metadata_task() -> int:
 
 
 @app.shared_task()
-@close_gevent_db_connection_decorator
 @task_timeout(timeout_seconds=TASK_TIME_LIMIT)
 def create_or_update_contract_with_metadata_task(
     address: ChecksumAddress,

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -14,7 +14,6 @@ from eth_typing import ChecksumAddress
 from redis.exceptions import LockError
 
 from safe_transaction_service.utils.redis import get_redis
-from safe_transaction_service.utils.utils import close_gevent_db_connection_decorator
 
 from ..events.services.queue_service import get_queue_service
 from ..utils.celery import task_timeout
@@ -115,7 +114,6 @@ def index_erc20_events_task(self) -> Optional[tuple[int, int]]:
 
 
 @app.shared_task
-@close_gevent_db_connection_decorator
 def index_erc20_events_out_of_sync_task(
     block_process_limit: Optional[int] = None,
     block_process_limit_max: Optional[int] = None,
@@ -394,8 +392,15 @@ def reindex_master_copies_task(
     addresses: Optional[ChecksumAddress] = None,
 ) -> None:
     """
-    Reindexes master copies
+    Reindex master copies
+
+    :param self:
+    :param from_block_number:
+    :param to_block_number:
+    :param addresses:
+    :return:
     """
+
     with contextlib.suppress(LockError):
         with only_one_running_task(
             self, lock_name_suffix=str(addresses) if addresses else None
@@ -421,7 +426,13 @@ def reindex_erc20_events_task(
     addresses: Optional[ChecksumAddress] = None,
 ) -> None:
     """
-    Reindexes master copies
+    Reindex erc20 events
+
+    :param self:
+    :param from_block_number:
+    :param to_block_number:
+    :param addresses:
+    :return:
     """
     with contextlib.suppress(LockError):
         with only_one_running_task(
@@ -521,7 +532,6 @@ def retry_get_metadata_task(
 
 
 @app.shared_task()
-@close_gevent_db_connection_decorator
 def remove_not_trusted_multisig_txs_task(
     time_delta: datetime.timedelta = datetime.timedelta(days=30),
 ) -> int:
@@ -535,7 +545,6 @@ def remove_not_trusted_multisig_txs_task(
 
 
 @app.shared_task()
-@close_gevent_db_connection_decorator
 def delete_expired_delegates_task():
     logger.info("Deleting expired Safe Delegates")
     now = timezone.now()

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -703,7 +703,7 @@ class TestInternalTx(TestCase):
 
 class TestInternalTxDecoded(TestCase):
     def test_order_by_processing_queue(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             InternalTxDecoded.objects.order_by_processing_queue(), []
         )
         ethereum_tx = EthereumTxFactory()
@@ -718,14 +718,14 @@ class TestInternalTxDecoded(TestCase):
             internal_tx__trace_address="15", internal_tx__ethereum_tx=ethereum_tx
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             InternalTxDecoded.objects.order_by_processing_queue(),
             [internal_tx_decoded_0, internal_tx_decoded_1, internal_tx_decoded_15],
         )
 
         internal_tx_decoded_15.function_name = "setup"
         internal_tx_decoded_15.save()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             InternalTxDecoded.objects.order_by_processing_queue(),
             [internal_tx_decoded_15, internal_tx_decoded_0, internal_tx_decoded_1],
         )

--- a/safe_transaction_service/tokens/tasks.py
+++ b/safe_transaction_service/tokens/tasks.py
@@ -13,7 +13,6 @@ from safe_eth.eth.utils import fast_to_checksum_address
 from web3.exceptions import Web3Exception
 
 from safe_transaction_service.utils.ethereum import get_ethereum_network
-from safe_transaction_service.utils.utils import close_gevent_db_connection_decorator
 
 from ..utils.celery import task_timeout
 from .exceptions import TokenListRetrievalException
@@ -45,7 +44,6 @@ class EthValueWithTimestamp:
 
 
 @app.shared_task()
-@close_gevent_db_connection_decorator
 @task_timeout(timeout_seconds=TASK_TIME_LIMIT)
 def fix_pool_tokens_task() -> Optional[int]:
     """
@@ -77,7 +75,6 @@ def _parse_token_address_from_token_list(
 
 
 @app.shared_task()
-@close_gevent_db_connection_decorator
 def update_token_info_from_token_list_task() -> int:
     """
     If there's at least one valid token list with at least 1 token, every token in the DB is marked as `not trusted`

--- a/safe_transaction_service/utils/tests/test_tasks.py
+++ b/safe_transaction_service/utils/tests/test_tasks.py
@@ -7,16 +7,12 @@ from redis.exceptions import LockError
 
 from ..tasks import (
     WORKER_STOPPED,
-    configure_workers,
     only_one_running_task,
     worker_shutting_down_handler,
 )
 
 
 class TestTasks(TestCase):
-    def test_configure_workers(self):
-        configure_workers()
-
     def test_worker_shutting_down_handler(self):
         worker_shutting_down_handler(None, None, None)
 

--- a/safe_transaction_service/utils/utils.py
+++ b/safe_transaction_service/utils/utils.py
@@ -1,11 +1,7 @@
 import datetime
 import socket
-from functools import wraps
 from itertools import islice
 from typing import Any, Iterable, Union
-
-from django.core.signals import request_finished
-from django.db import connection
 
 import gevent.socket
 
@@ -56,27 +52,6 @@ def chunks_iterable(iterable: Iterable[Any], n: int) -> Iterable[Iterable[Any]]:
 
 def running_on_gevent() -> bool:
     return socket.socket is gevent.socket.socket
-
-
-def close_gevent_db_connection() -> None:
-    """
-    Clean gevent db connections. Check `atomic block` to prevent breaking the tests (Django `TestCase` wraps tests
-    inside an atomic block that rollbacks at the end of the test)
-    https://github.com/jneight/django-db-geventpool#using-orm-when-not-serving-requests
-    """
-    if not connection.in_atomic_block:
-        request_finished.send(sender="greenlet")
-
-
-def close_gevent_db_connection_decorator(f):
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        try:
-            return f(*args, **kwargs)
-        finally:
-            close_gevent_db_connection()
-
-    return wrapper
 
 
 def parse_boolean_query_param(value: Union[bool, str, int]) -> bool:


### PR DESCRIPTION
- Migrate `django-db-geventpool` to native `psycopg3` pool
- Remove `django-db-geventpool` required boilerplate to close connections
