### PR TITLE
Fix type annotations and None block number guards in indexers

### DIFF
--- a/safe_transaction_service/history/indexers/element_already_processed_checker.py
+++ b/safe_transaction_service/history/indexers/element_already_processed_checker.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 from logging import getLogger
 
+from eth_typing import HexStr
 from hexbytes import HexBytes
 from safe_eth.util.util import to_0x_hex_str
 
@@ -20,14 +21,16 @@ class ElementAlreadyProcessedChecker:
     def clear(self) -> None:
         return self._processed_element_cache.clear()
 
-    def get_key(self, tx_hash: HexBytes, block_hash: HexBytes, index: int) -> HexBytes:
-        tx_hash = HexBytes(tx_hash)
-        block_hash = HexBytes(block_hash or 0)
-        index = HexBytes(index)
-        return tx_hash + block_hash + index
+    def get_key(
+        self, tx_hash: HexStr | bytes, block_hash: HexStr | bytes | None, index: int
+    ) -> bytes:
+        tx_hash_bytes = HexBytes(tx_hash)
+        block_hash_bytes = HexBytes(block_hash or 0)
+        index_bytes = HexBytes(index)
+        return tx_hash_bytes + block_hash_bytes + index_bytes
 
     def is_processed(
-        self, tx_hash: HexBytes, block_hash: HexBytes | None, index: int = 0
+        self, tx_hash: HexStr | bytes, block_hash: HexStr | bytes | None, index: int = 0
     ) -> bool:
         """
         :param tx_hash:
@@ -39,7 +42,7 @@ class ElementAlreadyProcessedChecker:
         return tx_id in self._processed_element_cache
 
     def mark_as_processed(
-        self, tx_hash: HexBytes, block_hash: HexBytes | None, index: int = 0
+        self, tx_hash: HexStr | bytes, block_hash: HexStr | bytes | None, index: int = 0
     ) -> bool:
         """
         Mark element as processed if it is not already marked
@@ -54,16 +57,16 @@ class ElementAlreadyProcessedChecker:
         if tx_id in self._processed_element_cache:
             logger.debug(
                 "Element with tx-hash=%s on block=%s with index=%d was already processed",
-                to_0x_hex_str(tx_hash),
-                to_0x_hex_str(block_hash),
+                to_0x_hex_str(HexBytes(tx_hash)),
+                to_0x_hex_str(HexBytes(block_hash or 0)),
                 index,
             )
             return False
         else:
             logger.debug(
                 "Marking element with tx-hash=%s on block=%s with index=%d as processed",
-                to_0x_hex_str(tx_hash),
-                to_0x_hex_str(block_hash),
+                to_0x_hex_str(HexBytes(tx_hash)),
+                to_0x_hex_str(HexBytes(block_hash or 0)),
                 index,
             )
             self._processed_element_cache[tx_id] = None

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from logging import getLogger
 from typing import Any
 
-from django.db.models import Min
+from django.db.models import Min, QuerySet
 
 from celery.exceptions import SoftTimeLimitExceeded
 from eth_typing import ChecksumAddress, HexStr
@@ -30,7 +30,7 @@ class EthereumIndexer(ABC):
     `database_field` should be defined with the field used to store the current block number for a monitored address
     `find_relevant_elements` elements should be defined with the query to get the relevant txs/events/etc.
     `process_elements` defines what happens with elements found
-    So the flow would be `start()` -> `process_addresses` -> `find_revelant_elements` -> `process_elements` ->
+    So the flow would be `start()` -> `process_addresses` -> `find_relevant_elements` -> `process_elements` ->
     `process_element`
     """
 
@@ -110,14 +110,14 @@ class EthereumIndexer(ABC):
 
     @property
     @abstractmethod
-    def database_field(self):
+    def database_field(self) -> str:
         """
         :return: Database field for `database_queryset` to store scan status
         """
 
     @property
     @abstractmethod
-    def database_queryset(self):
+    def database_queryset(self) -> QuerySet:
         """
         :return: Queryset of objects being scanned
         """
@@ -134,8 +134,8 @@ class EthereumIndexer(ABC):
         Find blockchain relevant elements for the `addresses`
 
         :param addresses:
-        :param from_block_number
-        :param to_block_number
+        :param from_block_number:
+        :param to_block_number:
         :param current_block_number:
         :return: Set of relevant elements
         """
