### PR TITLE
feat: Add trusted flag to INCOMING_TOKEN/OUTGOING_TOKEN events

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -675,6 +675,9 @@ TOKENS_ENS_IMAGE_URL = env.str(
 TOKENS_ERC20_GET_BALANCES_BATCH = env.int(
     "TOKENS_ERC20_GET_BALANCES_BATCH", default=2_000
 )  # Number of tokens to get balances from in the same request. From 2_500 some nodes raise HTTP 413
+TOKENS_TRUSTED_CACHE_TTL = env.int(
+    "TOKENS_TRUSTED_CACHE_TTL", default=60 * 60
+)  # Seconds the in-memory set of trusted token addresses is cached for (default 1h)
 
 # ENS
 # ------------------------------------------------------------------------------

--- a/safe_transaction_service/history/services/event_service.py
+++ b/safe_transaction_service/history/services/event_service.py
@@ -30,6 +30,7 @@ from safe_transaction_service.safe_messages.models import (
     SafeMessage,
     SafeMessageConfirmation,
 )
+from safe_transaction_service.tokens.services import TokenServiceProvider
 from safe_transaction_service.utils.ethereum import get_chain_id
 
 logger = getLogger(__name__)
@@ -183,6 +184,7 @@ def build_event_payload(
             "type": TransactionServiceEventType.INCOMING_TOKEN.name,
             "tokenAddress": instance.address,
             "txHash": to_0x_hex_str(HexBytes(instance.ethereum_tx_id)),
+            "trusted": TokenServiceProvider().is_trusted(instance.address),
         }
         if isinstance(instance, ERC20Transfer):
             incoming_payload["value"] = str(instance.value)

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -21,8 +21,11 @@ from ...safe_messages.tests.factories import (
     SafeMessageConfirmationFactory,
     SafeMessageFactory,
 )
+from ...tokens.services import TokenServiceProvider
+from ...tokens.tests.factories import TokenFactory
 from ..models import (
     ERC20Transfer,
+    ERC721Transfer,
     InternalTx,
     MultisigConfirmation,
     MultisigTransaction,
@@ -38,6 +41,7 @@ from ..signals import (
 )
 from .factories import (
     ERC20TransferFactory,
+    ERC721TransferFactory,
     InternalTxFactory,
     MultisigConfirmationFactory,
     MultisigTransactionFactory,
@@ -175,6 +179,27 @@ class TestSignals(SafeTestCaseMixin, TestCase):
                 with self.assertNoLogs(self.EVENT_SERVICE_LOGGER, level="ERROR"):
                     payloads = build_event_payload(ERC20Transfer, transfer)
                 self.assertEqual([p["type"] for p in payloads], expected)
+
+    @factory.django.mute_signals(post_save)
+    def test_build_event_payload_token_trusted(self):
+        self.addCleanup(TokenServiceProvider.del_singleton)
+        for sender, transfer_factory in (
+            (ERC20Transfer, ERC20TransferFactory),
+            (ERC721Transfer, ERC721TransferFactory),
+        ):
+            with self.subTest(sender=sender):
+                # An unknown / non-trusted token is flagged as not trusted
+                TokenServiceProvider.del_singleton()
+                transfer = self._annotated(transfer_factory())
+                payloads = build_event_payload(sender, transfer)
+                self.assertEqual([p["trusted"] for p in payloads], [False, False])
+
+                # A trusted token is flagged as trusted on both directional payloads
+                TokenServiceProvider.del_singleton()
+                trusted_transfer = self._annotated(transfer_factory())
+                TokenFactory(address=trusted_transfer.address, trusted=True)
+                payloads = build_event_payload(sender, trusted_transfer)
+                self.assertEqual([p["trusted"] for p in payloads], [True, True])
 
     @factory.django.mute_signals(post_save)
     def test_build_event_payload_ether_gating(self):

--- a/safe_transaction_service/tokens/apps.py
+++ b/safe_transaction_service/tokens/apps.py
@@ -5,3 +5,6 @@ from django.apps import AppConfig
 class TokensConfig(AppConfig):
     name = "safe_transaction_service.tokens"
     verbose_name = "Tokens for Safe Transaction Service"
+
+    def ready(self):
+        from . import signals  # noqa

--- a/safe_transaction_service/tokens/services/__init__.py
+++ b/safe_transaction_service/tokens/services/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+# flake8: noqa F401
+from .token_service import TokenService, TokenServiceProvider

--- a/safe_transaction_service/tokens/services/token_service.py
+++ b/safe_transaction_service/tokens/services/token_service.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+from threading import Lock
+
+from django.conf import settings
+
+from cachetools import TTLCache
+from eth_typing import ChecksumAddress
+
+from ..models import Token
+
+
+class TokenServiceProvider:
+    def __new__(cls):
+        if not hasattr(cls, "instance"):
+            cls.instance = TokenService()
+        return cls.instance
+
+    @classmethod
+    def del_singleton(cls):
+        if hasattr(cls, "instance"):
+            del cls.instance
+
+
+class TokenService:
+    def __init__(self):
+        self.cache_trusted_addresses: TTLCache[str, frozenset[ChecksumAddress]] = (
+            TTLCache(maxsize=1, ttl=settings.TOKENS_TRUSTED_CACHE_TTL)
+        )
+        self._trusted_addresses_lock = Lock()
+
+    def _load_trusted_token_addresses(self) -> frozenset[ChecksumAddress]:
+        return frozenset(
+            Token.objects.filter(trusted=True).values_list("address", flat=True)
+        )
+
+    def get_trusted_token_addresses(self) -> frozenset[ChecksumAddress]:
+        """
+        :return: Set with the addresses of every trusted token. Cached in memory
+            for ``TOKENS_TRUSTED_CACHE_TTL`` seconds.
+        """
+        cache_key = "trusted_addresses"
+        try:
+            return self.cache_trusted_addresses[cache_key]
+        except KeyError:
+            pass
+
+        # Lock to avoid a stampede of concurrent queries refilling the cache
+        with self._trusted_addresses_lock:
+            try:
+                return self.cache_trusted_addresses[cache_key]
+            except KeyError:
+                trusted_addresses = self._load_trusted_token_addresses()
+                self.cache_trusted_addresses[cache_key] = trusted_addresses
+                return trusted_addresses
+
+    def is_trusted(self, token_address: ChecksumAddress) -> bool:
+        """
+        :param token_address:
+        :return: ``True`` if the token is trusted, ``False`` otherwise
+        """
+        return token_address in self.get_trusted_token_addresses()

--- a/safe_transaction_service/tokens/signals.py
+++ b/safe_transaction_service/tokens/signals.py
@@ -11,6 +11,7 @@ from safe_transaction_service.history.services import (
 )
 
 from .models import Token
+from .services import TokenServiceProvider
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,8 @@ def clear_cache(sender: type[Model], instance: Token, created: bool, **kwargs) -
     :param kwargs:
     :return:
     """
+
+    TokenServiceProvider().cache_trusted_addresses.clear()
 
     if not created:
         balance_service = BalanceServiceProvider()

--- a/safe_transaction_service/tokens/tasks.py
+++ b/safe_transaction_service/tokens/tasks.py
@@ -17,6 +17,7 @@ from safe_transaction_service.utils.ethereum import get_ethereum_network
 from ..utils.celery import task_timeout
 from .exceptions import TokenListRetrievalException
 from .models import Token, TokenList, TokenListToken
+from .services import TokenServiceProvider
 
 logger = get_task_logger(__name__)
 
@@ -140,4 +141,6 @@ def update_token_info_from_token_list_task() -> int:
                 tokens_updated_count += Token.objects.filter(
                     address=token_address
                 ).update(**update_fields)
-        return tokens_updated_count
+
+    TokenServiceProvider().cache_trusted_addresses.clear()
+    return tokens_updated_count

--- a/safe_transaction_service/tokens/tests/test_services.py
+++ b/safe_transaction_service/tokens/tests/test_services.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+from django.test import TestCase
+
+from eth_account import Account
+
+from ..models import Token
+from ..services import TokenServiceProvider
+from .factories import TokenFactory
+
+
+class TokenServiceTestCase(TestCase):
+    def setUp(self):
+        TokenServiceProvider.del_singleton()
+
+    def tearDown(self):
+        TokenServiceProvider.del_singleton()
+
+    def test_is_trusted(self):
+        token_service = TokenServiceProvider()
+        trusted_token = TokenFactory(trusted=True)
+        TokenFactory(trusted=False)
+
+        self.assertTrue(token_service.is_trusted(trusted_token.address))
+        self.assertFalse(token_service.is_trusted(Account.create().address))
+
+    def test_get_trusted_token_addresses(self):
+        token_service = TokenServiceProvider()
+        self.assertEqual(token_service.get_trusted_token_addresses(), frozenset())
+
+        # Saving a Token fires the `post_save` signal that clears the cache
+        trusted_token = TokenFactory(trusted=True)
+        self.assertEqual(
+            token_service.get_trusted_token_addresses(),
+            frozenset({trusted_token.address}),
+        )
+
+    def test_cache_is_stale_until_cleared(self):
+        token_service = TokenServiceProvider()
+        token = TokenFactory(trusted=False)
+        # Populate the cache while the token is not trusted
+        self.assertEqual(token_service.get_trusted_token_addresses(), frozenset())
+
+        # A bulk `update` does not fire the `post_save` signal, so the cache is
+        # not invalidated and the change is not visible yet
+        Token.objects.filter(address=token.address).update(trusted=True)
+        self.assertEqual(token_service.get_trusted_token_addresses(), frozenset())
+
+        # Clearing the cache (as the daily task does) makes the change visible
+        token_service.cache_trusted_addresses.clear()
+        self.assertEqual(
+            token_service.get_trusted_token_addresses(), frozenset({token.address})
+        )

--- a/safe_transaction_service/tokens/tests/test_tasks.py
+++ b/safe_transaction_service/tokens/tests/test_tasks.py
@@ -10,6 +10,7 @@ from safe_eth.eth.ethereum_client import EthereumNetwork
 
 from ...utils.redis import get_redis
 from ..models import TokenList
+from ..services import TokenServiceProvider
 from ..tasks import fix_pool_tokens_task, update_token_info_from_token_list_task
 from .factories import TokenFactory, TokenListFactory
 from .mocks import token_list_mock
@@ -61,9 +62,15 @@ class TestTasks(TestCase):
             symbol="OLD",
         )
         self.assertFalse(token.trusted)
+        # Populate the trusted tokens cache while the token is not trusted yet
+        token_service = TokenServiceProvider()
+        self.assertEqual(token_service.get_trusted_token_addresses(), frozenset())
         self.assertEqual(update_token_info_from_token_list_task.delay().result, 1)
         token.refresh_from_db()
         self.assertTrue(token.trusted)
+        # The task marks tokens as trusted with a bulk `update` (no `post_save`
+        # signal), so it must clear the cache itself for the change to be visible
+        self.assertIn(token.address, token_service.get_trusted_token_addresses())
         self.assertEqual(
             token.logo_uri,
             "https://cloudflare-ipfs.com/ipfs/QmYNLKHDEoG9FLJtbJ1r8HCyi7by9gksuacRkhkakxwEQ8",


### PR DESCRIPTION
- Closes [PLA-1661](https://linear.app/safe-global/issue/PLA-1661/add-trusted-flag-to-incoming-token-outgoing-token-webhook-events)

Adds a `trusted` boolean for token transfer events from an in-memory TokenService cache, avoiding per-event DB lookups on the indexing path. 

Also wire up the tokens app `ready()` so its post_save signal (cache invalidation) is actually connected. 
  