### PR TITLE
feat: Add gas fee fields to CSV export endpoint

### DIFF
--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -1414,6 +1414,10 @@ class SafeExportTransactionSerializer(serializers.Serializer):
     transaction_hash = Sha3HashField()
     contract_address = EthereumAddressField(allow_null=True)
     nonce = serializers.CharField(allow_null=True)
+    gas_token = EthereumAddressField(allow_null=True)
+    fee = serializers.CharField(allow_null=True)
+    gas_token_symbol = serializers.CharField(allow_null=True)
+    gas_token_decimals = serializers.IntegerField(allow_null=True)
 
     def to_representation(self, instance):
         rep = super().to_representation(instance)

--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -1415,7 +1415,7 @@ class SafeExportTransactionSerializer(serializers.Serializer):
     contract_address = EthereumAddressField(allow_null=True)
     nonce = serializers.CharField(allow_null=True)
     gas_token = EthereumAddressField(allow_null=True)
-    fee = serializers.CharField(allow_null=True)
+    payment = serializers.CharField(allow_null=True)
     gas_token_symbol = serializers.CharField(allow_null=True)
     gas_token_decimals = serializers.IntegerField(allow_null=True)
 

--- a/safe_transaction_service/history/services/transaction_service.py
+++ b/safe_transaction_service/history/services/transaction_service.py
@@ -456,11 +456,7 @@ class TransactionService:
                 COALESCE(mt.origin->> 'note', '') as note,
                 encode(erc20.ethereum_tx_id, 'hex') as transaction_hash,
                 encode(COALESCE(mt.to, modtx.to), 'hex') as contract_address,
-                -- Only expose gas fee fields when the multisig tx belongs to the queried Safe.
-                -- Edge case: when Safe A sends to Safe B, Safe B's export sees a multisig tx
-                -- from Safe A (with its nonce, gas_token and payment) — those should be null.
-                -- payment is the exact refund paid by the Safe to the executor as emitted in
-                -- the ExecutionSuccess/ExecutionFailure event (differs from gas_used * gas_price).
+                -- Only expose the nonces and gas fee fields when the multisig tx belongs to the queried Safe.
                 CASE WHEN mt.safe = %s THEN mt.nonce ELSE NULL END AS nonce,
                 CASE WHEN mt.safe = %s THEN encode(mt.gas_token, 'hex') ELSE NULL END AS gas_token,
                 CASE WHEN mt.safe = %s THEN mt.payment::text ELSE NULL END AS payment,
@@ -507,11 +503,7 @@ class TransactionService:
                 COALESCE(mt.origin->> 'note', '') as note,
                 encode(erc721.ethereum_tx_id, 'hex') as transaction_hash,
                 encode(COALESCE(modtx.to, mt.to), 'hex') as contract_address,
-                -- Only expose gas fee fields when the multisig tx belongs to the queried Safe.
-                -- Edge case: when Safe A sends to Safe B, Safe B's export sees Safe A's multisig
-                -- tx — nonce, gas_token and payment should be null from Safe B's perspective.
-                -- payment is the exact refund paid by the Safe to the executor as emitted in
-                -- the ExecutionSuccess/ExecutionFailure event (differs from gas_used * gas_price).
+                -- Only expose the nonces and gas fee fields when the multisig tx belongs to the queried Safe.
                 CASE WHEN mt.safe = %s THEN mt.nonce ELSE NULL END AS nonce,
                 CASE WHEN mt.safe = %s THEN encode(mt.gas_token, 'hex') ELSE NULL END AS gas_token,
                 CASE WHEN mt.safe = %s THEN mt.payment::text ELSE NULL END AS payment,
@@ -559,11 +551,7 @@ class TransactionService:
                 COALESCE(mt.origin->> 'note', '') as note,
                 encode(itx.ethereum_tx_id, 'hex') as transaction_hash,
                 encode(COALESCE(mt.to, modtx.to), 'hex') as contract_address,
