### PR TITLE
fix: Close DB connection in spawned event greenlets

### DIFF
--- a/config/celery_app.py
+++ b/config/celery_app.py
@@ -2,6 +2,10 @@
 from celery import Celery
 from celery.signals import setup_logging, task_postrun
 
+from safe_transaction_service.utils.database import (
+    close_unusable_or_obsolete_connections,
+)
+
 
 @setup_logging.connect
 def on_celery_setup_logging(**kwargs):
@@ -26,8 +30,6 @@ def on_celery_setup_logging(**kwargs):
 
 @task_postrun.connect
 def close_db_connections(**kwargs):
-    from django.db import connections
-
     # Django's close_old_connections() is called automatically at the end of each web request
     # via middleware signals, but Celery tasks have no equivalent lifecycle hook.
     #
@@ -40,18 +42,7 @@ def close_db_connections(**kwargs):
     # but that only covers the fork/process-start path. With --pool=gevent there is no forking:
     # all tasks run as greenlets inside a single process, so close_pool never fires and
     # per-task connection cleanup must be handled explicitly here.
-    #
-    # CONN_MAX_AGE=0 means every connection is immediately eligible for closure,
-    # triggering close() → putconn() and returning the slot to the pool immediately.
-    #
-    # Connections inside an atomic block are skipped: in production this never happens
-    # because task_postrun fires after the task function returns (so any transaction.atomic
-    # blocks from the task itself have already exited). In tests, Django's TestCase wraps
-    # each test in a transaction (in_atomic_block=True), and closing the connection there
-    # would break test isolation.
-    for conn in connections.all(initialized_only=True):
-        if not conn.in_atomic_block:
-            conn.close_if_unusable_or_obsolete()
+    close_unusable_or_obsolete_connections()
 
 
 app = Celery("safe_transaction_service")

--- a/safe_transaction_service/history/signals.py
+++ b/safe_transaction_service/history/signals.py
@@ -11,6 +11,7 @@ import gevent
 from gevent.greenlet import Greenlet
 
 from ..events.services.queue_service import get_queue_service
