### PR TITLE
Return DB connections to pool after each Celery task

### DIFF
--- a/config/celery_app.py
+++ b/config/celery_app.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 import os
 
-from django.db import close_old_connections
+from django.db import connections
 
 from celery import Celery
 from celery.signals import setup_logging, task_postrun
@@ -43,9 +43,17 @@ def close_db_connections(**kwargs):
     # all tasks run as greenlets inside a single process, so close_pool never fires and
     # per-task connection cleanup must be handled explicitly here.
     #
-    # CONN_MAX_AGE=0 means close_old_connections() treats every connection as expired,
+    # CONN_MAX_AGE=0 means every connection is immediately eligible for closure,
     # triggering close() → putconn() and returning the slot to the pool immediately.
-    close_old_connections()
+    #
+    # Connections inside an atomic block are skipped: in production this never happens
+    # because task_postrun fires after the task function returns (so any transaction.atomic
+    # blocks from the task itself have already exited). In tests, Django's TestCase wraps
+    # each test in a transaction (in_atomic_block=True), and closing the connection there
+    # would break test isolation.
+    for conn in connections.all(initialized_only=True):
+        if not conn.in_atomic_block:
+            conn.close_if_unusable_or_obsolete()
 
 
 # set the default Django settings module for the 'celery' program.

--- a/config/celery_app.py
+++ b/config/celery_app.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 import os
 
+from django.db import close_old_connections
+
 from celery import Celery
-from celery.signals import setup_logging
+from celery.signals import setup_logging, task_postrun
 
 
 @setup_logging.connect
@@ -24,6 +26,26 @@ def on_celery_setup_logging(**kwargs):
             if key in logger:
                 logger[key] = ["celery_console"]
         dictConfig(settings.LOGGING)
+
+
+@task_postrun.connect
+def close_db_connections(**kwargs):
+    # Django's close_old_connections() is called automatically at the end of each web request
+    # via middleware signals, but Celery tasks have no equivalent lifecycle hook.
+    #
+    # Without this, connections acquired via pool.getconn() during a task are never returned
+    # to the psycopg3 pool via pool.putconn() — the pool exhausts its max_size slots and new
+    # tasks block until max_lifetime/max_idle timers recycle them.
+    #
+    # NOTE: Celery 5.x has built-in pool handling for Django 5.1+ (close_pool on worker
+    # process init — see https://docs.celeryq.dev/en/main/django/first-steps-with-django.html#django-connection-pool),
+    # but that only covers the fork/process-start path. With --pool=gevent there is no forking:
+    # all tasks run as greenlets inside a single process, so close_pool never fires and
+    # per-task connection cleanup must be handled explicitly here.
+    #
+    # CONN_MAX_AGE=0 means close_old_connections() treats every connection as expired,
+    # triggering close() → putconn() and returning the slot to the pool immediately.
+    close_old_connections()
 
 
 # set the default Django settings module for the 'celery' program.

--- a/safe_transaction_service/utils/tests/test_celery_app.py
+++ b/safe_transaction_service/utils/tests/test_celery_app.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+from unittest import mock
+
+from django.db import connection
+from django.test import TransactionTestCase
+
+from safe_transaction_service.history.tasks import delete_expired_delegates_task
+
+
+class TestCeleryApp(TransactionTestCase):
+    def test_db_connection_closed_after_task(self):
+        # TransactionTestCase is required: TestCase wraps each test in a transaction
+        # (in_atomic_block=True), which our signal handler deliberately skips to avoid
+        # breaking test isolation. TransactionTestCase has no wrapping transaction, so
+        # the handler actually runs and closes the connection.
+        with mock.patch.object(
+            connection,
+            "close_if_unusable_or_obsolete",
+            wraps=connection.close_if_unusable_or_obsolete,
+        ) as mock_close:
+            delete_expired_delegates_task.apply()
+            mock_close.assert_called_once()
+        self.assertIsNone(connection.connection)


### PR DESCRIPTION
## Summary

- Celery tasks with `--pool=gevent` never trigger Django's `close_old_connections()`, so connections taken via `pool.getconn()` are never returned via `pool.putconn()`, exhausting `DB_MAX_CONNS=100` and stalling indexing
- Added a `task_postrun` signal in `config/celery_app.py` that calls `close_old_connections()` after every task (success, failure, or gevent timeout)
- Celery 5.x has built-in pool teardown for Django 5.1+ but it only runs on process fork/init — with `--pool=gevent` there is no forking, so it never fires

## Why `task_postrun` is safe with concurrent greenlets

`task_postrun` is sent inline in a `finally` block inside Celery's `trace_task` — no new greenlet is spawned. It fires synchronously in the same greenlet that ran the task.

Django's `ConnectionHandler` uses `thread_critical = True`, which stores connections in `threading.local`. Celery's gevent pool monkey-patches `threading.local` → `gevent.local`, making it per-greenlet. So `close_old_connections()` always resolves the calling greenlet's own local storage and closes only that greenlet's connection — concurrent calls from other greenlets are fully isolated.

Closes PLA-1366