### PR TITLE
Log when an untrusted multisig transaction is proposed

### DIFF
--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -378,6 +378,17 @@ class SafeMultisigTransactionSerializer(SafeMultisigTxSerializer):
             multisig_transaction.trusted = trusted
             multisig_transaction.save(update_fields=["origin", "trusted"])
 
+        if created and not trusted:
+            logger.info(
+                "Proposed untrusted MultisigTransaction safe_tx_hash=%s safe=%s "
+                "proposer=%s proposed_by_delegate=%s sender=%s",
+                to_0x_hex_str(safe_tx_hash),
+                self.validated_data["safe"],
+                proposer,
+                proposed_by_delegate,
+                self.validated_data["sender"],
+            )
+
         logger.info(
             f"MultisigTransaction {'Created' if created else 'Updated'}",
             extra={


### PR DESCRIPTION
## What

Add a dedicated log line in `SafeMultisigTransactionSerializer.save()` that fires only when a newly created multisig transaction is `trusted=False`. It records who proposed it:

- `safe_tx_hash`
- `safe`
- `proposer`
- `proposed_by_delegate`
- raw request `sender`

## Why

We need visibility into when an untrusted transaction is proposed and by whom. The existing generic `MultisigTransaction Created` log dumps the full dict for every proposal and does not single out untrusted ones, so there is no clean line to grep or alert on.

The line is skipped for trusted proposals (signed, delegate-proposed, or `history.create_trusted` permission) and for updates / re-proposals of an existing transaction.

For untrusted proposals the proposer is not cryptographically verified yet (no signature), so the raw `sender` is logged alongside the claimed proposer.

Closes PLA-1703
