### PR TITLE
fix: allow owners registered as delegates to sign with multiple signatures

### DIFF
--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -294,7 +294,12 @@ class SafeMultisigTransactionSerializer(SafeMultisigTxSerializer):
                     f"Signer={owner} is not authorized to interact with the service"
                 )
 
-            if owner in delegates and len(parsed_signatures) > 1:
+            if (
+                owner in delegates
+                # An address that is both owner and delegate is treated as owner
+                and owner not in safe_owners
+                and len(parsed_signatures) > 1
+            ):
                 raise ValidationError(
                     "Just one signature is expected if using delegates"
                 )

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -2290,6 +2290,93 @@ class TestViewsV150(SafeTestCaseMixin, APITestCase):
             response.data["non_field_errors"][0],
         )
 
+    def test_post_multisig_transactions_with_owner_and_delegate(self):
+        """Owner that is also a delegate should be able to sign alongside other owners."""
+        safe_owners = [Account.create() for _ in range(4)]
+        safe_owner_addresses = [s.address for s in safe_owners]
+        # safe_owners[0] will be both an owner and a delegate
+        owner_and_delegate = safe_owners[0]
+        safe = self.deploy_test_safe(owners=safe_owner_addresses, threshold=3)
+        safe_address = safe.address
+
+        to = Account.create().address
+        data = {
+            "to": to,
+            "value": 100000000000000000,
+            "data": None,
+            "operation": 0,
+            "nonce": 0,
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": 0,
+            "gasToken": "0x0000000000000000000000000000000000000000",
+            "refundReceiver": "0x0000000000000000000000000000000000000000",
+            "sender": owner_and_delegate.address,
+            "origin": "Testing origin field",
+        }
+
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        safe_tx_hash = safe_tx.safe_tx_hash
+
+        # Register owner_and_delegate as a delegate for another owner
+        owner_delegate_record = SafeContractDelegateFactory(
+            safe_contract__address=safe_address,
+            delegate=owner_and_delegate.address,
+            delegator=safe_owners[1].address,
+        )
+
+        # Multiple owner signatures including the owner+delegate
+        sig_a = owner_and_delegate.unsafe_sign_hash(safe_tx_hash)["signature"]
+        sig_b = safe_owners[1].unsafe_sign_hash(safe_tx_hash)["signature"]
+        sig_c = safe_owners[2].unsafe_sign_hash(safe_tx_hash)["signature"]
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx_hash)
+        data["signature"] = to_0x_hex_str(sig_a + sig_b + sig_c)
+
+        response = self.client.post(
+            reverse("v1:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        multisig_transaction = MultisigTransaction.objects.get()
+        self.assertTrue(multisig_transaction.trusted)
+        # Sender is an owner, so proposer is the sender directly
+        self.assertEqual(multisig_transaction.proposer, owner_and_delegate.address)
+        self.assertIsNone(multisig_transaction.proposed_by_delegate)
+
+        # A pure delegate (non-owner) with multiple signatures still fails
+        MultisigTransaction.objects.all().delete()
+        pure_delegate = Account.create()
+        SafeContractDelegateFactory(
+            safe_contract=owner_delegate_record.safe_contract,
+            delegate=pure_delegate.address,
+            delegator=safe_owners[2].address,
+        )
+        data["sender"] = pure_delegate.address
+        sig_delegate = pure_delegate.unsafe_sign_hash(safe_tx_hash)["signature"]
+        data["signature"] = to_0x_hex_str(sig_delegate + sig_b)
+        response = self.client.post(
+            reverse("v1:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn(
+            "Just one signature is expected if using delegates",
+            response.data["non_field_errors"][0],
+        )
+
     def test_post_multisig_transactions_with_banned_signatures(self):
         safe_owners = [Account.create() for _ in range(4)]
         safe_owner_addresses = [s.address for s in safe_owners]

--- a/safe_transaction_service/history/tests/test_views_v2.py
+++ b/safe_transaction_service/history/tests/test_views_v2.py
@@ -2044,6 +2044,93 @@ class TestViewsV2V150(SafeTestCaseMixin, APITestCase):
             response.data["non_field_errors"][0],
         )
 
+    def test_post_multisig_transactions_with_owner_and_delegate(self):
+        """Owner that is also a delegate should be able to sign alongside other owners."""
+        safe_owners = [Account.create() for _ in range(4)]
+        safe_owner_addresses = [s.address for s in safe_owners]
+        # safe_owners[0] will be both an owner and a delegate
+        owner_and_delegate = safe_owners[0]
+        safe = self.deploy_test_safe(owners=safe_owner_addresses, threshold=3)
+        safe_address = safe.address
+
+        to = Account.create().address
+        data = {
+            "to": to,
+            "value": 100000000000000000,
+            "data": None,
+            "operation": 0,
+            "nonce": 0,
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": 0,
+            "gasToken": "0x0000000000000000000000000000000000000000",
+            "refundReceiver": "0x0000000000000000000000000000000000000000",
+            "sender": owner_and_delegate.address,
+            "origin": "Testing origin field",
+        }
+
+        safe_tx = safe.build_multisig_tx(
+            data["to"],
+            data["value"],
+            data["data"],
+            data["operation"],
+            data["safeTxGas"],
+            data["baseGas"],
+            data["gasPrice"],
+            data["gasToken"],
+            data["refundReceiver"],
+            safe_nonce=data["nonce"],
+        )
+        safe_tx_hash = safe_tx.safe_tx_hash
+
+        # Register owner_and_delegate as a delegate for another owner
+        owner_delegate_record = SafeContractDelegateFactory(
+            safe_contract__address=safe_address,
+            delegate=owner_and_delegate.address,
+            delegator=safe_owners[1].address,
+        )
+
+        # Multiple owner signatures including the owner+delegate
+        sig_a = owner_and_delegate.unsafe_sign_hash(safe_tx_hash)["signature"]
+        sig_b = safe_owners[1].unsafe_sign_hash(safe_tx_hash)["signature"]
+        sig_c = safe_owners[2].unsafe_sign_hash(safe_tx_hash)["signature"]
+        data["contractTransactionHash"] = to_0x_hex_str(safe_tx_hash)
+        data["signature"] = to_0x_hex_str(sig_a + sig_b + sig_c)
+
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        multisig_transaction = MultisigTransaction.objects.get()
+        self.assertTrue(multisig_transaction.trusted)
+        # Sender is an owner, so proposer is the sender directly
+        self.assertEqual(multisig_transaction.proposer, owner_and_delegate.address)
+        self.assertIsNone(multisig_transaction.proposed_by_delegate)
+
+        # A pure delegate (non-owner) with multiple signatures still fails
+        MultisigTransaction.objects.all().delete()
+        pure_delegate = Account.create()
+        SafeContractDelegateFactory(
+            safe_contract=owner_delegate_record.safe_contract,
+            delegate=pure_delegate.address,
+            delegator=safe_owners[2].address,
+        )
+        data["sender"] = pure_delegate.address
+        sig_delegate = pure_delegate.unsafe_sign_hash(safe_tx_hash)["signature"]
+        data["signature"] = to_0x_hex_str(sig_delegate + sig_b)
+        response = self.client.post(
+            reverse("v2:history:multisig-transactions", args=(safe_address,)),
+            format="json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn(
+            "Just one signature is expected if using delegates",
+            response.data["non_field_errors"][0],
+        )
+
     def test_post_multisig_transaction_with_delegate_call(self):
         safe_owner_1 = Account.create()
         safe = self.deploy_test_safe(owners=[safe_owner_1.address])


### PR DESCRIPTION
- Closes #2638 

When a address is both a Safe owner and a registered proposer (delegate), submitting a multisig transaction with multiple signatures returned a 422 error: "Just one signature is expected if using delegates".

The validation iterated over all signatures and raised an error if any signer was found in the delegates table, without checking whether that signer was also an owner. This caused legitimate owner signatures to be rejected whenever the owner happened to be registered as a proposer.


**Fix**

Added an owner not in safe_owners guard to the delegate signature restriction in `SafeMultisigTransactionSerializer.validate()`. The single-signature restriction now only applies to pure delegates (non-owners). If an address is both an owner and a delegate, it is treated as an owner with no signature count restriction.

The `save()` method already handled this correctly, when sender is in safe_owners, it is stored as proposer directly with proposed_by_delegate=None. The fix makes validate() consistent with that existing behavior.