+from ..utils.database import close_unusable_or_obsolete_connections
 from .cache import remove_cache_view_by_instance
 from .models import (
     ERC20Transfer,
@@ -223,6 +224,42 @@ def process_event(
     return _process_event(sender, instance, created, False)
 
 
+def _process_event_and_close_connections(
+    sender: type[Model],
+    instance: TokenTransfer
+    | InternalTx
+    | MultisigConfirmation
+    | MultisigTransaction
+    | SafeContract,
+    created: bool,
+    deleted: bool,
+) -> None:
+    """
+    Run ``_process_event`` and return any DB connection opened by the greenlet to the pool.
+
+    These greenlets are spawned fire-and-forget from the indexer flow, so they run on their
+    own greenlet-local connection *after* Celery's ``task_postrun`` cleanup
+    (``config.celery_app.close_db_connections``) has already fired for the task. Nothing else
+    closes that connection, so it lingers until the psycopg3 pool recycles it by idle/lifetime
+    timers. Some senders (e.g. ``MultisigConfirmation``) lazily load FKs while building the
+    payload, opening such a connection.
+
+    Mirrors the ``task_postrun`` cleanup pattern. ``close_if_unusable_or_obsolete`` is a no-op
+    when no connection was opened (the common transfer/ether case touches only Redis/queue), so
+    this is cheap.
+
+    :param sender: Sender type
+    :param instance: Sender instance
+    :param created: `True` if the instance has just been created, `False` otherwise
+    :param deleted: `True` if the instance has been deleted, `False` otherwise
+    :return:
+    """
+    try:
+        _process_event(sender, instance, created, deleted)
+    finally:
+        close_unusable_or_obsolete_connections()
+
+
 @receiver(
     post_bulk_create,
     sender=ModuleTransaction,
@@ -273,7 +310,9 @@ def process_event_from_bulk_create(
     :param kwargs:
     :return: Greenlet running _process_event
     """
-    return gevent.spawn(_process_event, sender, instance, created, False)
+    return gevent.spawn(
+        _process_event_and_close_connections, sender, instance, created, False
+    )
 
 
 @receiver(

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -27,8 +27,14 @@ from ..models import (
     MultisigConfirmation,
     MultisigTransaction,
     TransactionServiceEventType,
+    post_bulk_create,
 )
-from ..signals import _process_event, build_event_payload, is_relevant_event
+from ..signals import (
+    _process_event,
+    _process_event_and_close_connections,
+    build_event_payload,
+    is_relevant_event,
+)
 from .factories import (
     ERC20TransferFactory,
     InternalTxFactory,
@@ -326,3 +332,72 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         remove_cache_mock.assert_called_once()
         build_event_payload_mock.assert_not_called()
         send_event_mock.assert_not_called()
+
+    @factory.django.mute_signals(post_save)
+    @mock.patch("safe_transaction_service.history.signals._process_event")
+    def test_process_event_and_close_connections_closes_connection(
+        self, process_event_mock: MagicMock
+    ):
+        # Spawned greenlets run outside Celery's `task_postrun` cleanup, so the wrapper
+        # must return any connection opened while building the payload to the pool.
+        tx = ERC20TransferFactory()
+        conn = MagicMock(in_atomic_block=False)
+
+        with mock.patch("django.db.connections.all", return_value=[conn]):
+            _process_event_and_close_connections(
+                ERC20Transfer, tx, created=True, deleted=False
+            )
+
+        process_event_mock.assert_called_once_with(ERC20Transfer, tx, True, False)
+        conn.close_if_unusable_or_obsolete.assert_called_once()
+
+    @factory.django.mute_signals(post_save)
+    def test_post_bulk_create_dispatch_spawns_greenlet(self):
+        # Regression: `post_bulk_create.send(instance=..., created=True)` must reach
+        # `process_event_from_bulk_create` (which absorbs Django's signal kwargs and
+        # spawns a greenlet). If the receiver decorators bind to a function requiring
+        # `deleted`/lacking `**kwargs`, dispatch raises TypeError and breaks bulk_create.
+        tx = ERC20TransferFactory()
+
+        with mock.patch(
+            "safe_transaction_service.history.signals.gevent.spawn"
+        ) as spawn_mock:
+            post_bulk_create.send(ERC20Transfer, instance=tx, created=True)
+
+        spawn_mock.assert_called_once_with(
+            _process_event_and_close_connections, ERC20Transfer, tx, True, False
+        )
+
+    @factory.django.mute_signals(post_save)
+    @mock.patch("safe_transaction_service.history.signals._process_event")
+    def test_process_event_and_close_connections_closes_on_error(
+        self, process_event_mock: MagicMock
+    ):
+        # Connection must be returned even if payload building raises
+        process_event_mock.side_effect = ValueError("boom")
+        tx = ERC20TransferFactory()
+        conn = MagicMock(in_atomic_block=False)
+
+        with mock.patch("django.db.connections.all", return_value=[conn]):
+            with self.assertRaises(ValueError):
+                _process_event_and_close_connections(
+                    ERC20Transfer, tx, created=True, deleted=False
+                )
+
+        conn.close_if_unusable_or_obsolete.assert_called_once()
+
+    @factory.django.mute_signals(post_save)
+    @mock.patch("safe_transaction_service.history.signals._process_event")
+    def test_process_event_and_close_connections_skips_atomic_block(
+        self, process_event_mock: MagicMock
+    ):
+        # Connections inside an atomic block must not be closed (mirrors task_postrun cleanup)
+        tx = ERC20TransferFactory()
+        conn = MagicMock(in_atomic_block=True)
+
+        with mock.patch("django.db.connections.all", return_value=[conn]):
+            _process_event_and_close_connections(
+                ERC20Transfer, tx, created=True, deleted=False
+            )
+
+        conn.close_if_unusable_or_obsolete.assert_not_called()

--- a/safe_transaction_service/utils/database.py
+++ b/safe_transaction_service/utils/database.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+
+
+def close_unusable_or_obsolete_connections() -> None:
+    """
+    Return obsolete DB connections of the current execution context to the pool.
+
+    Mirrors Django's per-request cleanup for contexts that have no
+    ``request_finished`` lifecycle hook, such as Celery tasks (see
+    ``config.celery_app.close_db_connections``) and fire-and-forget greenlets
+    spawned outside a task. With ``CONN_MAX_AGE=0`` every connection is eligible
+    for closure, returning the psycopg3 pool slot immediately.
+
+    Connections inside an atomic block are skipped: closing them would break the
+    surrounding transaction (and test isolation, as ``TestCase`` wraps each test
+    in one). ``close_if_unusable_or_obsolete`` is a no-op when no connection was
+    opened, so calling this is always cheap.
+
+    ``django.db`` is imported lazily so importing this module (and, transitively,
+    ``config.celery_app``) does not pull ``django.db`` into ``sys.modules`` before
+    Django is set up.
+
+    :return:
+    """
+    from django.db import connections
+
+    for conn in connections.all(initialized_only=True):
+        if not conn.in_atomic_block:
+            conn.close_if_unusable_or_obsolete()


### PR DESCRIPTION
## What

Close DB connections opened inside fire-and-forget event-processing greenlets so they are returned to the psycopg3 pool promptly, instead of lingering until the pool's idle/lifetime timers recycle them.

## Why

`post_bulk_create` routes event processing to `gevent.spawn(_process_event, ...)` in `history/signals.py`. These greenlets run on their own greenlet-local DB connection **after** Celery's `task_postrun` cleanup (`config.celery_app.close_db_connections`) has already fired for the task, so nothing returns that connection to the pool.

Senders that lazily load FKs while building the payload open such a connection:

- `MultisigConfirmation` → `multisig_transaction.safe`
- `MultisigTransaction` → `executed` → `ethereum_tx.block_id`
- `SafeMessageConfirmation` → `safe_message.safe`

The high-volume transfer/ether events (`ERC20Transfer`, `ERC721Transfer`, `InternalTx`) only touch Redis/queue and never open a DB connection, so they are unaffected — but the leaked connections from the FK-loading senders accumulate against the pool (`max_size=100`) until the idle/lifetime timers recycle them.

Found while investigating PLA-1606.

## How

- Wrap the spawned greenlet body in `_process_event_and_close_connections`, whose `finally` returns any obsolete connection to the pool. Runs even if payload building raises.
- Extract the shared close-connections logic into `utils.database.close_unusable_or_obsolete_connections`, reused by both this wrapper and the existing `task_postrun` handler.
- `django.db` is imported lazily inside the helper, so importing it (and transitively `config.celery_app`) does not pull `django.db` into `sys.modules` before Django is set up — the existing import-isolation guard still holds.

This mirrors the existing `task_postrun` cleanup pattern. With `CONN_MAX_AGE=0`, every connection is immediately eligible for closure; `close_if_unusable_or_obsolete` is a no-op when no connection was opened, so the cleanup is cheap for the no-DB transfer/ether greenlets.

## Tests

- `_process_event_and_close_connections` closes the connection after processing.
- Cleanup runs even when processing raises.
- Connections inside an atomic block are not closed.
- Existing `config.celery_app` import-isolation and `close_db_connections` tests still pass.

Closes PLA-1610