### PR TITLE
fix: Only emit transfer/ether events for tracked Safes (PLA-1606)

### DIFF
--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -22,6 +22,7 @@ from ..models import (
     SafeRelevantTransaction,
     TokenTransfer,
 )
+from ..services.event_service import set_safe_membership
 from .events_indexer import EventsIndexer
 
 logger = getLogger(__name__)
@@ -149,20 +150,54 @@ class Erc20EventsIndexer(EventsIndexer):
     def events_to_erc20_transfer(
         self, log_receipts: Sequence[EventData]
     ) -> Iterator[ERC20Transfer]:
+        safe_addresses = self._get_safe_addresses_for_membership()
         for log_receipt in log_receipts:
             try:
-                yield ERC20Transfer.from_decoded_event(log_receipt)
+                transfer = ERC20Transfer.from_decoded_event(log_receipt)
+                self._annotate_safe_membership(transfer, safe_addresses)
+                yield transfer
             except ValueError:
                 pass
 
     def events_to_erc721_transfer(
         self, log_receipts: Sequence[EventData]
     ) -> Iterator[ERC721Transfer]:
+        safe_addresses = self._get_safe_addresses_for_membership()
         for log_receipt in log_receipts:
             try:
-                yield ERC721Transfer.from_decoded_event(log_receipt)
+                transfer = ERC721Transfer.from_decoded_event(log_receipt)
+                self._annotate_safe_membership(transfer, safe_addresses)
+                yield transfer
             except ValueError:
                 pass
+
+    def _get_safe_addresses_for_membership(self) -> set[ChecksumAddress] | None:
+        """
+        :return: The full set of monitored Safe addresses held in memory, or ``None`` if the
+            address cache has not been populated yet (abnormal: ``process_elements`` invoked
+            outside the normal indexing cycle). ``None`` makes ``_annotate_safe_membership`` a
+            no-op, so `build_event_payload` logs a "lacking metadata" error rather than guessing.
+        """
+        return self.addresses_cache.addresses if self.addresses_cache else None
+
+    @staticmethod
+    def _annotate_safe_membership(
+        transfer: TokenTransfer, safe_addresses: set[ChecksumAddress] | None
+    ) -> None:
+        """
+        Tag the transfer with whether its `to` / `_from` side is a tracked Safe, so only the
+        Safe side gets a directional event. No-op when ``safe_addresses`` is ``None``.
+
+        :param transfer: Transfer about to be stored
+        :param safe_addresses: Monitored Safe addresses, or ``None`` if unavailable
+        """
+        if safe_addresses is None:
+            return
+        set_safe_membership(
+            transfer,
+            to_is_a_safe=transfer.to in safe_addresses,
+            from_is_a_safe=transfer._from in safe_addresses,
+        )
 
     def events_to_safe_relevant_transaction(
         self, log_receipts: Sequence[EventData]

--- a/safe_transaction_service/history/indexers/internal_tx_indexer.py
+++ b/safe_transaction_service/history/indexers/internal_tx_indexer.py
@@ -28,6 +28,7 @@ from ..models import (
     SafeMasterCopy,
     SafeRelevantTransaction,
 )
+from ..services.event_service import set_safe_membership
 from .ethereum_indexer import EthereumIndexer, FindRelevantElementsException
 
 logger = getLogger(__name__)
@@ -373,12 +374,30 @@ class InternalTxIndexer(EthereumIndexer):
 
         ethereum_txs = self._prefetch_ethereum_txs(tx_hashes)
 
-        internal_txs = [
-            InternalTx.objects.build_from_trace(trace, ethereum_tx)
-            for ethereum_tx in ethereum_txs
-            if ethereum_tx.success
-            for trace in filtered_traces_by_tx_hash[HexBytes(ethereum_tx.tx_hash)]
-        ]
+        # Identify the Safe proxies active in each tx so ether transfers only emit a
+        # directional event for the Safe side. This indexer monitors Safe master-copy
+        # (singleton) addresses, so a tx is pulled in whenever any trace touches a master
+        # copy and then ALL its value hops are stored - including router->router hops with
+        # no Safe on either side. The Safe proxies are the `from` of the delegatecall to a
+        # master copy (computed from the full, pre-`is_relevant_trace` traces so empty-data
+        # fallback delegatecalls from plain ETH receives are not missed).
+        master_copies = self._get_master_copy_addresses()
+        internal_txs: list[InternalTx] = []
+        for ethereum_tx in ethereum_txs:
+            if not ethereum_tx.success:
+                continue
+            tx_hash = HexBytes(ethereum_tx.tx_hash)
+            safe_proxies = self._extract_safe_proxies(
+                tx_hash_with_traces.get(tx_hash), master_copies
+            )
+            for trace in filtered_traces_by_tx_hash[tx_hash]:
+                internal_tx = InternalTx.objects.build_from_trace(trace, ethereum_tx)
+                set_safe_membership(
+                    internal_tx,
+                    to_is_a_safe=internal_tx.to in safe_proxies,
+                    from_is_a_safe=internal_tx._from in safe_proxies,
+                )
+                internal_txs.append(internal_tx)
 
         with transaction.atomic():
             logger.debug("Storing traces")
@@ -418,6 +437,41 @@ class InternalTxIndexer(EthereumIndexer):
             )
             self._mark_processed(tx_hash, block_hash)
         return tx_hashes
