### PR TITLE
Use environment variables to configure connection pool

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -74,11 +74,11 @@ DATABASES["default"]["OPTIONS"] = {
     "options": f"-c statement_timeout={DB_STATEMENT_TIMEOUT}",
     "pool": {
         # https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool
-        "min_size": 4,
-        "max_size": env.int("DB_MAX_CONNS", default=50),
-        "timeout": 30,
-        "max_lifetime": 60 * 60,  # 1 hour
-        "max_idle": 60 * 10,  # 10 minutes
+        "min_size": env.int("DB_MIN_CONNS", default=4),
+        "max_size": env.int("DB_MAX_CONNS", default=100),
+        "timeout": env.int("DB_POOL_TIMEOUT", default=10),
+        "max_lifetime": env.int("DB_POOL_MAX_LIFETIME", default=60 * 60),  # 1 hour
+        "max_idle": env.int("DB_POOL_MAX_IDLE", default=60 * 10),  # 10 minutes
     },
 }
 


### PR DESCRIPTION
Add environmnet variables:
- `DB_MIN_CONNS`
- `DB_POOL_TIMEOUT`
- `DB_POOL_MAX_LIFETIME`
- `DB_POOL_MAX_IDLE`

Update configuration:
- Update `DB_POOL_TIMEOUT` from 30 to 10 seconds to fail fast
- Update `DB_MAX_CONNS` from 50 to 100

Context:

https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make PostgreSQL connection pool settings read from environment variables with updated defaults.
> 
> - **Settings**
>   - **Database pool (`config/settings/base.py`)**:
>     - Replace hardcoded pool params with env-driven values: `DB_MIN_CONNS`, `DB_MAX_CONNS`, `DB_POOL_TIMEOUT`, `DB_POOL_MAX_LIFETIME`, `DB_POOL_MAX_IDLE`.
>     - Update defaults: `max_size` to `100` (from `50`), `timeout` to `10s` (from `30s`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 173a29948f0554afb6f9b14019a295f505197c8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->