### PR TITLE
Tune DB pool, worker connections and add lock/idle timeouts

### DIFF
--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -6,5 +6,5 @@ Store gunicorn variables in this file, so they can be read by Django
 import os
 
 gunicorn_request_timeout = int(os.environ.get("WEB_WORKER_TIMEOUT", 60))
-gunicorn_worker_connections = int(os.environ.get("WEB_WORKER_CONNECTIONS", 200))
+gunicorn_worker_connections = int(os.environ.get("WEB_WORKER_CONNECTIONS", 100))
 gunicorn_workers = int(os.environ.get("WEB_CONCURRENCY", 2))

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -5,6 +5,6 @@ Store gunicorn variables in this file, so they can be read by Django
 
 import os
 
-gunicorn_request_timeout = os.environ.get("WEB_WORKER_TIMEOUT", 60)
-gunicorn_worker_connections = os.environ.get("WEB_WORKER_CONNECTIONS", 1000)
-gunicorn_workers = os.environ.get("WEB_CONCURRENCY", 2)
+gunicorn_request_timeout = int(os.environ.get("WEB_WORKER_TIMEOUT", 60))
+gunicorn_worker_connections = int(os.environ.get("WEB_WORKER_CONNECTIONS", 200))
+gunicorn_workers = int(os.environ.get("WEB_CONCURRENCY", 2))

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -91,7 +91,7 @@ DATABASES["default"]["OPTIONS"] = {
     "pool": {
         # https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool
         "min_size": env.int("DB_MIN_CONNS", default=4),
-        "max_size": env.int("DB_MAX_CONNS", default=200),
+        "max_size": env.int("DB_MAX_CONNS", default=100),
         "timeout": env.int("DB_POOL_TIMEOUT", default=10),
         "max_lifetime": env.int("DB_POOL_MAX_LIFETIME", default=60 * 5),  # 5 minutes
         "max_idle": env.int("DB_POOL_MAX_IDLE", default=60 * 2),  # 2 minutes

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -66,6 +66,15 @@ GUNICORN_WORKERS = gunicorn_workers
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
 # DB statements should timeout before Gunicorn, so this value must be less than WEB_WORKER_TIMEOUT on gunicorn.py
 DB_STATEMENT_TIMEOUT = env.int("DB_STATEMENT_TIMEOUT", 50_000)
+# Kills a statement waiting on a lock. Without this, a slow transaction holding a row lock causes other requests to
+# queue behind it — that queue can cascade into an outage. Must be lower than DB_STATEMENT_TIMEOUT.
+DB_LOCK_TIMEOUT = env.int("DB_LOCK_TIMEOUT", 5_000)
+# Kills a connection that is inside a transaction but idle (e.g. app crash mid-request, network drop). Without this,
+# those connections hold locks indefinitely until the pool recycles them via max_lifetime. Critical for preventing
+# lock pile-ups.
+DB_IDLE_IN_TRANSACTION_SESSION_TIMEOUT = env.int(
+    "DB_IDLE_IN_TRANSACTION_SESSION_TIMEOUT", 30_000
+)
 
 DATABASES = {
     "default": env.db("DATABASE_URL"),
@@ -74,11 +83,15 @@ DATABASES["default"]["ATOMIC_REQUESTS"] = False
 DATABASES["default"]["ENGINE"] = "django.db.backends.postgresql"
 DATABASES["default"]["CONN_MAX_AGE"] = 0
 DATABASES["default"]["OPTIONS"] = {
-    "options": f"-c statement_timeout={DB_STATEMENT_TIMEOUT}",
+    "options": (
+        f"-c statement_timeout={DB_STATEMENT_TIMEOUT}"
+        f" -c lock_timeout={DB_LOCK_TIMEOUT}"
+        f" -c idle_in_transaction_session_timeout={DB_IDLE_IN_TRANSACTION_SESSION_TIMEOUT}"
+    ),
     "pool": {
         # https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool
         "min_size": env.int("DB_MIN_CONNS", default=4),
-        "max_size": env.int("DB_MAX_CONNS", default=100),
+        "max_size": env.int("DB_MAX_CONNS", default=200),
         "timeout": env.int("DB_POOL_TIMEOUT", default=10),
         "max_lifetime": env.int("DB_POOL_MAX_LIFETIME", default=60 * 5),  # 5 minutes
         "max_idle": env.int("DB_POOL_MAX_IDLE", default=60 * 2),  # 2 minutes


### PR DESCRIPTION
## Summary

- Fix gunicorn env vars cast to `int` — `os.environ.get` returns `str` when the env var is set, causing type inconsistency when values are used elsewhere
- Drop `WEB_WORKER_CONNECTIONS` default from 1000 → 100 to match the DB pool ceiling; the extra greenlets were queuing on pool exhaustion rather than adding real concurrency
- Add `DB_LOCK_TIMEOUT` (5 s default) — prevents lock queue cascades when a slow transaction holds a row lock
- Add `DB_IDLE_IN_TRANSACTION_SESSION_TIMEOUT` (30 s default) — releases locks from connections that go idle mid-transaction (crash, network drop) before the pool recycles them via `max_lifetime`