### PR TITLE
fix: Add EIP-1271 ready preparedSignature for nested Safes (PLA-1534)

### DIFF
--- a/safe_transaction_service/safe_messages/models.py
+++ b/safe_transaction_service/safe_messages/models.py
@@ -11,7 +11,11 @@ from safe_eth.eth.django.models import (
     HexV2Field,
     Keccak256Field,
 )
-from safe_eth.safe.safe_signature import SafeSignatureType
+from safe_eth.safe.safe_signature import (
+    SafeSignature,
+    SafeSignatureContract,
+    SafeSignatureType,
+)
 from safe_eth.util.util import to_0x_hex_str
 
 from safe_transaction_service.utils.constants import SIGNATURE_LENGTH
@@ -54,6 +58,54 @@ class SafeMessage(TimeStampedModel):
                 )
             ]
         )
+
+    def build_eip1271_signature(self) -> bytes:
+        """
+        Build a single EIP-1271 signature claiming ``self.safe`` as signer, with the inner
+        multi-owner blob assembled in the format expected by Safe's ``checkSignatures``
+        (statics first, dynamics last with cumulative offsets).
+
+        Unlike ``build_signature``, which naively concatenates per-owner confirmations and
+        works only when every confirmation is an EOA signature, this produces a blob that is
+        directly usable wherever a single ``SafeSignature`` signed by this Safe is expected
+        (e.g. as the ``signature`` body for ``/api/v2/delegates/`` when the delegator is a
+        Safe). The consumer does not need to wrap or rewrite offsets.
+
+        :return: Wrapped ``CONTRACT_SIGNATURE`` bytes (``v=0 | r=safe | s=65 | length | inner``)
+            or ``b""`` if there are no parseable confirmations yet.
+        """
+        message_hash = HexBytes(self.message_hash)
+        parsed_signatures: list[SafeSignature] = []
+        for confirmation in self.confirmations.all():
+            parsed = SafeSignature.parse_signature(
+                bytes(confirmation.signature), message_hash
+            )
+            if len(parsed) != 1:
+                logger.warning(
+                    "SafeMessage=%s confirmation for owner=%s parsed into %d signatures; skipping",
+                    to_0x_hex_str(message_hash),
+                    confirmation.owner,
+                    len(parsed),
+                )
+                continue
+            parsed_signatures.append(parsed[0])
+
+        if not parsed_signatures:
+            return b""
+
+        # `export_signatures` (plural) sorts by owner.lower() and rewrites the contract
+        # signature offsets so the resulting blob satisfies GS020-GS023 of `checkSignatures`.
+        inner_blob = SafeSignature.export_signatures(parsed_signatures)
+
+        # `safe_hash`/`safe_hash_preimage` are metadata kept on the object for `is_valid()`
+        # and do not appear in the exported bytes, so the stored message_hash is enough.
+        outer = SafeSignatureContract.from_values(
+            safe_owner=self.safe,
+            safe_hash=message_hash,
+            safe_hash_preimage=message_hash,
+            contract_signature=inner_blob,
+        )
+        return bytes(outer.export_signature())
 
 
 class SafeMessageConfirmation(TimeStampedModel):

--- a/safe_transaction_service/safe_messages/serializers.py
+++ b/safe_transaction_service/safe_messages/serializers.py
@@ -219,6 +219,7 @@ class SafeMessageResponseSerializer(serializers.Serializer):
     safe_app_id = serializers.IntegerField()
     confirmations = serializers.SerializerMethodField()
     prepared_signature = serializers.SerializerMethodField()
+    prepared_signature_eip1271 = serializers.SerializerMethodField()
     origin = serializers.SerializerMethodField()
 
     def get_confirmations(self, obj: SafeMessage) -> dict[str, Any]:
@@ -234,12 +235,28 @@ class SafeMessageResponseSerializer(serializers.Serializer):
 
     def get_prepared_signature(self, obj: SafeMessage) -> str | None:
         """
-        Prepared signature sorted
+        Prepared signature sorted by owner.
+
+        Note: this is a raw concatenation of per-owner confirmations and is only directly
+        usable when every confirmation is an EOA signature. For messages with ``CONTRACT_SIGNATURE``
+        confirmations (nested EIP-1271) use ``preparedSignatureEip1271`` instead.
 
         :param obj: SafeMessage instance
         :return: Serialized queryset
         """
         signature = HexBytes(obj.build_signature())
