### PR TITLE
fix: Auto-adjust block range and tolerate RPC errors during reindex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,9 @@ It is the preferred place to capture shared context and expectations.
 ## Indexer Architecture (Summary)
 This repository includes multiple indexers under `safe_transaction_service/history/indexers/`.
 
+## Linear
+- All tickets go into `PLATFORM` team and with labels `Backend` and `Transaction Service`
+
 ### Base Classes
 - `ethereum_indexer.py`
   - Orchestrates block range selection and indexing flow.
@@ -35,7 +38,7 @@ This repository includes multiple indexers under `safe_transaction_service/histo
   - Indexes Safe `ProxyCreation` events, inserts `SafeContract`.
 
 ### Key Behavioral Constraints (Must Preserve)
-- L1 uses `InternalTxIndexer` and L2 uses `SafeEventsIndexer`. They do not run in parallel.
+- L1 uses `InternalTxIndexer` and L2 uses `SafeEventsIndexer`. They never run in parallel.
 - Internal traces are matched only by `SafeMasterCopy` addresses (no other address list).
 - `EthereumTx` should not exist without at least one related table row.
 - Do not index errored transactions.
@@ -54,7 +57,8 @@ This repository includes multiple indexers under `safe_transaction_service/histo
 
 ## Testing
 - Virtualenv is managed by uv at `.venv`. Activate with `source .venv/bin/activate` or prefix commands with `uv run`.
-- Use `pytest` (no parameters). It should auto-detect configuration.
+- Dependencies must be up before running tests: `docker compose --profile develop up db redis ganache rabbitmq -d`
+- Use `pytest` (no parameters). It should auto-detect configuration. `DJANGO_SETTINGS_MODULE=config.settings.test uv run python -m pytest``
 - Use factories (e.g. `SafeContractFactory`) instead of inline helpers or `get_or_create` calls in tests.
 
 ## Performance Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ This repository includes multiple indexers under `safe_transaction_service/histo
 ## Testing
 - Virtualenv is managed by uv at `.venv`. Activate with `source .venv/bin/activate` or prefix commands with `uv run`.
 - Dependencies must be up before running tests: `docker compose --profile develop up db redis ganache rabbitmq -d`
