### PR TITLE
feat: Publish events to topic exchange with routing keys (PLA-1466)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -688,7 +688,13 @@ SLACK_API_WEBHOOK = env("SLACK_API_WEBHOOK", default=None)
 # Events
 # ------------------------------------------------------------------------------
 EVENTS_QUEUE_URL = env("EVENTS_QUEUE_URL", default=None)
-EVENTS_QUEUE_EXCHANGE_NAME = env("EVENTS_QUEUE_EXCHANGE_NAME", default="amq.fanout")
+EVENTS_QUEUE_EXCHANGE_NAME = env(
+    "EVENTS_QUEUE_EXCHANGE_NAME", default="safe-transaction-service-events"
+)
+EVENTS_QUEUE_TOPIC_EXCHANGE_NAME = env(
+    "EVENTS_QUEUE_TOPIC_EXCHANGE_NAME",
+    default="safe-transaction-service-events-with-topics",
+)
 EVENTS_QUEUE_POOL_CONNECTIONS_LIMIT = env.int(
     "EVENTS_QUEUE_POOL_CONNECTIONS_LIMIT", default=20
 )

--- a/safe_transaction_service/events/services/queue_service.py
+++ b/safe_transaction_service/events/services/queue_service.py
@@ -15,7 +15,17 @@ logger = logging.getLogger(__name__)
 
 class QueueService:
     def __init__(self):
+        # Topic exchange — events are published here so consumers can subscribe
+        # by routing-key pattern. Routing keys are "{chainId}.{type}.{address}".
         self.exchange = Exchange(
+            settings.EVENTS_QUEUE_TOPIC_EXCHANGE_NAME,
+            type="topic",
+            durable=True,
+        )
+        # Legacy fanout exchange. Existing consumers stay bound to it; we bind
+        # it downstream of the topic exchange (routing_key="#") so every event
+        # still reaches them while consumers migrate to topic-based bindings.
+        self.legacy_exchange = Exchange(
             settings.EVENTS_QUEUE_EXCHANGE_NAME,
             type="fanout",
             durable=True,
@@ -24,9 +34,63 @@ class QueueService:
         limit = settings.EVENTS_QUEUE_POOL_CONNECTIONS_LIMIT
         if limit:
             producers[self.connection].limit = limit
-        self.unsent_events: list[bytes] = []
+        self.unsent_events: list[tuple[bytes, str]] = []
+        self._ensure_legacy_binding()
 
-    def _try_publish(self, event: bytes) -> bool:
+    def _ensure_legacy_binding(self) -> None:
+        """
+        Declare both exchanges and bind the legacy fanout exchange as a
+        destination of the topic exchange (``routing_key="#"``) so existing
+        fanout consumers keep receiving every event during the migration to
+        topic-based bindings.
+
+        Called once from ``__init__``. Forces the connection to open and
+        re-raises any broker error so the operator is alerted rather than
+        silently dropping events for legacy consumers — the ``@cache`` on
+        ``get_queue_service`` does not cache exceptions, so a subsequent
+        event will retry construction.
+
+        :raises Exception: Re-raises any broker error from declaring the
+            exchanges or creating the exchange-to-exchange binding.
+        """
+        try:
+            with self.connection.channel() as channel:
+                self.exchange(channel).declare()
+                self.legacy_exchange(channel).declare()
+                self.legacy_exchange(channel).bind_to(
+                    exchange=self.exchange, routing_key="#"
+                )
+        except Exception as exc:
+            logger.error(
+                "Could not bind legacy fanout exchange to topic exchange: %s",
+                exc,
+                exc_info=True,
+            )
+            raise
+
+    @staticmethod
+    def _build_routing_key(payload: dict[str, Any]) -> str:
+        """
+        Build the topic-exchange routing key for an event payload.
+
+        The key has the format ``{chainId}.{type}.{address}``, where each part
+        is a single AMQP word (no ``.``). Missing parts are replaced with ``_``
+        so the key always has three segments — this keeps ``*``-wildcard
+        bindings (which match exactly one word) usable by consumers. The
+        address segment is lower-cased so consumer bindings can ignore the
+        EIP-55 checksum casing of the payload.
+
+        :param payload: Event payload as produced by ``build_event_payload`` /
+            ``build_*_delegate_payload`` / ``build_reorg_payload``.
+        :return: Routing key ready to pass to ``producer.publish``.
+        """
+        chain_id = payload.get("chainId") or "_"
+        event_type = payload.get("type") or "_"
+        address = payload.get("address")
+        address_part = address.lower() if address else "_"
+        return f"{chain_id}.{event_type}.{address_part}"
+
+    def _try_publish(self, event: bytes, routing_key: str) -> bool:
         """Attempt to publish one pre-serialized JSON event. Returns True on success."""
         try:
             with producers[self.connection].acquire(block=False) as producer:
@@ -34,13 +98,14 @@ class QueueService:
                     event,
                     exchange=self.exchange,
                     declare=[self.exchange],
+                    routing_key=routing_key,
                     content_type="application/json",
                     content_encoding="utf-8",
                     retry=True,
                     retry_policy={"max_retries": 1, "interval_start": 0},
                     serializer="raw",
                 )
