### PR TITLE
Add backfill_delete_failed_ethereum_txs management command

### DIFF
--- a/safe_transaction_service/history/management/commands/backfill_delete_failed_ethereum_txs.py
+++ b/safe_transaction_service/history/management/commands/backfill_delete_failed_ethereum_txs.py
@@ -119,7 +119,7 @@ class Command(BaseCommand):
                 continue
 
             if tx_receipt.get("status") == 0:
-                self.stdout.write(f"Deleting {ethereum_tx.tx_hash.hex()}")
+                self.stdout.write(f"Deleting {ethereum_tx.tx_hash}")
                 if not dry_run:
                     ethereum_tx.delete()
                 deleted += 1

--- a/safe_transaction_service/history/management/commands/backfill_delete_failed_ethereum_txs.py
+++ b/safe_transaction_service/history/management/commands/backfill_delete_failed_ethereum_txs.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+import time
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+try:
+    from safe_eth.eth import EthereumClientProvider
+except ImportError:  # pragma: no cover - fallback for environments without provider
+    from safe_eth.eth import get_auto_ethereum_client
+
+    def EthereumClientProvider():
+        return get_auto_ethereum_client()
+
+
+from ...models import EthereumTx
+
+
+class Command(BaseCommand):
+    help = (
+        "Delete recent EthereumTx rows marked successful in DB after confirming "
+        "failed receipts on RPC"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=30,
+            help="Only inspect EthereumTx created in the last N days",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Only report rows that would be deleted",
+        )
+        parser.add_argument(
+            "--retries",
+            type=int,
+            default=3,
+            help="Number of RPC attempts per transaction before skipping",
+        )
+        parser.add_argument(
+            "--backoff",
+            type=float,
+            default=2.0,
+            help="Base backoff in seconds between retries (exponential: backoff ** attempt)",
+        )
+
+    def _get_receipt_with_retry(self, ethereum_client, tx_hash, retries, backoff):
+        for attempt in range(retries):
+            try:
+                return ethereum_client.get_transaction_receipt(tx_hash)
+            except Exception as exc:
+                if attempt == retries - 1:
+                    raise
+                delay = backoff**attempt
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"RPC error for {tx_hash} (attempt {attempt + 1}/{retries}): {exc}. "
+                        f"Retrying in {delay}s..."
+                    )
+                )
+                time.sleep(delay)
+
+    def handle(self, *args, **options):
+        days = options["days"]
+        dry_run = options["dry_run"]
+        retries = options["retries"]
+        backoff = options["backoff"]
+        cutoff = timezone.now() - timedelta(days=days)
+        ethereum_client = EthereumClientProvider()
+
+        queryset = EthereumTx.objects.filter(status=1, created__gte=cutoff).only(
+            "tx_hash"
+        )
+        total = queryset.count()
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Checking {total} EthereumTx rows with status=1 created since {cutoff.isoformat()}"
+            )
+        )
+
+        checked = 0
+        deleted = 0
+        missing_receipts = 0
+        still_success = 0
+        rpc_errors = 0
+
+        for i, ethereum_tx in enumerate(queryset.iterator(), start=1):
+            if i % 100_000 == 0:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Progress {i}/{total} checked={checked} deleted={deleted}"
+                    )
+                )
+
+            try:
+                tx_receipt = self._get_receipt_with_retry(
+                    ethereum_client, ethereum_tx.tx_hash, retries, backoff
+                )
+            except Exception as exc:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Skipping {ethereum_tx.tx_hash} after {retries} failed attempts: {exc}"
+                    )
+                )
+                rpc_errors += 1
+                continue
+            checked += 1
+
+            if not tx_receipt:
+                missing_receipts += 1
+                continue
+
+            if tx_receipt.get("status") == 0:
+                self.stdout.write(f"Deleting {ethereum_tx.tx_hash.hex()}")
+                if not dry_run:
+                    ethereum_tx.delete()
+                deleted += 1
+            else:
+                still_success += 1
+
+        action = "Would delete" if dry_run else "Deleted"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{action} {deleted}/{total} EthereumTx rows. "
+                f"Checked={checked}, missing_receipts={missing_receipts}, "
+                f"still_success={still_success}, rpc_errors={rpc_errors}"
+            )
+        )

