### PR TITLE
(fix) Celery DB pool cleanup

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,6 +1,1 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
-# This will make sure the app is always imported when
-# Django starts so that shared_task will use this app.
-from .celery_app import app as celery_app
-
-__all__ = ("celery_app",)

--- a/config/celery_app.py
+++ b/config/celery_app.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
-import os
-
 from celery import Celery
-from celery.signals import setup_logging
+from celery.signals import setup_logging, task_postrun
 
 
 @setup_logging.connect
@@ -26,8 +24,35 @@ def on_celery_setup_logging(**kwargs):
         dictConfig(settings.LOGGING)
 
 
-# set the default Django settings module for the 'celery' program.
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
+@task_postrun.connect
+def close_db_connections(**kwargs):
+    from django.db import connections
+
+    # Django's close_old_connections() is called automatically at the end of each web request
+    # via middleware signals, but Celery tasks have no equivalent lifecycle hook.
+    #
+    # Without this, connections acquired via pool.getconn() during a task are never returned
+    # to the psycopg3 pool via pool.putconn() — the pool exhausts its max_size slots and new
+    # tasks block until max_lifetime/max_idle timers recycle them.
+    #
+    # NOTE: Celery 5.x has built-in pool handling for Django 5.1+ (close_pool on worker
+    # process init — see https://docs.celeryq.dev/en/main/django/first-steps-with-django.html#django-connection-pool),
+    # but that only covers the fork/process-start path. With --pool=gevent there is no forking:
+    # all tasks run as greenlets inside a single process, so close_pool never fires and
+    # per-task connection cleanup must be handled explicitly here.
+    #
+    # CONN_MAX_AGE=0 means every connection is immediately eligible for closure,
+    # triggering close() → putconn() and returning the slot to the pool immediately.
+    #
+    # Connections inside an atomic block are skipped: in production this never happens
+    # because task_postrun fires after the task function returns (so any transaction.atomic
+    # blocks from the task itself have already exited). In tests, Django's TestCase wraps
+    # each test in a transaction (in_atomic_block=True), and closing the connection there
+    # would break test isolation.
+    for conn in connections.all(initialized_only=True):
+        if not conn.in_atomic_block:
+            conn.close_if_unusable_or_obsolete()
+
 
 app = Celery("safe_transaction_service")
 

--- a/safe_transaction_service/utils/tests/test_celery_app.py
+++ b/safe_transaction_service/utils/tests/test_celery_app.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+import subprocess
+import sys
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from config.celery_app import close_db_connections
+
+
+class TestCeleryApp(SimpleTestCase):
+    def test_celery_app_import_does_not_import_django_db(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import os, sys; os.environ['DJANGO_SETTINGS_MODULE'] = 'config.settings.test'; import config.celery_app; raise SystemExit('django.db' in sys.modules)",
+            ],
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_db_connections_closed_after_task(self):
+        conn_to_close = mock.Mock(in_atomic_block=False)
+        conn_in_atomic = mock.Mock(in_atomic_block=True)
+
+        with mock.patch(
+            "django.db.connections.all",
+            return_value=[conn_to_close, conn_in_atomic],
+        ) as mock_all:
+            close_db_connections()
+
+        mock_all.assert_called_once_with(initialized_only=True)
+        conn_to_close.close_if_unusable_or_obsolete.assert_called_once_with()
+        conn_in_atomic.close_if_unusable_or_obsolete.assert_not_called()


### PR DESCRIPTION
## Summary

This change fixes the production regression introduced by the Celery DB pool cleanup work and hardens startup behavior around gevent.

The root cause was an import side effect chain in the config package:

gunicorn.conf.py -> config.gunicorn -> config.__init__ -> config.celery_app

That caused the web pod to import Celery code before Gunicorn’s gevent worker had applied monkey patching. The new task_postrun cleanup in config.celery_app imported django.db, and under gevent that led to Django DB connections being created/closed under
mismatched thread identities in web requests.

## Changes

- Removed the eager Celery import from config/__init__.py
- Kept the Celery task_postrun DB connection cleanup, but made the django.db import lazy inside the signal handler
- Added regression tests covering:
  - importing config.celery_app does not import django.db
  - the Celery post-task cleanup still closes non-atomic DB connections

## Why

- Web startup should not import the Celery app as a package side effect
- Reusable modules like config.celery_app should not mutate process-global settings at import time
- Celery connection cleanup is still needed for gevent workers, but it must not affect the web pod import path

Closes PLA-1366