-- Use `pytest` (no parameters). It should auto-detect configuration. `DJANGO_SETTINGS_MODULE=config.settings.test uv run python -m pytest``
+- Use `pytest` (no parameters). It should auto-detect configuration. `DJANGO_SETTINGS_MODULE=config.settings.test uv run python -m pytest`
 - Use factories (e.g. `SafeContractFactory`) instead of inline helpers or `get_or_create` calls in tests.
 
 ## Performance Conventions

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -631,6 +631,9 @@ ETH_REORG_BLOCKS_BATCH = env.int(
 ETH_REORG_BLOCKS = env.int(
     "ETH_REORG_BLOCKS", default=200 if ETH_L2_NETWORK else 10
 )  # Number of blocks from the current block number needed to consider a block valid/stable
+ETH_REINDEX_MAX_RETRIES = env.int(
+    "ETH_REINDEX_MAX_RETRIES", default=5
+)  # Number of consecutive failures of the same block range during reindex
 ETH_ERC20_LOAD_ADDRESSES_CHUNK_SIZE = env.int(
     "ETH_ERC20_LOAD_ADDRESSES_CHUNK_SIZE", default=500_000
 )  # Load Safe addresses for the ERC20 indexer with a database iterator with the defined `chunk_size`

--- a/safe_transaction_service/history/indexers/events_indexer.py
+++ b/safe_transaction_service/history/indexers/events_indexer.py
@@ -16,7 +16,7 @@ from gevent import pool
 from hexbytes import HexBytes
 from safe_eth.util.util import to_0x_hex_str
 from web3.contract.contract import ContractEvent
-from web3.exceptions import LogTopicError
+from web3.exceptions import LogTopicError, Web3RPCError
 from web3.types import EventData, FilterParams, LogReceipt
 
 from safe_transaction_service.utils.utils import chunks
@@ -149,18 +149,13 @@ class EventsIndexer(EthereumIndexer):
 
         try:
             return self._do_node_query(addresses, from_block_number, to_block_number)
-        except OSError as e:
-            raise FindRelevantElementsException(
-                f"Request error retrieving events "
-                f"from-block={from_block_number} to-block={to_block_number}"
-            ) from e
-        except ValueError as e:
+        except (OSError, ValueError, Web3RPCError) as e:
             # For example, Polygon returns:
             #   ValueError({'code': -32005, 'message': 'eth_getLogs block range too large, range: 138001, max: 100000'})
             # BSC returns:
             #   ValueError({'code': -32000, 'message': 'exceed maximum block range: 5000'})
             logger.warning(
-                "%s: Value error retrieving events from-block=%d to-block=%d : %s",
+                "%s: Error retrieving events from-block=%d to-block=%d : %s",
                 self.__class__.__name__,
                 from_block_number,
                 to_block_number,

--- a/safe_transaction_service/history/indexers/internal_tx_indexer.py
+++ b/safe_transaction_service/history/indexers/internal_tx_indexer.py
@@ -10,6 +10,7 @@ from eth_typing import ChecksumAddress, HexStr
 from hexbytes import HexBytes
 from safe_eth.eth import EthereumClient
 from safe_eth.util.util import to_0x_hex_str
+from web3.exceptions import Web3RPCError
 from web3.types import BlockTrace, FilterTrace
 
 from safe_transaction_service.contracts.tx_decoder import (
@@ -170,7 +171,7 @@ class InternalTxIndexer(EthereumIndexer):
                     del traces[tx_hash]
 
             return traces
-        except OSError as e:
+        except (OSError, ValueError, Web3RPCError) as e:
             raise FindRelevantElementsException(
                 "Request error calling `trace_block`"
             ) from e
@@ -203,15 +204,11 @@ class InternalTxIndexer(EthereumIndexer):
                     to_block=to_block_number,
                     to_address=list(addresses),
                 )
-        except OSError as e:
-            raise FindRelevantElementsException(
-                "Request error calling `trace_filter`"
-            ) from e
-        except ValueError as e:
+        except (OSError, ValueError, Web3RPCError) as e:
             # For example, Infura returns:
             #   ValueError: {'code': -32005, 'data': {'from': '0x6BBCE1', 'limit': 10000, 'to': '0x7072DB'}, 'message': 'query returned more than 10000 results. Try with this block range [0x6BBCE1, 0x7072DB].'}
             logger.warning(
-                "%s: Value error retrieving trace_filter results from-block=%d to-block=%d : %s",
+                "%s: Error retrieving trace_filter results from-block=%d to-block=%d : %s",
                 self.__class__.__name__,
                 from_block_number,
                 to_block_number,

--- a/safe_transaction_service/history/management/commands/reindex_master_copies.py
+++ b/safe_transaction_service/history/management/commands/reindex_master_copies.py
@@ -21,8 +21,9 @@ class Command(BaseCommand):
         parser.add_argument(
             "--block-process-limit",
             type=int,
-            help="Number of blocks to query each time",
-            default=100,
+            help="Initial number of blocks to query each time. "
+            "If not provided, the indexer's configured value is used and auto-adjust drives it from there.",
+            required=False,
         )
         parser.add_argument(
             "--from-block-number",
@@ -35,7 +36,11 @@ class Command(BaseCommand):
         block_process_limit = options["block_process_limit"]
         from_block_number = options["from_block_number"]
         addresses = options["addresses"]
-        if addresses and not from_block_number:
+        if from_block_number is None:
+            if not addresses:
+                raise CommandError(
+                    "--from-block-number must be set if --addresses are not provided"
+                )
             from_block_number = SafeContract.objects.get_minimum_creation_block_number(
                 addresses
             )
@@ -46,17 +51,13 @@ class Command(BaseCommand):
             self.stdout.write(
                 self.style.SUCCESS(f"Setting from-block-number to {from_block_number}")
             )
-        elif not from_block_number:
-            raise CommandError(
-                "--from-block-number must be set if --addresses are not provided"
-            )
 
-        self.stdout.write(
-            self.style.SUCCESS(f"Setting block-process-limit to {block_process_limit}")
-        )
-        self.stdout.write(
-            self.style.SUCCESS(f"Setting from-block-number to {from_block_number}")
-        )
+        if block_process_limit is not None:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Setting block-process-limit to {block_process_limit}"
+                )
+            )
 
         self.reindex(from_block_number, block_process_limit, addresses)
 

--- a/safe_transaction_service/history/services/index_service.py
+++ b/safe_transaction_service/history/services/index_service.py
@@ -77,6 +77,7 @@ class IndexServiceProvider:
                 settings.ETH_L2_NETWORK,
                 settings.ETH_INTERNAL_TX_DECODED_PROCESS_BATCH,
                 settings.PROCESSING_ENABLE_OUT_OF_ORDER_CHECK,
+                settings.ETH_REINDEX_MAX_RETRIES,
             )
         return cls.instance
 
@@ -94,6 +95,7 @@ class IndexService:
         eth_l2_network: bool,
         eth_internal_tx_decoded_process_batch: int,
         processing_enable_out_of_order_check: bool,
+        eth_reindex_max_retries: int,
     ):
         self.ethereum_client = ethereum_client
         self.eth_reorg_blocks = eth_reorg_blocks
@@ -102,6 +104,7 @@ class IndexService:
             eth_internal_tx_decoded_process_batch
         )
         self.processing_enable_out_of_order_check = processing_enable_out_of_order_check
+        self.eth_reindex_max_retries = eth_reindex_max_retries
 
         # Prevent circular import
         from ..indexers.tx_processor import SafeTxProcessor, SafeTxProcessorProvider
@@ -624,6 +627,7 @@ class IndexService:
 
         element_number: int = 0
         block_number = from_block_number
+        consecutive_failures = 0
         while block_number <= stop_block_number:
             chunk_to = min(
                 block_number + indexer.block_process_limit - 1, stop_block_number
@@ -636,7 +640,22 @@ class IndexService:
             except FindRelevantElementsException as exc:
                 # Mirror `EthereumIndexer.process_addresses` recovery: drop the
                 # window to the minimum and retry the same range. Auto-adjust
-                # will grow it back as requests succeed.
+                # will grow it back as requests succeed. Abort if the same
+                # single-block range keeps failing, so we surface bad blocks
+                # / node bugs instead of looping forever.
+                consecutive_failures += 1
+                if (
+                    indexer.block_process_limit == 1
+                    and consecutive_failures >= self.eth_reindex_max_retries
+                ):
+                    logger.error(
+                        "Block range [%d, %d] failed %d consecutive times at "
+                        "block_process_limit=1, aborting reindex",
+                        block_number,
+                        chunk_to,
+                        consecutive_failures,
+                    )
+                    raise
                 logger.warning(
                     "Error reindexing block range [%d, %d]: %s. "
                     "Retrying with block_process_limit=1",
@@ -647,6 +666,7 @@ class IndexService:
                 indexer.block_process_limit = 1
                 continue
 
+            consecutive_failures = 0
             logger.info(
                 "Reindexed block range [%d, %d], found %d traces/events",
                 block_number,

--- a/safe_transaction_service/history/services/index_service.py
+++ b/safe_transaction_service/history/services/index_service.py
@@ -578,17 +578,21 @@ class IndexService:
         indexer: "EthereumIndexer",  # noqa F821
         from_block_number: int,
         to_block_number: int | None = None,
-        block_process_limit: int = 100,
+        block_process_limit: int | None = None,
         addresses: Collection[ChecksumAddress] | None = None,
     ) -> int:
         """
         :param indexer: A new instance must be provider, providing the singleton one can break indexing
         :param from_block_number:
         :param to_block_number:
-        :param block_process_limit:
+        :param block_process_limit: Initial chunk size. If ``None``, the indexer's
+            configured ``block_process_limit`` is used. The indexer's auto-adjust
+            mechanism may grow or shrink the limit during the run.
         :param addresses:
         :return: Number of reindexed elements
         """
+        from ..indexers import FindRelevantElementsException
+
         assert (not to_block_number) or to_block_number > from_block_number
 
         if addresses:
@@ -598,49 +602,68 @@ class IndexService:
         else:
             addresses = set(indexer.database_queryset.values_list("address", flat=True))
 
-        element_number: int = 0
         if not addresses:
             logger.warning("No addresses to process")
-        else:
-            # Don't log all the addresses
-            addresses_len = len(addresses)
-            addresses_str = (
-                str(addresses)
-                if addresses_len < 10
-                else f"{addresses_len} addresses..."
+            return 0
+
+        if block_process_limit is not None:
+            indexer.block_process_limit = block_process_limit
+
+        # Don't log all the addresses
+        addresses_len = len(addresses)
+        addresses_str = (
+            str(addresses) if addresses_len < 10 else f"{addresses_len} addresses..."
+        )
+        logger.info("Start reindexing addresses %s", addresses_str)
+        current_block_number = self.ethereum_client.current_block_number
+        stop_block_number = (
+            min(current_block_number, to_block_number)
+            if to_block_number
+            else current_block_number
+        )
+
+        element_number: int = 0
+        block_number = from_block_number
+        while block_number <= stop_block_number:
+            chunk_to = min(
+                block_number + indexer.block_process_limit - 1, stop_block_number
             )
-            logger.info("Start reindexing addresses %s", addresses_str)
-            current_block_number = self.ethereum_client.current_block_number
-            stop_block_number = (
-                min(current_block_number, to_block_number)
-                if to_block_number
-                else current_block_number
-            )
-            for block_number in range(
-                from_block_number, stop_block_number + 1, block_process_limit
-            ):
+            try:
                 elements = indexer.find_relevant_elements(
-                    addresses,
-                    block_number,
-                    min(block_number + block_process_limit - 1, stop_block_number),
+                    addresses, block_number, chunk_to
                 )
                 indexer.process_elements(elements)
-                logger.info(
-                    "Current block number %d, found %d traces/events",
+            except FindRelevantElementsException as exc:
+                # Mirror `EthereumIndexer.process_addresses` recovery: drop the
+                # window to the minimum and retry the same range. Auto-adjust
+                # will grow it back as requests succeed.
+                logger.warning(
+                    "Error reindexing block range [%d, %d]: %s. "
+                    "Retrying with block_process_limit=1",
                     block_number,
-                    len(elements),
+                    chunk_to,
+                    exc,
                 )
-                element_number += len(elements)
+                indexer.block_process_limit = 1
+                continue
 
-            logger.info("End reindexing addresses %s", addresses_str)
+            logger.info(
+                "Reindexed block range [%d, %d], found %d traces/events",
+                block_number,
+                chunk_to,
+                len(elements),
+            )
+            element_number += len(elements)
+            block_number = chunk_to + 1
 
+        logger.info("End reindexing addresses %s", addresses_str)
         return element_number
 
     def reindex_master_copies(
         self,
         from_block_number: int,
         to_block_number: int | None = None,
-        block_process_limit: int = 100,
+        block_process_limit: int | None = None,
         addresses: Collection[ChecksumAddress] | None = None,
     ) -> int:
         """
@@ -649,7 +672,8 @@ class IndexService:
 
         :param from_block_number: Block number to start indexing from
         :param to_block_number: Block number to stop indexing on
-        :param block_process_limit: Number of blocks to process each time
+        :param block_process_limit: Initial number of blocks to process each time.
+            If ``None``, the indexer's configured value is used and auto-adjust drives it from there.
         :param addresses: Master Copy or Safes(for L2 event processing) addresses. If not provided,
             all master copies will be used
         """
@@ -675,7 +699,7 @@ class IndexService:
         self,
         from_block_number: int,
         to_block_number: int | None = None,
-        block_process_limit: int = 100,
+        block_process_limit: int | None = None,
         addresses: Collection[ChecksumAddress] | None = None,
     ) -> int:
         """
@@ -684,7 +708,8 @@ class IndexService:
 
         :param from_block_number: Block number to start indexing from
         :param to_block_number: Block number to stop indexing on
-        :param block_process_limit: Number of blocks to process each time
+        :param block_process_limit: Initial number of blocks to process each time.
+            If ``None``, the indexer's configured value is used and auto-adjust drives it from there.
         :param addresses: Safe addresses. If not provided, all Safe addresses will be used
         """
         assert (not to_block_number) or to_block_number > from_block_number

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -316,6 +316,44 @@ class TestCommands(SafeTestCaseMixin, TestCase):
     @mock.patch.object(
         EthereumClient, "current_block_number", new_callable=PropertyMock
     )
+    def test_reindex_master_copies_without_block_process_limit(
+        self, current_block_number_mock: PropertyMock
+    ):
+        """
+        When ``--block-process-limit`` is not provided the indexer's
+        settings-derived limit must drive the first chunk (so auto-adjust
+        engages from that anchor), and no "Setting block-process-limit"
+        line is printed.
+        """
+        from django.conf import settings
+
+        # Set high enough so the first chunk is not clamped by stop_block_number
+        current_block_number_mock.return_value = 1_000_000
+        safe_master_copy = SafeMasterCopyFactory(l2=False)
+
+        buf = StringIO()
+        with mock.patch.object(
+            InternalTxIndexer, "find_relevant_elements", return_value=[]
+        ) as find_relevant_elements_mock:
+            IndexServiceProvider.del_singleton()
+            from_block_number = 100
+            call_command(
+                "reindex_master_copies",
+                f"--from-block-number={from_block_number}",
+                stdout=buf,
+            )
+            self.assertNotIn("Setting block-process-limit", buf.getvalue())
+            expected_limit = settings.ETH_INTERNAL_TXS_BLOCK_PROCESS_LIMIT
+            find_relevant_elements_mock.assert_any_call(
+                {safe_master_copy.address},
+                from_block_number,
+                from_block_number + expected_limit - 1,
+            )
+        IndexServiceProvider.del_singleton()
+
+    @mock.patch.object(
+        EthereumClient, "current_block_number", new_callable=PropertyMock
+    )
     def test_reindex_erc20_events(self, current_block_number_mock: PropertyMock):
         logger_name = "safe_transaction_service.history.services.index_service"
         current_block_number_mock.return_value = 1000

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -183,7 +183,6 @@ class TestCommands(SafeTestCaseMixin, TestCase):
                 stdout=buf,
             )
             self.assertIn("Setting block-process-limit to 11", buf.getvalue())
-            self.assertIn("Setting from-block-number to 76", buf.getvalue())
             self.assertIn("No addresses to process", cm.output[0])
 
         safe_master_copy = SafeMasterCopyFactory(l2=False)
@@ -337,7 +336,6 @@ class TestCommands(SafeTestCaseMixin, TestCase):
                 stdout=buf,
             )
             self.assertIn("Setting block-process-limit to 11", buf.getvalue())
-            self.assertIn("Setting from-block-number to 76", buf.getvalue())
             self.assertIn("No addresses to process", cm.output[0])
 
         safe_contract = SafeContractFactory()


### PR DESCRIPTION
## Summary
  - `reindex_master_copies` / `reindex_erc20_events` (commands, Celery tasks, and the "last hours" variants) now reuse the live indexer's self-tuning chunk size, so reindex throughput matches regular indexing on the same node.
  - Transient RPC errors (`OSError`, `ValueError`, `Web3RPCError`) no longer abort a reindex run. The chunk is retried with the minimum window, and auto-adjust grows it back as requests succeed — same recovery pattern the live indexer already uses.
  - Minor fixes to the `reindex_master_copies` management command: `--from-block-number 0` is now a valid input, duplicate log line dropped, and `--block-process-limit` becomes optional (falls back to the indexer's configured value).

Closes PLA-1493