### PR TITLE
feat: Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,9 +4,15 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, closed, synchronize]
+permissions: {}
 
 jobs:
   CLAAssistant:
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - name: 'CLA Assistant'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,10 +9,7 @@ permissions: {}
 jobs:
   CLAAssistant:
     permissions:
-      actions: write
       contents: read
-      pull-requests: write
-      statuses: write
     runs-on: ubuntu-latest
     steps:
       - name: 'CLA Assistant'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,7 +36,6 @@ jobs:
   test-app:
     permissions:
       contents: read
-      statuses: write
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,9 +7,12 @@ on:
   pull_request:
   release:
     types: [ released ]
+permissions: {}
 
 jobs:
   linting:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -31,6 +34,9 @@ jobs:
           SKIP: insert-license
 
   test-app:
+    permissions:
+      contents: read
+      statuses: write
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -105,6 +111,8 @@ jobs:
       with:
         file: coverage.lcov
   docker-deploy:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs:
       - linting
@@ -163,6 +171,8 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
   autodeploy:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [docker-deploy]
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'


### PR DESCRIPTION
Set permissions: {} at the workflow level (deny-all) and grant least-privilege scopes per job

### Make sure these boxes are checked! 📦✅

- [ ] You ran `./run_tests.sh`
- [ ] You ran `pre-commit run -a`
- [ ] If you want to add your network to `setup_service.py`, provide a link to your
    [safe-deployments PR](https://github.com/safe-global/safe-deployments/pulls) and check network name
    exists in [safe-eth-py](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py)

### What was wrong? 👾

Closes #

### How was it fixed? 🎯
