### PR TITLE
Add timestamp to remaining queue events

### DIFF
--- a/safe_transaction_service/history/services/event_service.py
+++ b/safe_transaction_service/history/services/event_service.py
@@ -139,10 +139,11 @@ def build_event_payload(
             }
         ]
     elif sender == MultisigTransaction and deleted:
-        # Off-chain event: use the last modification time as the deletion time
+        # Off-chain event fired on post_delete: `modified` is not refreshed on delete,
+        # so use the current time as the deletion (event emission) time
         payloads = [
             {
-                "timestamp": int(instance.modified.timestamp()),
+                "timestamp": int(timezone.now().timestamp()),
                 "address": instance.safe,
                 "type": TransactionServiceEventType.DELETED_MULTISIG_TRANSACTION.name,
                 "safeTxHash": to_0x_hex_str(HexBytes(instance.safe_tx_hash)),

--- a/safe_transaction_service/history/services/event_service.py
+++ b/safe_transaction_service/history/services/event_service.py
@@ -128,8 +128,10 @@ def build_event_payload(
     """
     payloads: list[dict[str, Any]] = []
     if sender == MultisigConfirmation and instance.multisig_transaction_id:
+        # Off-chain event: use the confirmation creation time
         payloads = [
             {
+                "timestamp": int(instance.created.timestamp()),
                 "address": instance.multisig_transaction.safe,  # This could make a db call
                 "type": TransactionServiceEventType.NEW_CONFIRMATION.name,
                 "owner": instance.owner,
@@ -137,8 +139,10 @@ def build_event_payload(
             }
         ]
     elif sender == MultisigTransaction and deleted:
+        # Off-chain event: use the last modification time as the deletion time
         payloads = [
             {
+                "timestamp": int(instance.modified.timestamp()),
                 "address": instance.safe,
                 "type": TransactionServiceEventType.DELETED_MULTISIG_TRANSACTION.name,
                 "safeTxHash": to_0x_hex_str(HexBytes(instance.safe_tx_hash)),
@@ -161,6 +165,9 @@ def build_event_payload(
             payload["isFailed"] = instance.failed
             payload["txHash"] = to_0x_hex_str(HexBytes(instance.ethereum_tx_id))
         else:
+            # Off-chain event (not yet executed): use the proposal creation time,
+            # kept first for readability
+            payload = {"timestamp": int(instance.created.timestamp()), **payload}
             payload["type"] = (
                 TransactionServiceEventType.PENDING_MULTISIG_TRANSACTION.name
             )
@@ -169,10 +176,10 @@ def build_event_payload(
         # INCOMING_ETHER / OUTGOING_ETHER
         transaction_hash = HexBytes(instance.ethereum_tx_id)
         incoming_payload = {
+            "timestamp": int(instance.timestamp.timestamp()),
             "id": build_transfer_unique_id(
                 transaction_hash, trace_address=instance.trace_address
             ),
-            "timestamp": int(instance.timestamp.timestamp()),
             "address": instance.to,
             "type": TransactionServiceEventType.INCOMING_ETHER.name,
             "txHash": to_0x_hex_str(transaction_hash),
@@ -188,10 +195,10 @@ def build_event_payload(
         # INCOMING_TOKEN / OUTGOING_TOKEN
         transaction_hash = HexBytes(instance.ethereum_tx_id)
         incoming_payload = {
+            "timestamp": int(instance.timestamp.timestamp()),
             "id": build_transfer_unique_id(
                 transaction_hash, log_index=instance.log_index
             ),
-            "timestamp": int(instance.timestamp.timestamp()),
             "address": instance.to,
             "type": TransactionServiceEventType.INCOMING_TOKEN.name,
             "tokenAddress": instance.address,
@@ -218,8 +225,11 @@ def build_event_payload(
             }
         ]
     elif sender == ModuleTransaction:
+        # On-chain event: block timestamp is denormalized on the related InternalTx,
+        # which is already dereferenced below, so no extra query is needed
         payloads = [
             {
+                "timestamp": int(instance.internal_tx.timestamp.timestamp()),
                 "address": instance.safe,
                 "type": TransactionServiceEventType.MODULE_TRANSACTION.name,
                 "module": instance.module,
@@ -227,16 +237,20 @@ def build_event_payload(
             }
         ]
     elif sender == SafeMessage:
+        # Off-chain event: use the message creation time
         payloads = [
             {
+                "timestamp": int(instance.created.timestamp()),
                 "address": instance.safe,
                 "type": TransactionServiceEventType.MESSAGE_CREATED.name,
                 "messageHash": to_0x_hex_str(HexBytes(instance.message_hash)),
             }
         ]
     elif sender == SafeMessageConfirmation:
+        # Off-chain event: use the confirmation creation time
         payloads = [
             {
+                "timestamp": int(instance.created.timestamp()),
                 "address": instance.safe_message.safe,  # This could make a db call
                 "type": TransactionServiceEventType.MESSAGE_CONFIRMATION.name,
                 "messageHash": to_0x_hex_str(HexBytes(instance.safe_message_id)),

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -129,21 +129,22 @@ class TestSignals(SafeTestCaseMixin, TestCase):
             payload["timestamp"], int(pending_multisig_tx.created.timestamp())
         )
 
-        # DELETED_MULTISIG_TRANSACTION: off-chain, timestamp from `modified`
+        # DELETED_MULTISIG_TRANSACTION: off-chain, fired on post_delete, timestamp is
+        # the current (deletion) time
         deleted_multisig_tx = MultisigTransactionFactory(ethereum_tx=None)
-        payload = build_event_payload(
-            MultisigTransaction,
-            deleted_multisig_tx,
-            deleted=True,
-        )[0]
+        delete_time = datetime.datetime(2026, 1, 2, 3, 4, 5, tzinfo=datetime.UTC)
+        with mock.patch.object(timezone, "now", return_value=delete_time):
+            payload = build_event_payload(
+                MultisigTransaction,
+                deleted_multisig_tx,
+                deleted=True,
+            )[0]
         self.assertEqual(
             payload["type"],
             TransactionServiceEventType.DELETED_MULTISIG_TRANSACTION.name,
         )
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
-        self.assertEqual(
-            payload["timestamp"], int(deleted_multisig_tx.modified.timestamp())
-        )
+        self.assertEqual(payload["timestamp"], int(delete_time.timestamp()))
 
         # MODULE_TRANSACTION: on-chain, timestamp from the related InternalTx block time
         module_tx = ModuleTransactionFactory()
@@ -379,13 +380,15 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         }
         send_event_mock.assert_called_with(pending_multisig_transaction_payload)
 
-        # Deleting a tx should fire an event
+        # Deleting a tx should fire an event timestamped at the deletion time
         send_event_mock.reset_mock()
         safe_tx_hash = multisig_tx.safe_tx_hash
-        multisig_tx.delete()
+        delete_time = datetime.datetime(2026, 1, 2, 3, 4, 5, tzinfo=datetime.UTC)
+        with mock.patch.object(timezone, "now", return_value=delete_time):
+            multisig_tx.delete()
 
         deleted_multisig_transaction_payload = {
-            "timestamp": int(multisig_tx.modified.timestamp()),
+            "timestamp": int(delete_time.timestamp()),
             "address": multisig_tx.safe,
             "type": TransactionServiceEventType.DELETED_MULTISIG_TRANSACTION.name,
             "safeTxHash": safe_tx_hash,

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -28,6 +28,7 @@ from ..models import (
     ERC20Transfer,
     ERC721Transfer,
     InternalTx,
+    ModuleTransaction,
     MultisigConfirmation,
     MultisigTransaction,
     TransactionServiceEventType,
@@ -44,6 +45,7 @@ from .factories import (
     ERC20TransferFactory,
     ERC721TransferFactory,
     InternalTxFactory,
+    ModuleTransactionFactory,
     MultisigConfirmationFactory,
     MultisigTransactionFactory,
     SafeContractDelegateFactory,
@@ -95,14 +97,16 @@ class TestSignals(SafeTestCaseMixin, TestCase):
             [str(EthereumNetwork.GANACHE.value), str(EthereumNetwork.GANACHE.value)],
         )
 
-        payload = build_event_payload(
-            MultisigConfirmation, MultisigConfirmationFactory()
-        )[0]
+        # NEW_CONFIRMATION: off-chain, timestamp from `created`
+        confirmation = MultisigConfirmationFactory()
+        payload = build_event_payload(MultisigConfirmation, confirmation)[0]
         self.assertEqual(
             payload["type"], TransactionServiceEventType.NEW_CONFIRMATION.name
         )
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
+        self.assertEqual(payload["timestamp"], int(confirmation.created.timestamp()))
 
+        # EXECUTED_MULTISIG_TRANSACTION is on-chain (tier 2): no timestamp yet
         payload = build_event_payload(
             MultisigTransaction, MultisigTransactionFactory()
         )[0]
@@ -111,19 +115,25 @@ class TestSignals(SafeTestCaseMixin, TestCase):
             TransactionServiceEventType.EXECUTED_MULTISIG_TRANSACTION.name,
         )
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
+        self.assertNotIn("timestamp", payload)
 
-        payload = build_event_payload(
-            MultisigTransaction, MultisigTransactionFactory(ethereum_tx=None)
-        )[0]
+        # PENDING_MULTISIG_TRANSACTION: off-chain, timestamp from `created`
+        pending_multisig_tx = MultisigTransactionFactory(ethereum_tx=None)
+        payload = build_event_payload(MultisigTransaction, pending_multisig_tx)[0]
         self.assertEqual(
             payload["type"],
             TransactionServiceEventType.PENDING_MULTISIG_TRANSACTION.name,
         )
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
+        self.assertEqual(
+            payload["timestamp"], int(pending_multisig_tx.created.timestamp())
+        )
 
+        # DELETED_MULTISIG_TRANSACTION: off-chain, timestamp from `modified`
+        deleted_multisig_tx = MultisigTransactionFactory(ethereum_tx=None)
         payload = build_event_payload(
             MultisigTransaction,
-            MultisigTransactionFactory(ethereum_tx=None),
+            deleted_multisig_tx,
             deleted=True,
         )[0]
         self.assertEqual(
@@ -131,6 +141,20 @@ class TestSignals(SafeTestCaseMixin, TestCase):
             TransactionServiceEventType.DELETED_MULTISIG_TRANSACTION.name,
         )
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
+        self.assertEqual(
+            payload["timestamp"], int(deleted_multisig_tx.modified.timestamp())
+        )
+
+        # MODULE_TRANSACTION: on-chain, timestamp from the related InternalTx block time
+        module_tx = ModuleTransactionFactory()
+        payload = build_event_payload(ModuleTransaction, module_tx)[0]
+        self.assertEqual(
+            payload["type"], TransactionServiceEventType.MODULE_TRANSACTION.name
+        )
+        self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
+        self.assertEqual(
+            payload["timestamp"], int(module_tx.internal_tx.timestamp.timestamp())
+        )
 
         safe_address = self.deploy_test_safe().address
         safe_message = SafeMessageFactory(safe=safe_address)
@@ -141,10 +165,14 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         self.assertEqual(payload["address"], safe_address)
         self.assertEqual(payload["messageHash"], safe_message.message_hash)
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
+        self.assertEqual(payload["timestamp"], int(safe_message.created.timestamp()))
 
+        safe_message_confirmation = SafeMessageConfirmationFactory(
+            safe_message=safe_message
+        )
         payload = build_event_payload(
             SafeMessageConfirmation,
-            SafeMessageConfirmationFactory(safe_message=safe_message),
+            safe_message_confirmation,
         )[0]
         self.assertEqual(
             payload["type"], TransactionServiceEventType.MESSAGE_CONFIRMATION.name
@@ -152,6 +180,9 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         self.assertEqual(payload["address"], safe_address)
         self.assertEqual(payload["messageHash"], safe_message.message_hash)
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
+        self.assertEqual(
+            payload["timestamp"], int(safe_message_confirmation.created.timestamp())
+        )
 
     @factory.django.mute_signals(post_save)
     def test_build_event_payload_transfer_id_and_timestamp(self):
@@ -354,6 +385,7 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         multisig_tx.delete()
 
         deleted_multisig_transaction_payload = {
+            "timestamp": int(multisig_tx.modified.timestamp()),
             "address": multisig_tx.safe,
             "type": TransactionServiceEventType.DELETED_MULTISIG_TRANSACTION.name,
             "safeTxHash": safe_tx_hash,

--- a/safe_transaction_service/safe_messages/tests/test_signals.py
+++ b/safe_transaction_service/safe_messages/tests/test_signals.py
@@ -33,6 +33,7 @@ class TestSafeMessageSignals(SafeTestCaseMixin, TestCase):
         safe_message = SafeMessageFactory(safe=safe_address)
         process_event(SafeMessage, safe_message, True)
         message_created_payload = {
+            "timestamp": int(safe_message.created.timestamp()),
             "address": safe_address,
             "type": TransactionServiceEventType.MESSAGE_CREATED.name,
             "messageHash": safe_message.message_hash,
@@ -58,6 +59,7 @@ class TestSafeMessageSignals(SafeTestCaseMixin, TestCase):
         # Creating a message should fire a signal and an event should be sent
         safe_message = SafeMessageFactory(safe=safe_address)
         message_created_payload = {
+            "timestamp": int(safe_message.created.timestamp()),
             "address": safe_address,
             "type": TransactionServiceEventType.MESSAGE_CREATED.name,
             "messageHash": safe_message.message_hash,
@@ -67,8 +69,11 @@ class TestSafeMessageSignals(SafeTestCaseMixin, TestCase):
         send_event_mock.assert_called_with(message_created_payload)
 
         # Creating a confirmation should fire a signal and an event should be sent
-        SafeMessageConfirmationFactory(safe_message=safe_message)
+        safe_message_confirmation = SafeMessageConfirmationFactory(
+            safe_message=safe_message
+        )
         message_confirmation_payload = {
+            "timestamp": int(safe_message_confirmation.created.timestamp()),
             "address": safe_address,
             "type": TransactionServiceEventType.MESSAGE_CONFIRMATION.name,
             "messageHash": safe_message.message_hash,


### PR DESCRIPTION
## What

Follow-up to PLA-1607 (which added `timestamp` + `id` to the four transfer events). Adds a `timestamp` field (Unix epoch seconds, int) to the remaining queue events that can source it **without an extra DB/RPC query**:

| Event | Source |
|---|---|
| `MODULE_TRANSACTION` | `internal_tx.timestamp` (on-chain block time; `internal_tx` already dereferenced) |
| `PENDING_MULTISIG_TRANSACTION` | `created` |
| `DELETED_MULTISIG_TRANSACTION` | `modified` |
| `NEW_CONFIRMATION` | `created` |
| `MESSAGE_CREATED` | `created` |
| `MESSAGE_CONFIRMATION` | `created` |

Off-chain events use the creation/modification time; module transactions use the denormalized `InternalTx` block timestamp. `timestamp` is the first key in each payload for readability.

## Out of scope

- `EXECUTED_MULTISIG_TRANSACTION`, `SAFE_CREATED` — on-chain, would need an extra `ethereum_tx → block` query.
- Delegate events — `SafeContractDelegate` has no `created`/`modified` field (would need a migration).
- `REORG_DETECTED` — no model instance, block may be gone during a reorg.

## Notes

- Additive, backwards-compatible payload change.
- Existing per-event payload tests now assert the new `timestamp`; no new dedicated test added.
- events-service README should document these fields as a follow-up (PLA-1701 tracks the transfer event docs).

Closes PLA-1707