+
+    @staticmethod
+    def _get_master_copy_addresses() -> set[ChecksumAddress]:
+        """
+        :return: The monitored Safe master-copy (singleton) addresses. A Safe proxy is
+            identified in a tx by delegatecalling one of these.
+        """
+        return set(SafeMasterCopy.objects.values_list("address", flat=True))
+
+    @staticmethod
+    def _extract_safe_proxies(
+        traces: list[FilterTrace] | None, master_copies: set[ChecksumAddress]
+    ) -> set[ChecksumAddress]:
+        """
+        Derive the Safe proxy addresses active in a tx: the `from` of any non-errored
+        ``DELEGATE_CALL`` whose `to` is a monitored master copy.
+
+        :param traces: Full (pre-filter) trace list for the tx, or ``None``
+        :param master_copies: Monitored master-copy addresses
+        :return: Set of Safe proxy addresses present in the tx
+        """
+        safe_proxies: set[ChecksumAddress] = set()
+        if not traces:
+            return safe_proxies
+        for trace in traces:
+            action = trace.get("action", {})
+            if (
+                EthereumTxCallType.parse_call_type(action.get("callType"))
+                == EthereumTxCallType.DELEGATE_CALL
+                and not trace.get("error")
+                and action.get("to") in master_copies
+            ):
+                if safe_proxy := action.get("from"):
+                    safe_proxies.add(safe_proxy)
+        return safe_proxies
 
     @staticmethod
     def is_relevant_trace(trace: FilterTrace) -> bool:

--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -36,6 +36,7 @@ from ..models import (
     SafeMasterCopy,
     SafeRelevantTransaction,
 )
+from ..services.event_service import set_safe_membership
 from .events_indexer import EventsIndexer
 
 logger = getLogger(__name__)
@@ -719,6 +720,19 @@ class SafeEventsIndexer(EventsIndexer):
 
         if not internal_tx:
             return []
