### PR TITLE
Add isFailed boolean to EXECUTED_MULTISIG_TRANSACTION event

### DIFF
--- a/safe_transaction_service/history/services/event_service.py
+++ b/safe_transaction_service/history/services/event_service.py
@@ -154,9 +154,9 @@ def build_event_payload(
             payload["type"] = (
                 TransactionServiceEventType.EXECUTED_MULTISIG_TRANSACTION.name
             )
-            payload["failed"] = json.dumps(
-                instance.failed
-            )  # Firebase only accepts strings
+            # Deprecated: stringified boolean kept for legacy clients, use `isFailed` instead
+            payload["failed"] = json.dumps(instance.failed)
+            payload["isFailed"] = instance.failed
             payload["txHash"] = to_0x_hex_str(HexBytes(instance.ethereum_tx_id))
         else:
             payload["type"] = (

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -277,6 +277,7 @@ class TestSignals(SafeTestCaseMixin, TestCase):
                 to_0x_hex_str(HexBytes(multisig_tx.data)) if multisig_tx.data else None
             ),
             "failed": "false",
+            "isFailed": False,
             "txHash": multisig_tx.ethereum_tx_id,
             "chainId": str(EthereumNetwork.GANACHE.value),
         }


### PR DESCRIPTION
The failed flag was stringified ("true"/"false") only because Firebase required string values. Firebase is no longer used. Add a proper boolean isFailed field alongside the deprecated failed string so clients can migrate without breaking. failed will be removed after a deprecation window.