### PR TITLE
Fix test queue declaration for RabbitMQ 4.x compatibility

### DIFF
--- a/safe_transaction_service/events/tests/test_queue_service.py
+++ b/safe_transaction_service/events/tests/test_queue_service.py
@@ -16,7 +16,11 @@ class TestQueueService(TestCase):
         exchange = Exchange(
             settings.EVENTS_QUEUE_EXCHANGE_NAME, type="fanout", durable=True
         )
-        self.test_queue = Queue("test_queue", exchange=exchange, durable=False)
+        # exclusive=True: RabbitMQ 4.x deprecated non-durable non-exclusive queues
+        # (transient_nonexcl_queues). Exclusive queues are still allowed, are
+        # auto-deleted when the connection closes, and still receive messages
+        # routed from the fanout exchange by the broker.
+        self.test_queue = Queue("test_queue", exchange=exchange, exclusive=True)
         with self.conn.channel() as channel:
             bound = self.test_queue(channel)
             bound.declare()


### PR DESCRIPTION
## Summary

- RabbitMQ 4.x deprecated non-durable non-exclusive queues (`transient_nonexcl_queues`), causing `TestQueueService` to fail in CI with `amqp.exceptions.InternalError: (541) INTERNAL_ERROR`
- Changed the test queue from `durable=False` to `exclusive=True` — exclusive queues are still permitted, auto-deleted when the connection closes, and still receive messages routed by the broker via the durable fanout exchange

Closes PLA-1372