### PR TITLE
Revert "Fix test queue declaration for RabbitMQ 4.x compatibility"

### DIFF
--- a/safe_transaction_service/events/tests/test_queue_service.py
+++ b/safe_transaction_service/events/tests/test_queue_service.py
@@ -16,11 +16,7 @@ class TestQueueService(TestCase):
         exchange = Exchange(
             settings.EVENTS_QUEUE_EXCHANGE_NAME, type="fanout", durable=True
         )
-        # exclusive=True: RabbitMQ 4.x deprecated non-durable non-exclusive queues
-        # (transient_nonexcl_queues). Exclusive queues are still allowed, are
-        # auto-deleted when the connection closes, and still receive messages
-        # routed from the fanout exchange by the broker.
-        self.test_queue = Queue("test_queue", exchange=exchange, exclusive=True)
+        self.test_queue = Queue("test_queue", exchange=exchange, durable=False)
         with self.conn.channel() as channel:
             bound = self.test_queue(channel)
             bound.declare()


### PR DESCRIPTION
Reverts safe-global/safe-transaction-service#2865