@@ -304,11 +304,14 @@ class EthereumIndexer(ABC):
         return not_updated_addresses
 
     def update_monitored_addresses(
-        self, addresses: set[str], from_block_number: int, to_block_number: int
-    ) -> bool:
+        self,
+        addresses: set[ChecksumAddress],
+        from_block_number: int,
+        to_block_number: int,
+    ) -> int:
         """
         :param addresses: Addresses to have the block number updated
-        :param from_block_number: Make sure that no reorg has happened checking that block number was not rollbacked
+        :param from_block_number: Make sure that no reorg has happened checking that block number was not rolled back
         :param to_block_number: Block number to be updated
         :return: Number of addresses updated
         """
@@ -513,6 +516,8 @@ class EthereumIndexer(ABC):
                 )
                 total_number_processed_elements += number_processed_elements
                 if start_block is None:
+                    # from_block_number can be None if no blocks to scan; that's fine
+                    # because the guard prevents overwriting a previously valid start_block
                     start_block = from_block_number
             last_block = to_block_number
         else:
@@ -540,7 +545,9 @@ class EthereumIndexer(ABC):
                     not_updated_addresses,
                     current_block_number=current_block_number,
                 )
-                if start_block is None or from_block_number < start_block:
+                if from_block_number is not None and (
+                    start_block is None or from_block_number < start_block
+                ):
                     start_block = from_block_number
 
                 number_processed_elements = len(processed_elements)
@@ -552,7 +559,8 @@ class EthereumIndexer(ABC):
                     to_block_number,
                 )
                 total_number_processed_elements += number_processed_elements
-                from_block_number += 1
+                if from_block_number is not None:
+                    from_block_number += 1
             if last_block is None or to_block_number > last_block:
                 last_block = to_block_number
         else:

--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -822,7 +822,7 @@ class SafeEventsIndexer(EventsIndexer):
             if setup_event:
                 if not proxy_creation_event:
                     # SafeSetup without ProxyCreation means proxy was created in a previous block
-                    # ProxyCreation is also emitted when ProxyCreationL2 or ChainSpecificProxyCreationL2 are emmited on v1.5.0.
+                    # ProxyCreation is also emitted when ProxyCreationL2 or ChainSpecificProxyCreationL2 are emitted on v1.5.0.
                     logger.debug(
                         "[%s] Proxy was created in previous blocks, deleting the old InternalTx",
                         safe_address,

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -310,7 +310,7 @@ class CollectiblesService:
     def get_metadata(self, collectible: Collectible | CollectibleWithMetadata) -> Any:
         """
         Return metadata for a collectible
-        :param collectible
+        :param collectible:
         """
         if not settings.COLLECTIBLES_ENABLE_DOWNLOAD_METADATA:
             logger.warning("Downloading collectibles metadata is disabled")

--- a/safe_transaction_service/history/services/transaction_service.py
+++ b/safe_transaction_service/history/services/transaction_service.py
@@ -129,7 +129,7 @@ class TransactionService:
         - Incoming native token transfers
 
         :param safe_address:
-        :return: Querylist with elements from `SafeRelevantTransaction` model
+        :return: QuerySet with elements from `SafeRelevantTransaction` model
         """
         logger.debug(
             "[%s] Getting all tx identifiers",


### PR DESCRIPTION
## Summary

- Broaden `ElementAlreadyProcessedChecker` to accept `HexStr | bytes` instead of requiring `HexBytes`, avoiding unnecessary wrapping at call sites
- Guard against `None` `from_block_number` in `EthereumIndexer.start()` before arithmetic (`+= 1`) and comparisons — `process_addresses` returns `None` when `get_block_numbers_for_search` finds no blocks to scan
- Add return type annotations to `database_field` and `database_queryset` abstract properties; fix `update_monitored_addresses` return type `bool → int` (it has always returned the count from `.update()`)
- Typo/docstring fixes: `rollbacked → rolled back`, `emmited → emitted`, `find_revelant → find_relevant`, `Querylist → QuerySet`