-                -- Only expose gas fee fields when the multisig tx belongs to the queried Safe.
-                -- Edge case: when Safe A sends to Safe B, Safe B's export sees Safe A's multisig
-                -- tx — nonce, gas_token and payment should be null from Safe B's perspective.
-                -- payment is the exact refund paid by the Safe to the executor as emitted in
-                -- the ExecutionSuccess/ExecutionFailure event (differs from gas_used * gas_price).
+                -- Only expose the nonces and gas fee fields when the multisig tx belongs to the queried Safe.
                 CASE WHEN mt.safe = %s THEN mt.nonce ELSE NULL END AS nonce,
                 CASE WHEN mt.safe = %s THEN encode(mt.gas_token, 'hex') ELSE NULL END AS gas_token,
                 CASE WHEN mt.safe = %s THEN mt.payment::text ELSE NULL END AS payment,

--- a/safe_transaction_service/history/services/transaction_service.py
+++ b/safe_transaction_service/history/services/transaction_service.py
@@ -456,12 +456,16 @@ class TransactionService:
                 COALESCE(mt.origin->> 'note', '') as note,
                 encode(erc20.ethereum_tx_id, 'hex') as transaction_hash,
                 encode(COALESCE(mt.to, modtx.to), 'hex') as contract_address,
-                -- Just get the nonces from the provided Safe
+                -- Only expose gas fee fields when the multisig tx belongs to the queried Safe.
+                -- Edge case: when Safe A sends to Safe B, Safe B's export sees a multisig tx
+                -- from Safe A (with its nonce, gas_token and payment) — those should be null.
+                -- payment is the exact refund paid by the Safe to the executor as emitted in
+                -- the ExecutionSuccess/ExecutionFailure event (differs from gas_used * gas_price).
                 CASE WHEN mt.safe = %s THEN mt.nonce ELSE NULL END AS nonce,
