### PR TITLE
Disable by default trusted delegate calls

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -789,5 +789,5 @@ BANNED_EOAS: set[ChecksumAddress] = {
 # Multisig Txs creation
 # ------------------------------------------------------------------------------
 DISABLE_CREATION_MULTISIG_TRANSACTIONS_WITH_DELEGATE_CALL_OPERATION = env.bool(
-    "DISABLE_CREATION_MULTISIG_TRANSACTIONS_WITH_DELEGATE_CALL_OPERATION", default=True
+    "DISABLE_CREATION_MULTISIG_TRANSACTIONS_WITH_DELEGATE_CALL_OPERATION", default=False
 )


### PR DESCRIPTION
# Descritption
Disables by default the check if `to` is  a Trusted Delegate contract for delegate calls.
