### PR TITLE
Add timestamp and per-transfer id to transfer events

### DIFF
--- a/safe_transaction_service/history/helpers.py
+++ b/safe_transaction_service/history/helpers.py
@@ -4,6 +4,7 @@ import time
 
 from eth_typing import ChecksumAddress, Hash32, HexStr
 from eth_utils import keccak
+from hexbytes import HexBytes
 from safe_eth.eth.eip712 import eip712_encode, eip712_encode_hash
 from safe_eth.eth.utils import fast_keccak
 
@@ -128,6 +129,35 @@ class DelegateSignatureHelperV2(TemporarySignatureHelper):
 
         preimage = b"".join(eip712_encode(payload))
         return fast_keccak(preimage), preimage
+
+
+def build_transfer_unique_id(
+    transaction_hash: bytes,
+    log_index: int | None = None,
+    trace_address: str | None = None,
+) -> str:
+    """
+    Build the unique transfer id shared by the API and the queue events, so the format
+    is defined in a single place.
+
+    Token transfers (ERC20/ERC721) are identified as ``e`` + transaction_hash + log_index.
+    Ether transfers (internal txs) are identified as ``i`` + transaction_hash + trace_address.
+
+    :param transaction_hash: transaction hash, as bytes
+    :param log_index: log index, set for token transfers
+    :param trace_address: trace address, set for ether transfers
+    :return: unique transfer id
+    :raises ValueError: if not exactly one of ``log_index`` / ``trace_address`` is provided
+    """
+    if (log_index is None) == (trace_address is None):
+        raise ValueError(
+            "Exactly one of log_index (token transfers) or trace_address "
+            "(ether transfers) must be provided"
+        )
+    tx_hash = bytes(HexBytes(transaction_hash)).hex()
+    if trace_address is not None:
+        return f"i{tx_hash}{trace_address}"
+    return f"e{tx_hash}{log_index}"
 
 
 def is_valid_unique_transfer_id(unique_transfer_id: str) -> bool:

--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 
 from drf_spectacular.utils import extend_schema_field
 from eth_typing import ChecksumAddress
+from hexbytes import HexBytes
 from rest_framework import serializers
 from rest_framework.exceptions import NotFound, ValidationError
 from safe_eth.eth import EthereumClient, get_auto_ethereum_client
