### PR TITLE
Improve reindex master copies command

### DIFF
--- a/safe_transaction_service/history/management/commands/reindex_master_copies.py
+++ b/safe_transaction_service/history/management/commands/reindex_master_copies.py
@@ -1,9 +1,10 @@
 from collections.abc import Sequence
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from eth_typing import ChecksumAddress
 
+from ...models import SafeContract
 from ...services import IndexServiceProvider
 
 
@@ -25,13 +26,30 @@ class Command(BaseCommand):
         parser.add_argument(
             "--from-block-number",
             type=int,
-            help="Which block to start reindexing from",
-            required=True,
+            help="Which block to start reindexing from. If not provided, minimun creation block for provided addresses will be used, 0 otherwise",
+            required=False,
         )
 
     def handle(self, *args, **options):
         block_process_limit = options["block_process_limit"]
         from_block_number = options["from_block_number"]
+        addresses = options["addresses"]
+        if addresses and not from_block_number:
+            from_block_number = SafeContract.objects.get_minimum_creation_block_number(
+                addresses
+            )
+            if from_block_number is None:
+                raise CommandError(
+                    "Cannot get from-block-number, please set --from-block-number yourself"
+                )
+            self.stdout.write(
+                self.style.SUCCESS(f"Setting from-block-number to {from_block_number}")
+            )
+        elif not from_block_number:
+            raise CommandError(
+                "--from-block-number must be set if --addresses are not provided"
+            )
+
         self.stdout.write(
             self.style.SUCCESS(f"Setting block-process-limit to {block_process_limit}")
         )
@@ -39,7 +57,7 @@ class Command(BaseCommand):
             self.style.SUCCESS(f"Setting from-block-number to {from_block_number}")
         )
 
-        self.reindex(from_block_number, block_process_limit, options["addresses"])
+        self.reindex(from_block_number, block_process_limit, addresses)
 
     def reindex(
         self,
@@ -47,8 +65,14 @@ class Command(BaseCommand):
         block_process_limit: int | None,
         addresses: Sequence[ChecksumAddress] | None,
     ) -> None:
-        return IndexServiceProvider().reindex_master_copies(
+        index_service = IndexServiceProvider()
+        # Reindex missing transactions
+        result = index_service.reindex_master_copies(
             from_block_number,
             block_process_limit=block_process_limit,
             addresses=addresses,
         )
+        # Reprocess addresses again (if provided)
+        if addresses:
+            index_service.reprocess_addresses(addresses)
+        return result

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -30,6 +30,7 @@ from ..models import (
     InternalTxDecoded,
     MultisigConfirmation,
     MultisigTransaction,
+    SafeContract,
     SafeContractDelegate,
     SafeLastStatus,
     SafeMasterCopy,
@@ -1047,6 +1048,45 @@ class TestSafeStatus(TestCase):
         safe_status_2 = SafeStatusFactory(nonce=2, address=safe_status_5.address)
         self.assertIsNone(safe_status_2.previous())
         self.assertEqual(safe_status_5.previous(), safe_status_2)
+
+
+class TestSafeContract(TestCase):
+    def test_get_minimum_creation_block_number(self):
+        address_1 = Account.create().address
+        address_2 = Account.create().address
+        self.assertIsNone(
+            SafeContract.objects.get_minimum_creation_block_number(
+                [address_1, address_2]
+            )
+        )
+
+        block_number_1 = 15
+        block_number_2 = 16
+        SafeContractFactory(
+            address=address_1, ethereum_tx__block__number=block_number_1
+        )
+        SafeContractFactory(
+            address=address_2, ethereum_tx__block__number=block_number_2
+        )
+
+        self.assertEqual(
+            SafeContract.objects.get_minimum_creation_block_number(
+                [address_1, address_2]
+            ),
+            block_number_1,
+        )
+
+        address_3 = Account.create().address
+        block_number_3 = 8
+        SafeContractFactory(
+            address=address_3, ethereum_tx__block__number=block_number_3
+        )
+        self.assertEqual(
+            SafeContract.objects.get_minimum_creation_block_number(
+                [address_1, address_2, address_3]
+            ),
+            block_number_3,
+        )
 
 
 class TestSafeContractDelegate(TestCase):


### PR DESCRIPTION
- `--from-block-number` is not required if Safes are already in the database. Minimum creation block number for all the addresses providen will be used
- After reindex, a reprocessing will be triggered to prevent race conditions

So previously the command for reindexing a Safe would be:

`python manage.py reindex_master_copies --addresses $SAFE_ADDRESS --from-block-number $SAFE_CREATION_BLOCK_NUMBER`

Now:

`python manage.py reindex_master_copies --addresses $SAFE_ADDRESS`