### PR TITLE
chore: optimize dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,62 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    open-pull-requests-limit: 10
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 7
+    groups:
+      django:
+        patterns:
+          - "django*"
+          - "drf*"
+        update-types:
+          - minor
+          - patch
+      eth:
+        patterns:
+          - "safe-eth-py"
+          - "web3"
+          - "eth-*"
+        update-types:
+          - minor
+          - patch
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: docker
     directory: "/docker/web"
     schedule:
       interval: weekly
       day: monday
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      docker:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
       day: monday
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## What

Optimize `.github/dependabot.yml` following GitHub's [PR-creation recommendations](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates), mirroring the change made in `safe-fee-service` (#130) and adapting it to this repo's Python/`uv` stack.

## Changes

- **Cooldown + grouping for `github-actions` and `docker`** — previously had neither, so they PR'd on day-zero releases, one per bump. Now grouped into a single PR each with a 7-day cooldown.
- **Per-semver cooldown for `uv`** — `semver-major-days: 30 / semver-minor-days: 7 / semver-patch-days: 7`, so riskier bumps soak longer. The 7-day floor matches the existing `exclude-newer = "7 days"` in `pyproject.toml`; using fee-service's 3-day patch cooldown here would let dependabot propose releases that `uv lock` then refuses to resolve.
- **`uv` groups + catch-all** — `django` (`django*`, `drf*`) and `eth` (`safe-eth-py`, `web3`, `eth-*`) families, plus a `dependencies` catch-all to consolidate the long tail. All groups are scoped to minor/patch, so majors still open individual PRs. Group order is intentional: dependabot assigns each dependency to the first matching group, so the family carve-outs sit above the catch-all.
- **`open-pull-requests-limit: 10`** on all three ecosystems (was unset, defaulting to 5).