--- a/safe_transaction_service/history/management/commands/backfill_delete_failed_ethereum_txs.py
+++ b/safe_transaction_service/history/management/commands/backfill_delete_failed_ethereum_txs.py
@@ -27,8 +27,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "--days",
             type=int,
-            default=30,
-            help="Only inspect EthereumTx created in the last N days",
+            default=None,
+            help="Only inspect EthereumTx created in the last N days (default: all)",
         )
         parser.add_argument(
             "--dry-run",
@@ -69,16 +69,20 @@ class Command(BaseCommand):
         dry_run = options["dry_run"]
         retries = options["retries"]
         backoff = options["backoff"]
-        cutoff = timezone.now() - timedelta(days=days)
         ethereum_client = EthereumClientProvider()
 
-        queryset = EthereumTx.objects.filter(status=1, created__gte=cutoff).only(
-            "tx_hash"
-        )
+        queryset = EthereumTx.objects.filter(status=1).only("tx_hash")
+        if days is not None:
+            cutoff = timezone.now() - timedelta(days=days)
+            queryset = queryset.filter(created__gte=cutoff)
+            scope_msg = f"created since {cutoff.isoformat()}"
+        else:
+            scope_msg = "all time"
+
         total = queryset.count()
         self.stdout.write(
             self.style.SUCCESS(
-                f"Checking {total} EthereumTx rows with status=1 created since {cutoff.isoformat()}"
+                f"Checking {total} EthereumTx rows with status=1 ({scope_msg})"
             )
         )
 

--- a/safe_transaction_service/history/management/commands/backfill_delete_failed_ethereum_txs.py
+++ b/safe_transaction_service/history/management/commands/backfill_delete_failed_ethereum_txs.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
             "--backoff",
             type=float,
             default=2.0,
-            help="Base backoff in seconds between retries (exponential: backoff ** attempt)",
+            help="Base backoff in seconds between retries (exponential: backoff ** (attempt + 1))",
         )
 
     def _get_receipt_with_retry(self, ethereum_client, tx_hash, retries, backoff):
@@ -55,7 +55,7 @@ class Command(BaseCommand):
             except Exception as exc:
                 if attempt == retries - 1:
                     raise