+
+        # Annotate Safe membership so ether transfers only emit the directional event for the
+        # Safe side. The Safe is always `safe_address` (the event emitter): `SafeReceived` has
+        # to=safe (incoming only); an exec-tx ether transfer has _from=safe (outgoing only).
+        # A Safe->Safe transfer's incoming side is covered by the recipient's own SafeReceived.
+        for tx in (internal_tx, child_internal_tx):
+            if tx is not None:
+                set_safe_membership(
+                    tx,
+                    to_is_a_safe=tx.to == safe_address,
+                    from_is_a_safe=tx._from == safe_address,
+                )
+
         return [
             internal_tx,
             internal_tx_decoded,

--- a/safe_transaction_service/history/services/event_service.py
+++ b/safe_transaction_service/history/services/event_service.py
@@ -5,6 +5,7 @@ Build event payloads for the queue
 
 import json
 from datetime import timedelta
+from logging import getLogger
 from typing import Any, Literal, TypedDict
 
 from django.db.models import Model
@@ -30,6 +31,81 @@ from safe_transaction_service.safe_messages.models import (
     SafeMessageConfirmation,
 )
 from safe_transaction_service.utils.ethereum import get_chain_id
+
+logger = getLogger(__name__)
+
+# Transient (non-DB) attributes set by the indexers on transfer / ether ``InternalTx``
+# instances, telling whether the `to` / `_from` side is a tracked Safe. Used by
+# `build_event_payload` to only emit the directional event whose side is a Safe.
+TO_IS_A_SAFE_ATTR = "_to_is_a_safe"
+FROM_IS_A_SAFE_ATTR = "_from_is_a_safe"
+
+
+def set_safe_membership(
+    instance: TokenTransfer | InternalTx,
+    to_is_a_safe: bool,
+    from_is_a_safe: bool,
+) -> None:
+    """
+    Annotate a ``TokenTransfer`` / ether ``InternalTx`` with whether its `to` / `_from`
+    side is a tracked Safe, so `build_event_payload` only emits the directional
+    event for the Safe side.
+
+    Called by the indexers at index time (where Safe membership is known in memory). The
+    attribute is transient; it survives to the `post_bulk_create` signal because the same
+    instance is passed through (see ``BulkCreateSignalMixin.bulk_create``).
+
+    :param instance: ``TokenTransfer`` or ether ``InternalTx`` about to be stored
+    :param to_is_a_safe: whether ``instance.to`` is a tracked Safe
+    :param from_is_a_safe: whether ``instance._from`` is a tracked Safe
+    :return:
+    """
+    setattr(instance, TO_IS_A_SAFE_ATTR, to_is_a_safe)
+    setattr(instance, FROM_IS_A_SAFE_ATTR, from_is_a_safe)
+
+
+def _filter_not_safe_transfers(
+    instance: TokenTransfer | InternalTx,
+    incoming_payload: dict[str, Any],
+    outgoing_payload: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """
+    Keep only the directional payloads whose addressed side is a tracked Safe.
+
+    ``INCOMING_*`` is addressed by ``instance.to`` and gated by ``_to_is_a_safe``;
+    ``OUTGOING_*`` by ``instance._from`` and gated by ``_from_is_a_safe``. The indexers
+    annotate both attributes (each possibly ``False`` when that side is not a Safe).
+
+    If both attributes are absent, the instance reached payload building without going
+    through an annotating indexer: emit nothing and log an error so the gap is visible.
+
+    :param instance: ``TokenTransfer`` or ether ``InternalTx`` being processed
+    :param incoming_payload: payload addressed to ``instance.to``
+    :param outgoing_payload: payload addressed to ``instance._from``
+    :return: the subset of payloads that should be emitted
+    """
+    to_is_a_safe = getattr(instance, TO_IS_A_SAFE_ATTR, None)
+    from_is_a_safe = getattr(instance, FROM_IS_A_SAFE_ATTR, None)
+
+    if to_is_a_safe is None and from_is_a_safe is None:
+        identifier = (
+            instance.trace_address
+            if isinstance(instance, InternalTx)
+            else instance.log_index
+        )
+        logger.error(
+            "Lacking metadata to build event for transfer with hash=%s identifier=%s",
+            to_0x_hex_str(HexBytes(instance.ethereum_tx_id)),
+            identifier,
+        )
+        return []
+
+    payloads: list[dict[str, Any]] = []
+    if to_is_a_safe:
+        payloads.append(incoming_payload)
+    if from_is_a_safe:
+        payloads.append(outgoing_payload)
+    return payloads
 
 
 def build_event_payload(
@@ -97,7 +173,9 @@ def build_event_payload(
         outgoing_payload = dict(incoming_payload)
         outgoing_payload["type"] = TransactionServiceEventType.OUTGOING_ETHER.name
         outgoing_payload["address"] = instance._from
-        payloads = [incoming_payload, outgoing_payload]
+        payloads = _filter_not_safe_transfers(
+            instance, incoming_payload, outgoing_payload
+        )
     elif sender in (ERC20Transfer, ERC721Transfer):
         # INCOMING_TOKEN / OUTGOING_TOKEN
         incoming_payload = {
@@ -113,7 +191,9 @@ def build_event_payload(
         outgoing_payload = dict(incoming_payload)
         outgoing_payload["type"] = TransactionServiceEventType.OUTGOING_TOKEN.name
         outgoing_payload["address"] = instance._from
-        payloads = [incoming_payload, outgoing_payload]
+        payloads = _filter_not_safe_transfers(
+            instance, incoming_payload, outgoing_payload
+        )
     elif sender == SafeContract:  # Safe created
         payloads = [
             {

--- a/safe_transaction_service/history/tests/test_erc20_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_erc20_events_indexer.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 from safe_eth.eth.tests.ethereum_test_case import EthereumTestCaseMixin
 
 from ..indexers import Erc20EventsIndexerProvider
+from ..indexers.erc20_events_indexer import AddressesCache
 from ..models import ERC20Transfer, EthereumTx, IndexingStatus, SafeRelevantTransaction
 from .factories import EthereumTxFactory, SafeContractFactory
 from .mocks.mocks_erc20_events_indexer import log_receipt_mock
@@ -105,6 +106,35 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
         self.assertEqual(
             len(self.erc20_events_indexer.process_elements(log_receipt_mock)), 1
         )
+
+    def test_events_to_transfer_annotates_safe_membership(self):
+        indexer = self.erc20_events_indexer
+
+        # Block/tx must exist so `from_decoded_event` can resolve the timestamp
+        for log_receipt in log_receipt_mock:
+            EthereumTxFactory(
+                tx_hash=log_receipt["transactionHash"],
+                block__block_hash=log_receipt["blockHash"],
+            )
+
+        # Without a populated address cache the transfer is left unannotated, so
+        # build_event_payload will log the "lacking metadata" error rather than guess.
+        indexer.addresses_cache = None
+        (transfer,) = list(indexer.events_to_erc20_transfer(log_receipt_mock))
+        self.assertFalse(hasattr(transfer, "_to_is_a_safe"))
+        self.assertFalse(hasattr(transfer, "_from_is_a_safe"))
+
+        # With only the recipient tracked: incoming side is a Safe, outgoing side is not.
+        indexer.addresses_cache = AddressesCache({transfer.to}, None)
+        (transfer,) = list(indexer.events_to_erc20_transfer(log_receipt_mock))
+        self.assertTrue(transfer._to_is_a_safe)
+        self.assertFalse(transfer._from_is_a_safe)
+
+        # With only the sender tracked: outgoing side is a Safe, incoming side is not.
+        indexer.addresses_cache = AddressesCache({transfer._from}, None)
+        (transfer,) = list(indexer.events_to_erc20_transfer(log_receipt_mock))
+        self.assertFalse(transfer._to_is_a_safe)
+        self.assertTrue(transfer._from_is_a_safe)
 
     def test_get_almost_updated_addresses(self):
         self.assertIsNone(self.erc20_events_indexer.addresses_cache)

--- a/safe_transaction_service/history/tests/test_internal_tx_indexer.py
+++ b/safe_transaction_service/history/tests/test_internal_tx_indexer.py
@@ -86,6 +86,51 @@ class TestInternalTxIndexer(TestCase):
         self.assertTrue(indexer.is_relevant_trace(create_trace))
         self.assertFalse(indexer.is_relevant_trace(not_relevant_trace))
 
+    def test_extract_safe_proxies(self):
+        indexer = self.internal_tx_indexer
+        master_copy = "0x" + "ab" * 20
+        safe_proxy = "0x" + "11" * 20
+        other = "0x" + "22" * 20
+
+        traces = [
+            # Safe proxy delegatecalling its master copy -> proxy identified
+            {
+                "type": "call",
+                "action": {
+                    "callType": "delegatecall",
+                    "from": safe_proxy,
+                    "to": master_copy,
+                },
+            },
+            # delegatecall to a non-master-copy -> ignored
+            {
+                "type": "call",
+                "action": {"callType": "delegatecall", "from": other, "to": other},
+            },
+            # plain CALL to the master copy (not a delegatecall) -> ignored
+            {
+                "type": "call",
+                "action": {"callType": "call", "from": other, "to": master_copy},
+            },
+            # errored delegatecall to the master copy -> ignored
+            {
+                "type": "call",
+                "error": "Reverted",
+                "action": {
+                    "callType": "delegatecall",
+                    "from": other,
+                    "to": master_copy,
+                },
+            },
+        ]
+
+        self.assertEqual(
+            indexer._extract_safe_proxies(traces, {master_copy}), {safe_proxy}
+        )
+        # No traces / empty input -> empty set, never raises
+        self.assertEqual(indexer._extract_safe_proxies(None, {master_copy}), set())
+        self.assertEqual(indexer._extract_safe_proxies([], {master_copy}), set())
+
     def return_sorted_blocks(self, hashes: HexStr):
         """
         Mock function helper

--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -2,6 +2,7 @@
 from abc import ABC, abstractmethod
 
 from django.test import TestCase
+from django.utils import timezone
 
 from eth_account import Account
 from eth_typing import ChecksumAddress
@@ -1586,3 +1587,33 @@ class TestSafeEventsIndexerV1_3_0(SafeEventsIndexerBaseAbstractTestBase):
         :return: Last Safe Contract available
         """
         return get_safe_V1_3_0_contract(w3, address=address)
+
+
+class TestSafeEventsIndexerSafeMembership(SafeTestCaseMixin, TestCase):
+    def test_process_decoded_element_annotates_safe_membership(self):
+        # On L2 the Safe is always the event emitter (`address`), so an incoming
+        # `SafeReceived` must be annotated as incoming-only (to=safe, _from=sender).
+        indexer = SafeEventsIndexer(
+            self.ethereum_client, confirmations=0, blocks_to_reindex_again=0
+        )
+        safe_address = Account.create().address
+        sender = Account.create().address
+        block_hash = HexBytes("0x" + "ab" * 32)
+        indexer.block_hashes_with_timestamp = {block_hash: timezone.now()}
+
+        element = AttributeDict(
+            {
+                "event": "SafeReceived",
+                "address": safe_address,
+                "blockNumber": 1,
+                "transactionHash": HexBytes("0x" + "cd" * 32),
+                "logIndex": 0,
+                "blockHash": block_hash,
+                "args": AttributeDict({"sender": sender, "value": 1000}),
+            }
+        )
+
+        internal_tx = indexer._process_decoded_element(element)[0]
+        self.assertTrue(internal_tx.is_ether_transfer)
+        self.assertTrue(internal_tx._to_is_a_safe)
+        self.assertFalse(internal_tx._from_is_a_safe)

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -29,6 +29,7 @@ from ..models import (
     TransactionServiceEventType,
     post_bulk_create,
 )
+from ..services.event_service import set_safe_membership
 from ..signals import (
     _process_event,
     _process_event_and_close_connections,
@@ -46,13 +47,20 @@ from .factories import (
 
 
 class TestSignals(SafeTestCaseMixin, TestCase):
+    @staticmethod
+    def _annotated(instance):
+        # Mark both sides as tracked Safes so both directional events are emitted (the
+        # default for these structural assertions; gating is covered by dedicated tests).
+        set_safe_membership(instance, to_is_a_safe=True, from_is_a_safe=True)
+        return instance
+
     @factory.django.mute_signals(post_save)
     def test_build_message_payload(self):
         self.assertEqual(
             [
                 payload["type"]
                 for payload in build_event_payload(
-                    ERC20Transfer, ERC20TransferFactory()
+                    ERC20Transfer, self._annotated(ERC20TransferFactory())
                 )
             ],
             [
@@ -63,7 +71,9 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         self.assertEqual(
             [
                 payload["type"]
-                for payload in build_event_payload(InternalTx, InternalTxFactory())
+                for payload in build_event_payload(
+                    InternalTx, self._annotated(InternalTxFactory())
+                )
             ],
             [
                 TransactionServiceEventType.INCOMING_ETHER.name,
@@ -74,7 +84,7 @@ class TestSignals(SafeTestCaseMixin, TestCase):
             [
                 payload["chainId"]
                 for payload in build_event_payload(
-                    ERC20Transfer, ERC20TransferFactory()
+                    ERC20Transfer, self._annotated(ERC20TransferFactory())
                 )
             ],
             [str(EthereumNetwork.GANACHE.value), str(EthereumNetwork.GANACHE.value)],
@@ -137,6 +147,77 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         self.assertEqual(payload["address"], safe_address)
         self.assertEqual(payload["messageHash"], safe_message.message_hash)
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
+
+    EVENT_SERVICE_LOGGER = "safe_transaction_service.history.services.event_service"
+
+    @factory.django.mute_signals(post_save)
+    def test_build_event_payload_token_gating(self):
+        # Only the directional event whose side is a tracked Safe is emitted
+        cases = [
+            (
+                True,
+                True,
+                [
+                    TransactionServiceEventType.INCOMING_TOKEN.name,
+                    TransactionServiceEventType.OUTGOING_TOKEN.name,
+                ],
+            ),
+            (True, False, [TransactionServiceEventType.INCOMING_TOKEN.name]),
+            (False, True, [TransactionServiceEventType.OUTGOING_TOKEN.name]),
+            (False, False, []),  # router->router: emit neither, silently
+        ]
+        for to_is_a_safe, from_is_a_safe, expected in cases:
+            with self.subTest(to=to_is_a_safe, from_=from_is_a_safe):
+                transfer = ERC20TransferFactory()
+                set_safe_membership(
+                    transfer, to_is_a_safe=to_is_a_safe, from_is_a_safe=from_is_a_safe
+                )
+                with self.assertNoLogs(self.EVENT_SERVICE_LOGGER, level="ERROR"):
+                    payloads = build_event_payload(ERC20Transfer, transfer)
+                self.assertEqual([p["type"] for p in payloads], expected)
+
+    @factory.django.mute_signals(post_save)
+    def test_build_event_payload_ether_gating(self):
+        cases = [
+            (
+                True,
+                True,
+                [
+                    TransactionServiceEventType.INCOMING_ETHER.name,
+                    TransactionServiceEventType.OUTGOING_ETHER.name,
+                ],
+            ),
+            (True, False, [TransactionServiceEventType.INCOMING_ETHER.name]),
+            (False, True, [TransactionServiceEventType.OUTGOING_ETHER.name]),
+            (False, False, []),
+        ]
+        for to_is_a_safe, from_is_a_safe, expected in cases:
+            with self.subTest(to=to_is_a_safe, from_=from_is_a_safe):
+                internal_tx = InternalTxFactory()
+                set_safe_membership(
+                    internal_tx,
+                    to_is_a_safe=to_is_a_safe,
+                    from_is_a_safe=from_is_a_safe,
+                )
+                with self.assertNoLogs(self.EVENT_SERVICE_LOGGER, level="ERROR"):
+                    payloads = build_event_payload(InternalTx, internal_tx)
+                self.assertEqual([p["type"] for p in payloads], expected)
+
+    @factory.django.mute_signals(post_save)
+    def test_build_event_payload_missing_metadata_logs_error(self):
+        # Unannotated instances must emit nothing and log an error pinpointing the transfer
+        transfer = ERC20TransferFactory()  # not annotated
+        with self.assertLogs(self.EVENT_SERVICE_LOGGER, level="ERROR") as cm:
+            self.assertEqual(build_event_payload(ERC20Transfer, transfer), [])
+        self.assertIn("Lacking metadata", cm.output[0])
+        self.assertIn(to_0x_hex_str(HexBytes(transfer.ethereum_tx_id)), cm.output[0])
+        self.assertIn(str(transfer.log_index), cm.output[0])
+
+        internal_tx = InternalTxFactory()  # not annotated, is_ether_transfer
+        with self.assertLogs(self.EVENT_SERVICE_LOGGER, level="ERROR") as cm:
+            self.assertEqual(build_event_payload(InternalTx, internal_tx), [])
+        self.assertIn(to_0x_hex_str(HexBytes(internal_tx.ethereum_tx_id)), cm.output[0])
+        self.assertIn(internal_tx.trace_address, cm.output[0])
 
     @factory.django.mute_signals(post_save)
     def test_is_relevant_event_multisig_confirmation(self):


### PR DESCRIPTION
## What

Only emit `INCOMING_*` / `OUTGOING_*` events whose addressed side is a tracked Safe, so the queue no longer publishes transfer/ether events addressed to DEX routers, pools, WETH or the zero address.

## Why

`build_event_payload` emitted **both** a directional `INCOMING_*` (`address = instance.to`) and `OUTGOING_*` (`address = instance._from`) payload for every transfer / ether `InternalTx`, with no check that the addressed side is a tracked Safe.

- **Tokens (ERC20/721) & L2 ether:** the row is legitimately stored (one side *is* the Safe), but the other side still got a bogus event.
- **L1 ether:** the internal-tx indexer monitors Safe **master-copy** addresses. When a tx merely touches a master copy (e.g. a Safe receives a fee → its proxy delegatecalls the singleton), `InternalTx.is_relevant` stores **every** value hop in the tx — router→router hops included — each emitting junk events on both sides.

Confirmed end-to-end on `0xb6c9d812…`: a MetaMask smart account (a Safe) receives a 0.0006 ETH fee deep in the internal txs; that pulled the whole swap in and produced `OUTGOING_ETHER` events for the 1inch router, MetaMask Swaps Spender and Swap Router. Downstream (balance-service) then had to call `getSafeInfo` on every event and drop the non-Safes — wasteful at ~10M events/day.

Closes PLA-1606.

## How

Annotate each model instance at index time — where Safe membership is already known in memory — with two transient (non-DB) attributes, then gate emission in `build_event_payload`. The same instance flows from `bulk_create` to the `post_bulk_create` signal, so the annotation survives to payload building. No per-event DB query, no Redis set, no DB connection in the spawned greenlet.

- **`event_service.build_event_payload`** — emits `INCOMING_*` only if `_to_is_a_safe`, `OUTGOING_*` only if `_from_is_a_safe`. New `set_safe_membership` helper keeps the attribute names in one place.
- **ERC20/721 (`erc20_events_indexer`)** — membership against the indexer's in-memory address cache.
- **L1 ether (`internal_tx_indexer`)** — per-tx Safe proxies derived from the full (pre-filter) traces: the `from` of any non-errored delegatecall whose `to` is a monitored master copy.
- **L2 ether (`safe_events_indexer`)** — the Safe is the event emitter (`safe_address`).

**Fail-closed with observability:** indexers always set both attributes (each possibly `False`). An *annotated* transfer with neither side a Safe (router→router) emits nothing, silently. An *unannotated* instance reaching payload building emits nothing **and** logs `error("Lacking metadata to build event for transfer with hash …")` with the tx hash and log_index/trace_address, so any missed path is visible rather than silently over-emitting.

No stored data changes. (Trimming the L1 ether noise rows from storage is intentionally out of scope — separate follow-up.)