@@ -47,6 +48,7 @@ from .helpers import (
     DelegateSignatureHelper,
     DelegateSignatureHelperV2,
     DeleteMultisigTxSignatureHelper,
+    build_transfer_unique_id,
 )
 from .models import (
     MAX_SIGNATURE_LENGTH,
@@ -991,11 +993,15 @@ class TransferResponseSerializer(serializers.Serializer):
             return TransferType.UNKNOWN.name
 
     def get_transfer_id(self, obj: TransferDict) -> str:
-        transaction_hash = obj["transaction_hash"][2:]  # Remove 0x
+        transaction_hash = HexBytes(obj["transaction_hash"])
         if self.get_type(obj) == TransferType.ETHER_TRANSFER.name:
-            return "i" + transaction_hash + obj["_trace_address"]
+            return build_transfer_unique_id(
+                transaction_hash, trace_address=obj["_trace_address"]
+            )
         else:
-            return "e" + transaction_hash + str(obj["_log_index"])
+            return build_transfer_unique_id(
+                transaction_hash, log_index=obj["_log_index"]
+            )
 
     def validate(self, attrs):
         super().validate(attrs)

--- a/safe_transaction_service/history/services/event_service.py
+++ b/safe_transaction_service/history/services/event_service.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from hexbytes import HexBytes
 from safe_eth.util.util import to_0x_hex_str
 
+from safe_transaction_service.history.helpers import build_transfer_unique_id
 from safe_transaction_service.history.models import (
     ERC20Transfer,
     ERC721Transfer,
@@ -164,11 +165,17 @@ def build_event_payload(
                 TransactionServiceEventType.PENDING_MULTISIG_TRANSACTION.name
             )
         payloads = [payload]
-    elif sender == InternalTx and instance.is_ether_transfer:  # INCOMING_ETHER
+    elif sender == InternalTx and instance.is_ether_transfer:
+        # INCOMING_ETHER / OUTGOING_ETHER
+        transaction_hash = HexBytes(instance.ethereum_tx_id)
         incoming_payload = {
+            "id": build_transfer_unique_id(
+                transaction_hash, trace_address=instance.trace_address
+            ),
+            "timestamp": int(instance.timestamp.timestamp()),
             "address": instance.to,
             "type": TransactionServiceEventType.INCOMING_ETHER.name,
-            "txHash": to_0x_hex_str(HexBytes(instance.ethereum_tx_id)),
+            "txHash": to_0x_hex_str(transaction_hash),
             "value": str(instance.value),
         }
         outgoing_payload = dict(incoming_payload)
@@ -179,11 +186,16 @@ def build_event_payload(
         )
     elif sender in (ERC20Transfer, ERC721Transfer):
         # INCOMING_TOKEN / OUTGOING_TOKEN
+        transaction_hash = HexBytes(instance.ethereum_tx_id)
         incoming_payload = {
+            "id": build_transfer_unique_id(
+                transaction_hash, log_index=instance.log_index
+            ),
+            "timestamp": int(instance.timestamp.timestamp()),
             "address": instance.to,
             "type": TransactionServiceEventType.INCOMING_TOKEN.name,
             "tokenAddress": instance.address,
-            "txHash": to_0x_hex_str(HexBytes(instance.ethereum_tx_id)),
+            "txHash": to_0x_hex_str(transaction_hash),
             "trusted": TokenServiceProvider().is_trusted(instance.address),
         }
         if isinstance(instance, ERC20Transfer):

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -23,6 +23,7 @@ from ...safe_messages.tests.factories import (
 )
 from ...tokens.services import TokenServiceProvider
 from ...tokens.tests.factories import TokenFactory
+from ..helpers import build_transfer_unique_id
 from ..models import (
     ERC20Transfer,
     ERC721Transfer,
@@ -151,6 +152,45 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         self.assertEqual(payload["address"], safe_address)
         self.assertEqual(payload["messageHash"], safe_message.message_hash)
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
+
+    @factory.django.mute_signals(post_save)
+    def test_build_event_payload_transfer_id_and_timestamp(self):
+        # Token transfer: `id` uses the log_index scheme, both directional payloads
+        # share the same `id` and `timestamp` (Unix epoch seconds, int)
+        transfer = self._annotated(ERC20TransferFactory())
+        expected_id = build_transfer_unique_id(
+            HexBytes(transfer.ethereum_tx_id), log_index=transfer.log_index
+        )
+        expected_timestamp = int(transfer.timestamp.timestamp())
+        payloads = build_event_payload(ERC20Transfer, transfer)
+        self.assertEqual(len(payloads), 2)
+        for payload in payloads:
+            self.assertEqual(payload["id"], expected_id)
+            self.assertEqual(payload["timestamp"], expected_timestamp)
+            self.assertIsInstance(payload["timestamp"], int)
+
+        # Ether transfer: `id` uses the trace_address scheme
+        internal_tx = self._annotated(InternalTxFactory())
+        expected_id = build_transfer_unique_id(
+            HexBytes(internal_tx.ethereum_tx_id),
+            trace_address=internal_tx.trace_address,
+        )
+        expected_timestamp = int(internal_tx.timestamp.timestamp())
+        payloads = build_event_payload(InternalTx, internal_tx)
+        self.assertEqual(len(payloads), 2)
+        for payload in payloads:
+            self.assertEqual(payload["id"], expected_id)
+            self.assertEqual(payload["timestamp"], expected_timestamp)
+            self.assertIsInstance(payload["timestamp"], int)
+
+    def test_build_transfer_unique_id_requires_exactly_one_identifier(self):
+        tx_hash = HexBytes("0x" + "ab" * 32)
+        # Neither identifier provided
+        with self.assertRaises(ValueError):
+            build_transfer_unique_id(tx_hash)
+        # Both identifiers provided
+        with self.assertRaises(ValueError):
+            build_transfer_unique_id(tx_hash, log_index=0, trace_address="0")
 
     EVENT_SERVICE_LOGGER = "safe_transaction_service.history.services.event_service"
 


### PR DESCRIPTION
## What

Transfer events (`INCOMING_ETHER`, `OUTGOING_ETHER`, `INCOMING_TOKEN`, `OUTGOING_TOKEN`) now carry two extra fields consumers (starting with balance-service) need:

- **`timestamp`**: block timestamp as a Unix epoch integer (seconds), taken from the existing `timestamp` column on the transfer row. No extra DB/RPC call.
- **`id`**: per-transfer unique identifier, reusing the existing `transferId` scheme:
  - token transfers: `e` + txHash (no `0x`) + logIndex
  - ether transfers: `i` + txHash (no `0x`) + traceAddress

## Why

Consumers currently fetch the receipt/block just to get the timestamp (a large, avoidable RPC cost at ~10M events/day), and the current payload can't distinguish at-least-once redeliveries or multi-send transfers of the same token and amount. `id` gives a real unicity key per transfer within a tx.

## Notes

- The `transferId` format is now built from a single shared helper (`build_transfer_unique_id`) used by both the API serializer and the event payload, so the format lives in one place.
- `id` and `timestamp` are shared by the `INCOMING_*`/`OUTGOING_*` pair of the same on-chain transfer, so `id` is unique per transfer-within-tx, not per event. Consumers keying a per-transfer table on `id` must include the Safe address + direction.
- Additive, backwards-compatible payload change.
- events-service README update tracked in PLA-1701.

Closes PLA-1607