+        return to_0x_hex_str(HexBytes(signature)) if signature else None
+
+    def get_prepared_signature_eip1271(self, obj: SafeMessage) -> str | None:
+        """
+        Single EIP-1271 signature ready to be consumed as a ``SafeSignature`` whose owner is
+        ``obj.safe`` (e.g. for ``/api/v2/delegates/`` when the delegator is a Safe). Handles
+        both EOA-only and ``CONTRACT_SIGNATURE`` confirmations, including nested ones.
+
+        :param obj: SafeMessage instance
+        :return: Hex-encoded signature, or ``None`` if there are no parseable confirmations yet
+        """
+        signature = obj.build_eip1271_signature()
         return to_0x_hex_str(HexBytes(signature)) if signature else None
 
     def get_origin(self, obj: SafeMessage) -> str:

--- a/safe_transaction_service/safe_messages/tests/test_models.py
+++ b/safe_transaction_service/safe_messages/tests/test_models.py
@@ -4,12 +4,20 @@ from unittest.mock import PropertyMock
 
 from django.test import TestCase
 
+import eth_abi
 from eth_account import Account
 from hexbytes import HexBytes
 from safe_eth.eth.utils import fast_keccak
+from safe_eth.safe.safe_signature import (
+    SafeSignature,
+    SafeSignatureContract,
+    SafeSignatureType,
+)
+from safe_eth.safe.signatures import signature_to_bytes
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 from safe_eth.util.util import to_0x_hex_str
 
+from ..models import SafeMessageConfirmation
 from ..utils import get_message_encoded, get_safe_message_hash_and_preimage_for_message
 from .factories import SafeMessageConfirmationFactory, SafeMessageFactory
 from .mocks import get_eip712_payload_mock
@@ -100,3 +108,118 @@ class TestSafeMessage(SafeTestCaseMixin, TestCase):
             safe_message_confirmation_1.signature
         )
         self.assertEqual(safe_message.build_signature(), expected_signature)
