### PR TITLE
Add SafeContractManager.upsert_from_ethereum_tx_hash

### DIFF
--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -544,19 +544,9 @@ class SafeTxProcessor(TxProcessor):
             threshold = arguments["_threshold"]
             fallback_handler = arguments.get("fallbackHandler", NULL_ADDRESS)
             nonce = 0
-            try:
-                safe_contract: SafeContract = SafeContract.objects.get(
-                    address=contract_address
-                )
-                if not safe_contract.ethereum_tx_id:
-                    safe_contract.ethereum_tx = internal_tx.ethereum_tx
-                    safe_contract.save(update_fields=["ethereum_tx"])
-            except SafeContract.DoesNotExist:
-                SafeContract.objects.create(
-                    address=contract_address,
-                    ethereum_tx=internal_tx.ethereum_tx,
-                )
-                logger.info("Found new Safe=%s", contract_address)
+            SafeContract.objects.upsert_from_ethereum_tx_hash(
+                contract_address, internal_tx.ethereum_tx_id
+            )
 
             self.store_new_safe_status(
                 SafeLastStatus(

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -2067,6 +2067,22 @@ class SafeContractManager(models.Manager):
         """
         return set(self.filter(address__in=addresses).values_list("address", flat=True))
 
+    def upsert_from_ethereum_tx_hash(
+        self, address: ChecksumAddress, ethereum_tx_id: HexBytes
+    ) -> None:
+        """
+        Insert a new SafeContract or update ``ethereum_tx_id`` on conflict. Single query.
+
+        :param address: Safe contract address
+        :param ethereum_tx_id: Creation transaction hash
+        """
+        self.bulk_create(
+            [self.model(address=address, ethereum_tx_id=ethereum_tx_id)],
+            update_conflicts=True,
+            unique_fields=["address"],
+            update_fields=["ethereum_tx"],
+        )
+
 
 class SafeContractQuerySet(models.QuerySet):
     def banned(

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -1120,6 +1120,21 @@ class TestSafeContract(TestCase):
             block_number_3,
         )
 
+    def test_upsert_from_ethereum_tx_hash(self):
+        address = Account.create().address
+        ethereum_tx = EthereumTxFactory()
+
+        # Record does not exist → inserts
+        SafeContract.objects.upsert_from_ethereum_tx_hash(address, ethereum_tx.tx_hash)
+        safe_contract = SafeContract.objects.get(address=address)
+        self.assertEqual(safe_contract.ethereum_tx_id, ethereum_tx.tx_hash)
+
+        # Record already exists → updates ethereum_tx_id
+        another_tx = EthereumTxFactory()
+        SafeContract.objects.upsert_from_ethereum_tx_hash(address, another_tx.tx_hash)
+        safe_contract.refresh_from_db()
+        self.assertEqual(safe_contract.ethereum_tx_id, another_tx.tx_hash)
+
 
 class TestSafeContractDelegate(TestCase):
     def test_get_for_safe(self):


### PR DESCRIPTION
Replaces the two-query try/except GET+CREATE pattern in the setup function handler with a single INSERT ... ON CONFLICT upsert via Django's bulk_create(update_conflicts=True).