-                delay = backoff**attempt
+                delay = backoff ** (attempt + 1)
                 self.stdout.write(
                     self.style.WARNING(
                         f"RPC error for {tx_hash} (attempt {attempt + 1}/{retries}): {exc}. "

--- a/safe_transaction_service/history/management/commands/backfill_delete_failed_ethereum_txs.py
+++ b/safe_transaction_service/history/management/commands/backfill_delete_failed_ethereum_txs.py
@@ -1,20 +1,22 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
+import argparse
 import time
 from datetime import timedelta
 
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-try:
-    from safe_eth.eth import EthereumClientProvider
-except ImportError:  # pragma: no cover - fallback for environments without provider
-    from safe_eth.eth import get_auto_ethereum_client
-
-    def EthereumClientProvider():
-        return get_auto_ethereum_client()
-
+from safe_eth.eth import EthereumClient, get_auto_ethereum_client
+from web3.types import TxReceipt
 
 from ...models import EthereumTx
+
+
+def _positive_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError(f"{value} must be a positive integer")
+    return ivalue
 
 
 class Command(BaseCommand):
@@ -37,9 +39,9 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--retries",
-            type=int,
+            type=_positive_int,
             default=3,
-            help="Number of RPC attempts per transaction before skipping",
+            help="Number of RPC attempts per transaction before skipping (must be > 0)",
         )
         parser.add_argument(
             "--backoff",
@@ -48,7 +50,13 @@ class Command(BaseCommand):
             help="Base backoff in seconds between retries (exponential: backoff ** (attempt + 1))",
         )
 
-    def _get_receipt_with_retry(self, ethereum_client, tx_hash, retries, backoff):
+    def _get_receipt_with_retry(
+        self,
+        ethereum_client: EthereumClient,
+        tx_hash: str,
+        retries: int,
+        backoff: float,
+    ) -> TxReceipt | None:
         for attempt in range(retries):
             try:
                 return ethereum_client.get_transaction_receipt(tx_hash)
@@ -69,7 +77,7 @@ class Command(BaseCommand):
         dry_run = options["dry_run"]
         retries = options["retries"]
         backoff = options["backoff"]
-        ethereum_client = EthereumClientProvider()
+        ethereum_client = get_auto_ethereum_client()
 
         queryset = EthereumTx.objects.filter(status=1).only("tx_hash")
         if days is not None:

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -939,3 +939,20 @@ class TestBackfillDeleteFailedEthereumTxsCommand(TestCase):
 
         self.assertTrue(EthereumTx.objects.filter(tx_hash=tx.tx_hash).exists())
         self.assertIn("Checking 0 EthereumTx rows", buf.getvalue())
+
+    @mock.patch(_CLIENT_PATH)
+    def test_no_days_includes_all_txs(self, mock_provider):
+        client = MagicMock()
+        client.get_transaction_receipt.return_value = {"status": 0}
+        mock_provider.return_value = client
+
+        tx = EthereumTxFactory(status=1)
+        EthereumTx.objects.filter(tx_hash=tx.tx_hash).update(
+            created=timezone.now() - timedelta(days=365)
+        )
+
+        buf = StringIO()
+        call_command(_COMMAND, stdout=buf)
+
+        self.assertFalse(EthereumTx.objects.filter(tx_hash=tx.tx_hash).exists())
+        self.assertIn("all time", buf.getvalue())

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -907,6 +907,7 @@ class TestBackfillDeleteFailedEthereumTxsCommand(TestCase):
 
         self.assertFalse(EthereumTx.objects.filter(tx_hash=tx.tx_hash).exists())
         self.assertIn("Deleted 1/1", buf.getvalue())
+        mock_sleep.assert_called_once_with(0.0)
 
     @mock.patch("time.sleep")
     @mock.patch(_CLIENT_PATH)

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 import os.path
 import tempfile
+from datetime import timedelta
 from io import StringIO
 from unittest import mock
 from unittest.mock import MagicMock, PropertyMock
 
 from django.core.management import CommandError, call_command
 from django.test import TestCase
+from django.utils import timezone
 
 from django_celery_beat.models import PeriodicTask
 from eth_account import Account
@@ -18,6 +20,7 @@ from safe_eth.util.util import to_0x_hex_str
 
 from ..indexers import Erc20EventsIndexer, InternalTxIndexer, SafeEventsIndexer
 from ..models import (
+    EthereumTx,
     IndexingStatus,
     InternalTxDecoded,
     ProxyFactory,
@@ -823,3 +826,116 @@ class TestCommands(SafeTestCaseMixin, TestCase):
         self.assertIn("Updated payment for 1/1", buf.getvalue())
         multisig_tx_2.refresh_from_db()
         self.assertEqual(multisig_tx_2.payment, 2471261352604)
+
+
+_COMMAND = "backfill_delete_failed_ethereum_txs"
+_CLIENT_PATH = "safe_transaction_service.history.management.commands.backfill_delete_failed_ethereum_txs.EthereumClientProvider"
+
+
+class TestBackfillDeleteFailedEthereumTxsCommand(TestCase):
+    def _make_client_mock(self, receipt):
+        client = MagicMock()
+        client.get_transaction_receipt.return_value = receipt
+        mock_provider = MagicMock(return_value=client)
+        return mock_provider, client
+
+    @mock.patch(_CLIENT_PATH)
+    def test_deletes_tx_with_failed_receipt(self, mock_provider):
+        client = MagicMock()
+        client.get_transaction_receipt.return_value = {"status": 0}
+        mock_provider.return_value = client
+
+        tx = EthereumTxFactory(status=1)
+        buf = StringIO()
+        call_command(_COMMAND, stdout=buf)
+
+        self.assertFalse(EthereumTx.objects.filter(tx_hash=tx.tx_hash).exists())
+        self.assertIn("Deleted 1/1", buf.getvalue())
+
+    @mock.patch(_CLIENT_PATH)
+    def test_keeps_tx_with_successful_receipt(self, mock_provider):
+        client = MagicMock()
+        client.get_transaction_receipt.return_value = {"status": 1}
+        mock_provider.return_value = client
+
+        tx = EthereumTxFactory(status=1)
+        buf = StringIO()
+        call_command(_COMMAND, stdout=buf)
+
+        self.assertTrue(EthereumTx.objects.filter(tx_hash=tx.tx_hash).exists())
+        self.assertIn("Deleted 0/1", buf.getvalue())
+
+    @mock.patch(_CLIENT_PATH)
+    def test_skips_tx_with_missing_receipt(self, mock_provider):
+        client = MagicMock()
+        client.get_transaction_receipt.return_value = None
+        mock_provider.return_value = client
+
+        tx = EthereumTxFactory(status=1)
+        buf = StringIO()
+        call_command(_COMMAND, stdout=buf)
+
+        self.assertTrue(EthereumTx.objects.filter(tx_hash=tx.tx_hash).exists())
+        self.assertIn("missing_receipts=1", buf.getvalue())
+
+    @mock.patch(_CLIENT_PATH)
+    def test_dry_run_does_not_delete(self, mock_provider):
+        client = MagicMock()
+        client.get_transaction_receipt.return_value = {"status": 0}
+        mock_provider.return_value = client
+
+        tx = EthereumTxFactory(status=1)
+        buf = StringIO()
+        call_command(_COMMAND, "--dry-run", stdout=buf)
+
+        self.assertTrue(EthereumTx.objects.filter(tx_hash=tx.tx_hash).exists())
+        self.assertIn("Would delete 1/1", buf.getvalue())
+
+    @mock.patch("time.sleep")
+    @mock.patch(_CLIENT_PATH)
+    def test_retries_on_rpc_error_then_succeeds(self, mock_provider, mock_sleep):
+        client = MagicMock()
+        client.get_transaction_receipt.side_effect = [
+            Exception("timeout"),
+            {"status": 0},
+        ]
+        mock_provider.return_value = client
+
+        tx = EthereumTxFactory(status=1)
+        buf = StringIO()
+        call_command(_COMMAND, "--retries=2", "--backoff=0", stdout=buf)
+
+        self.assertFalse(EthereumTx.objects.filter(tx_hash=tx.tx_hash).exists())
+        self.assertIn("Deleted 1/1", buf.getvalue())
+
+    @mock.patch("time.sleep")
+    @mock.patch(_CLIENT_PATH)
+    def test_skips_tx_after_exhausted_retries(self, mock_provider, mock_sleep):
+        client = MagicMock()
+        client.get_transaction_receipt.side_effect = Exception("timeout")
+        mock_provider.return_value = client
+
+        tx = EthereumTxFactory(status=1)
+        buf = StringIO()
+        call_command(_COMMAND, "--retries=3", "--backoff=0", stdout=buf)
+
+        self.assertTrue(EthereumTx.objects.filter(tx_hash=tx.tx_hash).exists())
+        self.assertIn("rpc_errors=1", buf.getvalue())
+        self.assertEqual(client.get_transaction_receipt.call_count, 3)
+
+    @mock.patch(_CLIENT_PATH)
+    def test_days_filter_excludes_old_txs(self, mock_provider):
+        client = MagicMock()
+        client.get_transaction_receipt.return_value = {"status": 0}
+        mock_provider.return_value = client
+
+        tx = EthereumTxFactory(status=1)
+        EthereumTx.objects.filter(tx_hash=tx.tx_hash).update(
+            created=timezone.now() - timedelta(days=40)
+        )
+
+        buf = StringIO()
+        call_command(_COMMAND, "--days=30", stdout=buf)
+
+        self.assertTrue(EthereumTx.objects.filter(tx_hash=tx.tx_hash).exists())
+        self.assertIn("Checking 0 EthereumTx rows", buf.getvalue())

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -829,7 +829,7 @@ class TestCommands(SafeTestCaseMixin, TestCase):
 
 
 _COMMAND = "backfill_delete_failed_ethereum_txs"
-_CLIENT_PATH = "safe_transaction_service.history.management.commands.backfill_delete_failed_ethereum_txs.EthereumClientProvider"
+_CLIENT_PATH = "safe_transaction_service.history.management.commands.backfill_delete_failed_ethereum_txs.get_auto_ethereum_client"
 
 
 class TestBackfillDeleteFailedEthereumTxsCommand(TestCase):


### PR DESCRIPTION
## Summary

- Adds a `backfill_delete_failed_ethereum_txs` management command that identifies `EthereumTx` rows stored with `status=1` whose on-chain receipt actually reports `status=0` (failure), and deletes them to resolve the DB/chain state mismatch believed to be causing reindex incidents (PLA-1011)
- Supports `--dry-run` to audit impact before committing, `--days` to limit the scan window, and `--retries`/`--backoff` for RPC resilience with exponential backoff
- Adds tests covering deletion, dry-run, missing receipts, retry-then-succeed, exhausted retries, and the days filter

Closes PLA-1404
Related to PLA-1011