+
+    def test_build_eip1271_signature_empty(self):
+        safe_message = SafeMessageFactory(safe=self.deploy_test_safe().address)
+        self.assertEqual(safe_message.build_eip1271_signature(), b"")
+
+    def test_build_eip1271_signature_eoa_only(self):
+        owner_1 = Account.create()
+        owner_2 = Account.create()
+        safe = self.deploy_test_safe(
+            owners=[owner_1.address, owner_2.address], threshold=2
+        )
+        safe_message = SafeMessageFactory(safe=safe.address)
+        SafeMessageConfirmationFactory(signing_owner=owner_1, safe_message=safe_message)
+        SafeMessageConfirmationFactory(signing_owner=owner_2, safe_message=safe_message)
+
+        wrapped = safe_message.build_eip1271_signature()
+        message_hash = HexBytes(safe_message.message_hash)
+
+        # The wrapped blob must parse as a single SafeSignature whose owner is the Safe
+        outer_signatures = SafeSignature.parse_signature(wrapped, message_hash)
+        self.assertEqual(len(outer_signatures), 1)
+        self.assertIsInstance(outer_signatures[0], SafeSignatureContract)
+        self.assertEqual(outer_signatures[0].owner, safe.address)
+
+        # Unwrapping the contract signature payload yields the two EOA sigs ordered ascending
+        inner_signatures = SafeSignature.parse_signature(
+            outer_signatures[0].contract_signature, message_hash
+        )
+        self.assertEqual(len(inner_signatures), 2)
+        self.assertEqual(
+            [sig.signature_type for sig in inner_signatures],
+            [SafeSignatureType.EOA, SafeSignatureType.EOA],
+        )
+        recovered_owners = [sig.owner for sig in inner_signatures]
+        self.assertEqual(recovered_owners, sorted(recovered_owners, key=str.lower))
+        self.assertEqual(set(recovered_owners), {owner_1.address, owner_2.address})
+
+    def test_build_eip1271_signature_with_contract_signature(self):
+        """
+        Cover the case the naive `build_signature` cannot: a confirmation whose owner is
+        itself a Safe (nested EIP-1271). The wrapped blob must keep GS021 happy — every
+        inner `CONTRACT_SIGNATURE` static must point to an offset ``>= n_signatures * 65``.
+        """
+        eoa_owner_1 = Account.create()
+        eoa_owner_2 = Account.create()
+        nested_eoa = Account.create()
+        safe_owner = self.deploy_test_safe(owners=[nested_eoa.address])
+        safe = self.deploy_test_safe(
+            owners=[eoa_owner_1.address, eoa_owner_2.address, safe_owner.address],
+            threshold=3,
+        )
+        safe_message = SafeMessageFactory(safe=safe.address)
+        message_hash = HexBytes(safe_message.message_hash)
+
+        # Two EOA confirmations via the factory
+        SafeMessageConfirmationFactory(
+            signing_owner=eoa_owner_1, safe_message=safe_message
+        )
+        SafeMessageConfirmationFactory(
+            signing_owner=eoa_owner_2, safe_message=safe_message
+        )
+
+        # The Safe-owner confirmation: a CONTRACT_SIGNATURE whose payload is the nested EOA
+        # signing the double-wrapped SafeMessage hash. The bytes here are synthetic: this
+        # test verifies structural wrapping, not on-chain EIP-1271 validation.
+        safe_owner_message_hash, _ = safe_owner.get_message_hash_and_preimage(
+            message_hash
+        )
+        nested_eoa_sig = nested_eoa.unsafe_sign_hash(safe_owner_message_hash)[
+            "signature"
+        ]
+        contract_signature_bytes = (
+            signature_to_bytes(
+                0,
+                int.from_bytes(HexBytes(safe_owner.address), byteorder="big"),
+                65,
+            )
+            + eth_abi.encode(["bytes"], [bytes(nested_eoa_sig)])[32:]
+        )
+        SafeMessageConfirmation.objects.create(
+            safe_message=safe_message,
+            owner=safe_owner.address,
+            signature=contract_signature_bytes,
+            signature_type=SafeSignatureType.CONTRACT_SIGNATURE.value,
+        )
+
+        wrapped = safe_message.build_eip1271_signature()
+
+        # Outer wrap: single CONTRACT_SIGNATURE pointing to the Safe
+        outer_signatures = SafeSignature.parse_signature(wrapped, message_hash)
+        self.assertEqual(len(outer_signatures), 1)
+        self.assertIsInstance(outer_signatures[0], SafeSignatureContract)
+        self.assertEqual(outer_signatures[0].owner, safe.address)
+
+        # Inner blob: three signatures, sorted ascending by owner.lower(), with the contract
+        # sig's offset satisfying GS021 (>= 3 * 65 = 195).
+        inner_signatures = SafeSignature.parse_signature(
+            outer_signatures[0].contract_signature, message_hash
+        )
+        self.assertEqual(len(inner_signatures), 3)
+        recovered_owners = [sig.owner for sig in inner_signatures]
+        self.assertEqual(recovered_owners, sorted(recovered_owners, key=str.lower))
+        self.assertEqual(
+            set(recovered_owners),
+            {eoa_owner_1.address, eoa_owner_2.address, safe_owner.address},
+        )
+        contract_sig_in_inner = next(
+            sig
+            for sig in inner_signatures
+            if sig.signature_type == SafeSignatureType.CONTRACT_SIGNATURE
+        )
+        self.assertGreaterEqual(contract_sig_in_inner.s, 3 * 65)
+        self.assertEqual(
+            bytes(contract_sig_in_inner.contract_signature), bytes(nested_eoa_sig)
+        )

--- a/safe_transaction_service/safe_messages/tests/test_views.py
+++ b/safe_transaction_service/safe_messages/tests/test_views.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 from django.urls import reverse
 
 import eth_abi
+from eth_abi.packed import encode_packed
 from eth_account import Account
 from hexbytes import HexBytes
 from packaging.version import Version
@@ -15,11 +16,14 @@ from rest_framework.exceptions import ErrorDetail
 from rest_framework.test import APITestCase
 from safe_eth.eth.eip712 import eip712_encode
 from safe_eth.eth.utils import fast_keccak
-from safe_eth.safe.safe_signature import SafeSignatureEOA
+from safe_eth.safe.safe_signature import SafeSignatureContract, SafeSignatureEOA
 from safe_eth.safe.signatures import signature_to_bytes
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 from safe_eth.util.util import to_0x_hex_str
 
+from safe_transaction_service.history.helpers import DelegateSignatureHelperV2
+from safe_transaction_service.history.models import SafeContractDelegate
+from safe_transaction_service.history.tests.factories import SafeContractFactory
 from safe_transaction_service.safe_messages.models import (
     SafeMessage,
     SafeMessageConfirmation,
@@ -65,6 +69,7 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                 "safeAppId": safe_message.safe_app_id,
                 "origin": json.dumps(safe_message.origin),
                 "preparedSignature": None,
+                "preparedSignatureEip1271": None,
                 "confirmations": [],
             },
         )