-            logger.debug("Event sent: %s", event)
+            logger.debug("Event sent with routing_key=%s: %s", routing_key, event)
             return True
         except OperationalError:
             logger.debug("Connection pool exhausted, buffering event")
@@ -57,9 +122,10 @@ class QueueService:
         :return: number of events published (1 + any flushed unsent)
         """
         event: bytes = orjson.dumps(payload)
-        if not self._try_publish(event):
+        routing_key = self._build_routing_key(payload)
+        if not self._try_publish(event, routing_key):
             logger.debug("Adding %s to unsent messages", payload)
-            self.unsent_events.append(event)
+            self.unsent_events.append((event, routing_key))
             return 0
         return 1 + self.send_unsent_events()
 
@@ -75,11 +141,11 @@ class QueueService:
         self.unsent_events = []
         total = 0
         logger.info("Sending %d previously unsent messages", len(unsent))
-        for i, event in enumerate(unsent):
-            if self._try_publish(event):
+        for i, (event, routing_key) in enumerate(unsent):
+            if self._try_publish(event, routing_key):
                 total += 1
             else:
-                self.unsent_events.append(event)
+                self.unsent_events.append((event, routing_key))
                 self.unsent_events.extend(unsent[i + 1 :])
                 logger.info(
                     "Sent %d / %d unsent messages before failure", total, len(unsent)

--- a/safe_transaction_service/events/tests/test_queue_service.py
+++ b/safe_transaction_service/events/tests/test_queue_service.py
@@ -3,7 +3,7 @@ import json
 from unittest import mock
 
 from django.conf import settings
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from kombu import Connection, Exchange, Queue
 
@@ -79,3 +79,64 @@ class TestQueueService(TestCase):
         result = queue_service.send_event({"message": "recovered"})
         self.assertEqual(result, 2)
         self.assertEqual(len(queue_service.unsent_events), 0)
+
+
+class TestBuildRoutingKey(SimpleTestCase):
+    """
+    The routing key is the contract consumers bind their queues against,
+    so its shape must stay stable. These tests pin the format.
+    """
+
+    def test_full_payload_renders_chainid_type_address(self):
+        payload = {
+            "chainId": "1",
+            "type": "EXECUTED_MULTISIG_TRANSACTION",
+            "address": "0x1234567890abcdef1234567890abcdef12345678",
+        }
+        self.assertEqual(
+            QueueService._build_routing_key(payload),
+            "1.EXECUTED_MULTISIG_TRANSACTION."
+            "0x1234567890abcdef1234567890abcdef12345678",
+        )
+
+    def test_address_is_lowercased_for_case_insensitive_bindings(self):
+        # Payloads can carry EIP-55 checksum-cased addresses, but consumers
+        # bind with a fixed casing — lowercase the address segment so the
+        # routing key is stable regardless of how the payload was built.
+        key = QueueService._build_routing_key(
+            {
+                "chainId": "1",
+                "type": "MODULE_TRANSACTION",
+                "address": "0xABCDef0000000000000000000000000000000000",
+            }
+        )
+        self.assertEqual(
+            key,
+            "1.MODULE_TRANSACTION.0xabcdef0000000000000000000000000000000000",
+        )
+
+    def test_missing_address_uses_placeholder_to_preserve_three_segments(self):
+        # A topic-exchange `*` matches exactly one word. If we emitted
+        # "1.REORG_DETECTED." (trailing empty segment), bindings like
+        # "*.*.0x..." would no longer match anything. The "_" placeholder
+        # keeps the segment count at 3 so wildcard bindings work uniformly.
+        self.assertEqual(
+            QueueService._build_routing_key({"chainId": "1", "type": "REORG_DETECTED"}),
+            "1.REORG_DETECTED._",
+        )
+
+    def test_none_address_is_treated_as_missing(self):
+        # SafeContractDelegate without a safe_contract_id produces a payload
+        # with address=None; it must not blow up or end up as "none" in the
+        # routing key.
+        self.assertEqual(
+            QueueService._build_routing_key(
+                {"chainId": "1", "type": "NEW_DELEGATE", "address": None}
+            ),
+            "1.NEW_DELEGATE._",
+        )
+
+    def test_empty_payload_returns_all_placeholders(self):
+        # Defensive: an unexpected/empty payload must still produce a valid
+        # 3-segment routing key so the publish call does not crash.
+        self.assertEqual(QueueService._build_routing_key({}), "_._._")


### PR DESCRIPTION
Switch the events producer from a fanout-only setup to a topic exchange so consumers can subscribe to specific event types / chains / safes instead of filtering every message in application code.

Routing key format:
- `"{chainId}.{type}.{address}" `(address lower-cased, "_" placeholder when absent).

The legacy fanout exchange is bound downstream of the topic exchange with routing_key="#" on first publish (idempotent), so existing consumers keep receiving every event during the migration window with no producer-side duplication or loss. Once consumers have migrated their bindings, the legacy exchange can be removed.