-                encode(mt.gas_token, 'hex') AS gas_token,
-                (et.gas_used * et.gas_price)::text AS fee,
-                gt.symbol AS gas_token_symbol,
-                gt.decimals AS gas_token_decimals,
+                CASE WHEN mt.safe = %s THEN encode(mt.gas_token, 'hex') ELSE NULL END AS gas_token,
+                CASE WHEN mt.safe = %s THEN mt.payment::text ELSE NULL END AS payment,
+                CASE WHEN mt.safe = %s THEN gt.symbol ELSE NULL END AS gas_token_symbol,
+                CASE WHEN mt.safe = %s THEN gt.decimals ELSE NULL END AS gas_token_decimals,
                 -- Assigns a row number to each ERC20 transfer grouped by tx and log index.
                 -- Prioritizes module > multisig > standalone using execution time as tiebreaker.
                 ROW_NUMBER() OVER (
@@ -503,12 +507,16 @@ class TransactionService:
                 COALESCE(mt.origin->> 'note', '') as note,
                 encode(erc721.ethereum_tx_id, 'hex') as transaction_hash,
                 encode(COALESCE(modtx.to, mt.to), 'hex') as contract_address,
-                -- Just get the nonces from the provided Safe
+                -- Only expose gas fee fields when the multisig tx belongs to the queried Safe.
+                -- Edge case: when Safe A sends to Safe B, Safe B's export sees Safe A's multisig
+                -- tx — nonce, gas_token and payment should be null from Safe B's perspective.
+                -- payment is the exact refund paid by the Safe to the executor as emitted in
+                -- the ExecutionSuccess/ExecutionFailure event (differs from gas_used * gas_price).
                 CASE WHEN mt.safe = %s THEN mt.nonce ELSE NULL END AS nonce,
-                encode(mt.gas_token, 'hex') AS gas_token,
-                (et.gas_used * et.gas_price)::text AS fee,
-                gt.symbol AS gas_token_symbol,
-                gt.decimals AS gas_token_decimals,
+                CASE WHEN mt.safe = %s THEN encode(mt.gas_token, 'hex') ELSE NULL END AS gas_token,
+                CASE WHEN mt.safe = %s THEN mt.payment::text ELSE NULL END AS payment,
+                CASE WHEN mt.safe = %s THEN gt.symbol ELSE NULL END AS gas_token_symbol,
+                CASE WHEN mt.safe = %s THEN gt.decimals ELSE NULL END AS gas_token_decimals,
                 -- Assigns a row number to each ERC721 transfer grouped by tx and log index.
                 -- Prioritizes module > multisig > standalone using execution time as tiebreaker.
                 ROW_NUMBER() OVER (
@@ -551,12 +559,16 @@ class TransactionService:
                 COALESCE(mt.origin->> 'note', '') as note,
                 encode(itx.ethereum_tx_id, 'hex') as transaction_hash,
                 encode(COALESCE(mt.to, modtx.to), 'hex') as contract_address,
-                -- Just get the nonces from the provided Safe
+                -- Only expose gas fee fields when the multisig tx belongs to the queried Safe.
+                -- Edge case: when Safe A sends to Safe B, Safe B's export sees Safe A's multisig
+                -- tx — nonce, gas_token and payment should be null from Safe B's perspective.
+                -- payment is the exact refund paid by the Safe to the executor as emitted in
+                -- the ExecutionSuccess/ExecutionFailure event (differs from gas_used * gas_price).
                 CASE WHEN mt.safe = %s THEN mt.nonce ELSE NULL END AS nonce,
-                encode(mt.gas_token, 'hex') AS gas_token,
-                (et.gas_used * et.gas_price)::text AS fee,
-                gt.symbol AS gas_token_symbol,
-                gt.decimals AS gas_token_decimals,
+                CASE WHEN mt.safe = %s THEN encode(mt.gas_token, 'hex') ELSE NULL END AS gas_token,
+                CASE WHEN mt.safe = %s THEN mt.payment::text ELSE NULL END AS payment,
+                CASE WHEN mt.safe = %s THEN gt.symbol ELSE NULL END AS gas_token_symbol,
+                CASE WHEN mt.safe = %s THEN gt.decimals ELSE NULL END AS gas_token_decimals,
                 -- Assigns a row number to each native transfer grouped by tx and log index.
                 -- Prioritizes module > multisig > standalone using execution time as tiebreaker.
                 ROW_NUMBER() OVER (
@@ -598,7 +610,7 @@ class TransactionService:
             contract_address,
             nonce,
             gas_token,
-            fee,
+            payment,
             gas_token_symbol,
             gas_token_decimals
         FROM export_data
@@ -610,7 +622,7 @@ class TransactionService:
         safe_address_bytes = HexBytes(safe_address)
         main_params = [
             safe_address_bytes
-        ] * 15 + [  # 15 instances of safe address in the query
+        ] * 27 + [  # 27 instances of safe address in the query
             limit,
             offset,
         ]
@@ -709,7 +721,7 @@ class TransactionService:
                         if row_dict["gas_token"] is not None
                         else None
                     ),
-                    "fee": row_dict["fee"],
+                    "payment": row_dict["payment"],
                     "gas_token_symbol": row_dict["gas_token_symbol"],
                     "gas_token_decimals": row_dict["gas_token_decimals"],
                 }

--- a/safe_transaction_service/history/services/transaction_service.py
+++ b/safe_transaction_service/history/services/transaction_service.py
@@ -458,6 +458,10 @@ class TransactionService:
                 encode(COALESCE(mt.to, modtx.to), 'hex') as contract_address,
                 -- Just get the nonces from the provided Safe
                 CASE WHEN mt.safe = %s THEN mt.nonce ELSE NULL END AS nonce,
+                encode(mt.gas_token, 'hex') AS gas_token,
+                (et.gas_used * et.gas_price)::text AS fee,
+                gt.symbol AS gas_token_symbol,
+                gt.decimals AS gas_token_decimals,
                 -- Assigns a row number to each ERC20 transfer grouped by tx and log index.
                 -- Prioritizes module > multisig > standalone using execution time as tiebreaker.
                 ROW_NUMBER() OVER (
@@ -477,6 +481,7 @@ class TransactionService:
             LEFT JOIN history_internaltx itx ON itx.ethereum_tx_id = erc20.ethereum_tx_id
             LEFT JOIN history_moduletransaction modtx ON modtx.internal_tx_id = itx.id
             LEFT JOIN tokens_token t ON erc20.address = t.address
+            LEFT JOIN tokens_token gt ON mt.gas_token = gt.address
             WHERE (erc20.to = %s OR erc20._from = %s){erc20_timestamp_conditions}
 
             UNION ALL
@@ -500,6 +505,10 @@ class TransactionService:
                 encode(COALESCE(modtx.to, mt.to), 'hex') as contract_address,
                 -- Just get the nonces from the provided Safe
                 CASE WHEN mt.safe = %s THEN mt.nonce ELSE NULL END AS nonce,
+                encode(mt.gas_token, 'hex') AS gas_token,
+                (et.gas_used * et.gas_price)::text AS fee,
+                gt.symbol AS gas_token_symbol,
+                gt.decimals AS gas_token_decimals,
                 -- Assigns a row number to each ERC721 transfer grouped by tx and log index.
                 -- Prioritizes module > multisig > standalone using execution time as tiebreaker.
                 ROW_NUMBER() OVER (
@@ -519,6 +528,7 @@ class TransactionService:
             LEFT JOIN history_internaltx itx ON itx.ethereum_tx_id = erc721.ethereum_tx_id
             LEFT JOIN history_moduletransaction modtx ON modtx.internal_tx_id = itx.id
             LEFT JOIN tokens_token t ON erc721.address = t.address
+            LEFT JOIN tokens_token gt ON mt.gas_token = gt.address
             WHERE (erc721.to = %s OR erc721._from = %s){erc721_timestamp_conditions}
 
             UNION ALL
@@ -543,6 +553,10 @@ class TransactionService:
                 encode(COALESCE(mt.to, modtx.to), 'hex') as contract_address,
                 -- Just get the nonces from the provided Safe
                 CASE WHEN mt.safe = %s THEN mt.nonce ELSE NULL END AS nonce,
+                encode(mt.gas_token, 'hex') AS gas_token,
+                (et.gas_used * et.gas_price)::text AS fee,
+                gt.symbol AS gas_token_symbol,
+                gt.decimals AS gas_token_decimals,
                 -- Assigns a row number to each native transfer grouped by tx and log index.
                 -- Prioritizes module > multisig > standalone using execution time as tiebreaker.
                 ROW_NUMBER() OVER (
@@ -560,6 +574,7 @@ class TransactionService:
             JOIN history_ethereumtx et ON rel.ethereum_tx_id = et.tx_hash
             LEFT JOIN history_multisigtransaction mt ON itx.ethereum_tx_id = mt.ethereum_tx_id
             LEFT JOIN history_moduletransaction modtx ON modtx.internal_tx_id = itx.id
+            LEFT JOIN tokens_token gt ON mt.gas_token = gt.address
             WHERE(itx.to = %s OR itx._from = %s)
             AND itx.call_type = 0
             AND itx.value > 0{native_timestamp_conditions}
@@ -581,7 +596,11 @@ class TransactionService:
             note,
             transaction_hash,
             contract_address,
-            nonce
+            nonce,
+            gas_token,
+            fee,
+            gas_token_symbol,
+            gas_token_decimals
         FROM export_data
         WHERE rn = 1
         ORDER BY execution_date DESC, transaction_hash
@@ -685,6 +704,14 @@ class TransactionService:
                         else None
                     ),
                     "nonce": row_dict["nonce"],
+                    "gas_token": (
+                        fast_to_checksum_address(row_dict["gas_token"])
+                        if row_dict["gas_token"] is not None
+                        else None
+                    ),
+                    "fee": row_dict["fee"],
+                    "gas_token_symbol": row_dict["gas_token_symbol"],
+                    "gas_token_decimals": row_dict["gas_token_decimals"],
                 }
                 results.append(export_item)
 

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -5023,6 +5023,7 @@ class TestViewsV150(SafeTestCaseMixin, APITestCase):
             trusted=True,
             gas_price=1000000000,
             gas_token=NULL_ADDRESS,
+            payment=21000000000000,
         )
         ERC20TransferFactory(
             ethereum_tx=ethereum_tx_erc20,
@@ -5041,8 +5042,8 @@ class TestViewsV150(SafeTestCaseMixin, APITestCase):
         self.assertEqual(result["gasToken"], NULL_ADDRESS)
         self.assertIsNone(result["gasTokenSymbol"])
         self.assertIsNone(result["gasTokenDecimals"])
-        self.assertIsNotNone(result["fee"])
-        self.assertTrue(int(result["fee"]) > 0)
+        self.assertIsNotNone(result["payment"])
+        self.assertTrue(int(result["payment"]) > 0)
 
         # Case 2: ERC721 transfer with GTF, gas_token = NULL_ADDRESS
         ethereum_tx_erc721 = EthereumTxFactory(gas_used=21000)
@@ -5052,6 +5053,7 @@ class TestViewsV150(SafeTestCaseMixin, APITestCase):
             trusted=True,
             gas_price=1000000000,
             gas_token=NULL_ADDRESS,
+            payment=21000000000000,
         )
         ERC721TransferFactory(
             ethereum_tx=ethereum_tx_erc721,
@@ -5070,7 +5072,7 @@ class TestViewsV150(SafeTestCaseMixin, APITestCase):
         self.assertEqual(erc721_result["gasToken"], NULL_ADDRESS)
         self.assertIsNone(erc721_result["gasTokenSymbol"])
         self.assertIsNone(erc721_result["gasTokenDecimals"])
-        self.assertIsNotNone(erc721_result["fee"])
+        self.assertIsNotNone(erc721_result["payment"])
 
         # Case 3: Native ETH transfer with GTF, gas_token = NULL_ADDRESS
         ethereum_tx_native = EthereumTxFactory(gas_used=21000)
@@ -5082,6 +5084,7 @@ class TestViewsV150(SafeTestCaseMixin, APITestCase):
             gas_token=NULL_ADDRESS,
             to=self.external_address,
             value=1000000000000000000,
+            payment=21000000000000,
         )
         InternalTxFactory(
             ethereum_tx=ethereum_tx_native,
@@ -5099,7 +5102,7 @@ class TestViewsV150(SafeTestCaseMixin, APITestCase):
         self.assertEqual(native_result["gasToken"], NULL_ADDRESS)
         self.assertIsNone(native_result["gasTokenSymbol"])
         self.assertIsNone(native_result["gasTokenDecimals"])
-        self.assertIsNotNone(native_result["fee"])
+        self.assertIsNotNone(native_result["payment"])
 
         # Case 4: standalone incoming transfer (no multisig tx) → all four gas fee fields are null
         ethereum_tx_standalone = EthereumTxFactory()
@@ -5119,7 +5122,7 @@ class TestViewsV150(SafeTestCaseMixin, APITestCase):
         ]
         self.assertEqual(len(standalone_results), 1)
         standalone = standalone_results[0]
-        self.assertIsNone(standalone["fee"])
+        self.assertIsNone(standalone["payment"])
         self.assertIsNone(standalone["gasTokenSymbol"])
         self.assertIsNone(standalone["gasTokenDecimals"])
 
@@ -5134,6 +5137,7 @@ class TestViewsV150(SafeTestCaseMixin, APITestCase):
             trusted=True,
             gas_price=1000000000,
             gas_token=gas_token.address,
+            payment=21000000000000,
         )
         ERC20TransferFactory(
             ethereum_tx=ethereum_tx_erc20_gas,
@@ -5156,7 +5160,47 @@ class TestViewsV150(SafeTestCaseMixin, APITestCase):
         self.assertEqual(usdc_result["gasToken"], gas_token.address)
         self.assertEqual(usdc_result["gasTokenSymbol"], "USDC")
         self.assertEqual(usdc_result["gasTokenDecimals"], 6)
-        self.assertIsNotNone(usdc_result["fee"])
+        self.assertIsNotNone(usdc_result["payment"])
+
+    def test_export_view_incoming_transfer_from_safe_payment_is_null(self):
+        """
+        When Safe B receives a transfer from Safe A, the multisig transaction
+        belongs to Safe A. Safe B's export should show null for payment, gas_token,
+        gas_token_symbol and gas_token_decimals (case: Safe-to-Safe transfer).
+        """
+        self._setup_export_tests()
+
+        sender_safe_address = Account.create().address
+        ethereum_tx = EthereumTxFactory(gas_used=21000)
+        # Multisig tx belongs to the sender Safe, not the queried Safe
+        MultisigTransactionFactory(
+            safe=sender_safe_address,
+            ethereum_tx=ethereum_tx,
+            trusted=True,
+            gas_price=1000000000,
+            gas_token=NULL_ADDRESS,
+            payment=21000000000000,
+        )
+        # ERC20TransferFactory already registers SafeRelevantTransaction for both _from and to
+        ERC20TransferFactory(
+            ethereum_tx=ethereum_tx,
+            address=self.token.address,
+            _from=sender_safe_address,
+            to=self.safe_address,
+            value=500000000000000000,
+        )
+
+        response = self.client.get(
+            reverse("v1:history:safe-export", args=(self.safe_address,)), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        self.assertIsNone(result["payment"])
+        self.assertIsNone(result["gasToken"])
+        self.assertIsNone(result["gasTokenSymbol"])
+        self.assertIsNone(result["gasTokenDecimals"])
 
 
 class TestViewsV141(TestViewsV150):

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -5011,6 +5011,153 @@ class TestViewsV150(SafeTestCaseMixin, APITestCase):
         self.assertEqual(result["transactionHash"], ethereum_tx.tx_hash)
         # Standalone transfers should not have safe_tx_hash
 
+    def test_export_view_gas_fee_fields(self):
+        """Test that gas fee fields are populated for GTF transactions and null otherwise."""
+        self._setup_export_tests()
+
+        # Case 1: ERC20 transfer with GTF, gas_token = NULL_ADDRESS (native ETH)
+        ethereum_tx_erc20 = EthereumTxFactory(gas_used=21000)
+        MultisigTransactionFactory(
+            safe=self.safe_address,
+            ethereum_tx=ethereum_tx_erc20,
+            trusted=True,
+            gas_price=1000000000,
+            gas_token=NULL_ADDRESS,
+        )
+        ERC20TransferFactory(
+            ethereum_tx=ethereum_tx_erc20,
+            address=self.token.address,
+            _from=self.safe_address,
+            to=self.external_address,
+            value=1000000000000000000,
+        )
+
+        response = self.client.get(
+            reverse("v1:history:safe-export", args=(self.safe_address,)), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        result = response.json()["results"][0]
+        self.assertEqual(result["assetType"], "erc20")
+        self.assertEqual(result["gasToken"], NULL_ADDRESS)
+        self.assertIsNone(result["gasTokenSymbol"])
+        self.assertIsNone(result["gasTokenDecimals"])
+        self.assertIsNotNone(result["fee"])
+        self.assertTrue(int(result["fee"]) > 0)
+
+        # Case 2: ERC721 transfer with GTF, gas_token = NULL_ADDRESS
+        ethereum_tx_erc721 = EthereumTxFactory(gas_used=21000)
+        MultisigTransactionFactory(
+            safe=self.safe_address,
+            ethereum_tx=ethereum_tx_erc721,
+            trusted=True,
+            gas_price=1000000000,
+            gas_token=NULL_ADDRESS,
+        )
+        ERC721TransferFactory(
+            ethereum_tx=ethereum_tx_erc721,
+            address=self.nft_token.address,
+            _from=self.safe_address,
+            to=self.external_address,
+            token_id=999,
+        )
+
+        response = self.client.get(
+            reverse("v1:history:safe-export", args=(self.safe_address,)), format="json"
+        )
+        erc721_result = next(
+            r for r in response.json()["results"] if r["assetType"] == "erc721"
+        )
+        self.assertEqual(erc721_result["gasToken"], NULL_ADDRESS)
+        self.assertIsNone(erc721_result["gasTokenSymbol"])
+        self.assertIsNone(erc721_result["gasTokenDecimals"])
+        self.assertIsNotNone(erc721_result["fee"])
+
+        # Case 3: Native ETH transfer with GTF, gas_token = NULL_ADDRESS
+        ethereum_tx_native = EthereumTxFactory(gas_used=21000)
+        MultisigTransactionFactory(
+            safe=self.safe_address,
+            ethereum_tx=ethereum_tx_native,
+            trusted=True,
+            gas_price=1000000000,
+            gas_token=NULL_ADDRESS,
+            to=self.external_address,
+            value=1000000000000000000,
+        )
+        InternalTxFactory(
+            ethereum_tx=ethereum_tx_native,
+            _from=self.safe_address,
+            to=self.external_address,
+            value=1000000000000000000,
+        )
+
+        response = self.client.get(
+            reverse("v1:history:safe-export", args=(self.safe_address,)), format="json"
+        )
+        native_result = next(
+            r for r in response.json()["results"] if r["assetType"] == "native"
+        )
+        self.assertEqual(native_result["gasToken"], NULL_ADDRESS)
+        self.assertIsNone(native_result["gasTokenSymbol"])
+        self.assertIsNone(native_result["gasTokenDecimals"])
+        self.assertIsNotNone(native_result["fee"])
+
+        # Case 4: standalone incoming transfer (no multisig tx) → all four gas fee fields are null
+        ethereum_tx_standalone = EthereumTxFactory()
+        ERC20TransferFactory(
+            ethereum_tx=ethereum_tx_standalone,
+            address=self.token.address,
+            _from=self.external_address,
+            to=self.safe_address,
+            value=500000000000000000,
+        )
+
+        response = self.client.get(
+            reverse("v1:history:safe-export", args=(self.safe_address,)), format="json"
+        )
+        standalone_results = [
+            r for r in response.json()["results"] if r["gasToken"] is None
+        ]
+        self.assertEqual(len(standalone_results), 1)
+        standalone = standalone_results[0]
+        self.assertIsNone(standalone["fee"])
+        self.assertIsNone(standalone["gasTokenSymbol"])
+        self.assertIsNone(standalone["gasTokenDecimals"])
+
+        # Case 5: GTF with ERC20 token as gas_token
+        gas_token = TokenFactory(
+            address=Account.create().address, symbol="USDC", decimals=6
+        )
+        ethereum_tx_erc20_gas = EthereumTxFactory(gas_used=21000)
+        MultisigTransactionFactory(
+            safe=self.safe_address,
+            ethereum_tx=ethereum_tx_erc20_gas,
+            trusted=True,
+            gas_price=1000000000,
+            gas_token=gas_token.address,
+        )
+        ERC20TransferFactory(
+            ethereum_tx=ethereum_tx_erc20_gas,
+            address=self.token.address,
+            _from=self.safe_address,
+            to=self.external_address,
+            value=100000000000000000,
+        )
+
+        response = self.client.get(
+            reverse("v1:history:safe-export", args=(self.safe_address,)), format="json"
+        )
+        usdc_results = [
+            r
+            for r in response.json()["results"]
+            if r.get("gasToken") == gas_token.address
+        ]
+        self.assertEqual(len(usdc_results), 1)
+        usdc_result = usdc_results[0]
+        self.assertEqual(usdc_result["gasToken"], gas_token.address)
+        self.assertEqual(usdc_result["gasTokenSymbol"], "USDC")
+        self.assertEqual(usdc_result["gasTokenDecimals"], 6)
+        self.assertIsNotNone(usdc_result["fee"])
+
 
 class TestViewsV141(TestViewsV150):
     """


### PR DESCRIPTION
- Related with https://linear.app/safe-global/issue/PLA-1419/history-csv-export-should-contain-paid-from-the-safe-info#comment-9b93eec1

## Summary                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                          
  - Adds `gas_token`, `fee`, `gas_token_symbol` and `gas_token_decimals` to the                                                                                                                                                                                                                                           
    `/api/v1/safes/{address}/export/` response (PLA-1419)
  - Follows the same semantics as `/api/v1/multisig-transactions/`: `gas_token`                                                                                                                                                                                                                                           
    is always returned when a multisig transaction exists (null for incoming or                                                                                                                                                                                                                                           
    standalone transfers); ~`fee` is `gas_used × eth_gas_price`~ payment, null when either                                                                                                                                                                                                                                          
    is not available                                                                                                                                                                                                                                                                                                      
  - `gas_token_symbol` and `gas_token_decimals` are resolved via the tokens table                                                                                                                                                                                                                                         
    (same pattern as the existing `asset_symbol`/`asset_decimals` fields),                                                                                                                                                                                                                                                
    allowing the gateway to call `formatUnits(fee, gas_token_decimals)` without
    additional lookups.