@@ -89,6 +94,9 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                 "safeAppId": safe_message.safe_app_id,
                 "origin": json.dumps(safe_message.origin),
                 "preparedSignature": to_0x_hex_str(safe_message_confirmation.signature),
+                "preparedSignatureEip1271": to_0x_hex_str(
+                    HexBytes(safe_message.build_eip1271_signature())
+                ),
                 "confirmations": [
                     {
                         "created": datetime_to_str(safe_message_confirmation.created),
@@ -126,6 +134,9 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                 "safeAppId": safe_message.safe_app_id,
                 "origin": json.dumps(safe_message.origin),
                 "preparedSignature": to_0x_hex_str(safe_message_confirmation.signature),
+                "preparedSignatureEip1271": to_0x_hex_str(
+                    HexBytes(safe_message.build_eip1271_signature())
+                ),
                 "confirmations": [
                     {
                         "created": datetime_to_str(safe_message_confirmation.created),
@@ -500,6 +511,7 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                         "safeAppId": safe_message.safe_app_id,
                         "origin": json.dumps(safe_message.origin),
                         "preparedSignature": None,
+                        "preparedSignatureEip1271": None,
                         "confirmations": [],
                     }
                 ],
@@ -532,6 +544,9 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                         "origin": json.dumps(safe_message.origin),
                         "preparedSignature": to_0x_hex_str(
                             safe_message_confirmation.signature
+                        ),
+                        "preparedSignatureEip1271": to_0x_hex_str(
+                            HexBytes(safe_message.build_eip1271_signature())
                         ),
                         "confirmations": [
                             {
@@ -585,6 +600,9 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                         "preparedSignature": to_0x_hex_str(
                             safe_message_confirmation.signature
                         ),
+                        "preparedSignatureEip1271": to_0x_hex_str(
+                            HexBytes(safe_message.build_eip1271_signature())
+                        ),
                         "confirmations": [
                             {
                                 "created": datetime_to_str(
@@ -633,6 +651,7 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                 "safeAppId": safe_message.safe_app_id,
                 "origin": json.dumps(safe_message.origin),
                 "preparedSignature": None,
+                "preparedSignatureEip1271": None,
                 "confirmations": [],
             },
         )
@@ -657,6 +676,9 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                 "safeAppId": safe_message.safe_app_id,
                 "origin": json.dumps(safe_message.origin),
                 "preparedSignature": to_0x_hex_str(safe_message_confirmation.signature),
+                "preparedSignatureEip1271": to_0x_hex_str(
+                    HexBytes(safe_message.build_eip1271_signature())
+                ),
                 "confirmations": [
                     {
                         "created": datetime_to_str(safe_message_confirmation.created),
@@ -668,3 +690,126 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
                 ],
             },
         )
+
+    def test_nested_eip1271_delegate_flow_end_to_end(self):
+        """
+        End-to-end: EOA owns Safe1, Safe1 owns Safe2, Safe2 owns Safe3. Add a delegate
+        for Safe2 (delegator) in Safe3 (safe).
+
+        Signatures are collected through ``/safe-messages/`` on Safe2 (one
+        ``CONTRACT_SIGNATURE`` confirmation by Safe1, whose payload is the EOA's
+        signature over the double-wrapped SafeMessage). The resulting
+        ``preparedSignatureEip1271`` is then used as-is to create the delegate.
+        """
+        eoa = Account.create()
+        chain_id = self.ethereum_client.get_chain_id()
+
+        safe1 = self.deploy_test_safe(owners=[eoa.address], threshold=1)
+        safe2 = self.deploy_test_safe(owners=[safe1.address], threshold=1)
+        safe3 = self.deploy_test_safe(owners=[safe2.address], threshold=1)
+        SafeContractFactory(address=safe3.address)
+
+        delegate = Account.create()
+        delegate_msg_hash, _ = DelegateSignatureHelperV2.calculate_hash_and_preimage(
+            delegate.address, chain_id, previous_totp=False
+        )
+        totp = DelegateSignatureHelperV2.calculate_totp(previous=False)
+
+        delegate_eip712_message = {
+            "types": {
+                "EIP712Domain": [
+                    {"name": "name", "type": "string"},
+                    {"name": "version", "type": "string"},
+                    {"name": "chainId", "type": "uint256"},
+                ],
+                "Delegate": [
+                    {"name": "delegateAddress", "type": "address"},
+                    {"name": "totp", "type": "uint256"},
+                ],
+            },
+            "primaryType": "Delegate",
+            "domain": {
+                "name": "Safe Transaction Service",
+                "version": "1.0",
+                "chainId": chain_id,
+            },
+            "message": {"delegateAddress": delegate.address, "totp": totp},
+        }
+        # The EIP-712 hash of the message we POST must match what the delegate
+        # endpoint will reproduce locally via DelegateSignatureHelperV2.
+        self.assertEqual(
+            fast_keccak(b"".join(eip712_encode(delegate_eip712_message))),
+            bytes(delegate_msg_hash),
+        )
+
+        # The EOA signs the doubly-wrapped SafeMessage hash. For Safe v1.5 the on-chain
+        # `isValidSignature(bytes32, bytes)` recomputes the SafeMessage of its msg.sender
+        # over the input hash, so we feed the bytes32 form into each `get_message_hash`.
+        safe2_message_hash = safe2.get_message_hash(delegate_msg_hash)
+        safe1_message_hash = safe1.get_message_hash(safe2_message_hash)
+        eoa_signature = eoa.unsafe_sign_hash(safe1_message_hash)["signature"]
+
+        # Safe1's CONTRACT_SIGNATURE blob, posted as the proposal for Safe2's SafeMessage
+        # The dynamic part for a CONTRACT_SIGNATURE is `[32B length][raw signature bytes]`.
+        # `encode_packed` lays them out directly without abi offset/padding, matching the
+        # exact layout produced by `SafeSignatureContract.export_signature()`.
+        eoa_signature_bytes = bytes(eoa_signature)
+        safe1_contract_signature = signature_to_bytes(
+            0, int.from_bytes(HexBytes(safe1.address), byteorder="big"), 65
+        ) + encode_packed(
+            ["uint256", "bytes"], [len(eoa_signature_bytes), eoa_signature_bytes]
+        )
+        # Cross-check the manual construction against the canonical builder in safe-eth-py
+        safe1_contract_signature_via_helper = bytes(
+            SafeSignatureContract.from_values(
+                safe_owner=safe1.address,
+                safe_hash=safe2_message_hash,
+                safe_hash_preimage=safe2_message_hash,
+                contract_signature=eoa_signature_bytes,
+            ).export_signature()
+        )
+        self.assertEqual(safe1_contract_signature, safe1_contract_signature_via_helper)
+
+        # 1) POST the SafeMessage on Safe2 with Safe1's EIP-1271 confirmation
+        response = self.client.post(
+            reverse("v1:safe_messages:safe-messages", args=(safe2.address,)),
+            format="json",
+            data={
+                "message": delegate_eip712_message,
+                "signature": to_0x_hex_str(HexBytes(safe1_contract_signature)),
+            },
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_201_CREATED, response.content
+        )
+
+        # 2) Retrieve preparedSignatureEip1271 from the SafeMessage detail endpoint
+        safe_message_hash_hex = to_0x_hex_str(safe2_message_hash)
+        response = self.client.get(
+            reverse("v1:safe_messages:message", args=(safe_message_hash_hex,))
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        prepared_eip1271 = response.json()["preparedSignatureEip1271"]
+        self.assertIsNotNone(prepared_eip1271)
+
+        # 3) Use it directly as the delegator signature when adding the delegate to Safe3
+        response = self.client.post(
+            reverse("v2:history:delegates"),
+            format="json",
+            data={
+                "label": "Nested 3-level Safe delegator",
+                "safe": safe3.address,
+                "delegate": delegate.address,
+                "delegator": safe2.address,
+                "signature": prepared_eip1271,
+            },
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_201_CREATED, response.content
+        )
+
+        self.assertEqual(SafeContractDelegate.objects.count(), 1)
+        record = SafeContractDelegate.objects.get()
+        self.assertEqual(record.delegate, delegate.address)
+        self.assertEqual(record.delegator, safe2.address)
+        self.assertEqual(record.safe_contract_id, safe3.address)


### PR DESCRIPTION
## Summary
  - Expose a new `preparedSignatureEip1271` field on the `SafeMessage` response that is ready to be consumed as a single `SafeSignature` whose owner is the Safe (e.g. for the v2 delegate endpoint when the delegator is a Safe).
  - Keep `preparedSignature` unchanged for backwards compatibility. Its `help_text` now notes it only works for EOA-only confirmations and points readers to the new field.
  - Closes [PLA-1534](https://linear.app/safe-global/issue/PLA-1534).