### PR TITLE
Enrich event data

### DIFF
--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -1798,6 +1798,21 @@ class MultisigTransaction(TimeStampedModel):
             and self.to not in Contract.objects.trusted_addresses_for_delegate_call()
         )
 
+    def get_confirmations_required(self) -> int | None:
+        threshold = (
+            SafeStatus.objects.filter(address=self.safe, nonce=self.nonce)
+            .order_by("-internal_tx_id")
+            .values_list("threshold", flat=True)
+            .first()
+        )
+        if threshold is None:
+            threshold = (
+                SafeLastStatus.objects.filter(address=self.safe)
+                .values_list("threshold", flat=True)
+                .first()
+            )
+        return threshold
+
 
 class ModuleTransactionManager(models.Manager):
     def not_indexed_metadata_contract_addresses(self):

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -1799,6 +1799,15 @@ class MultisigTransaction(TimeStampedModel):
         )
 
     def get_confirmations_required(self) -> int | None:
+        """
+        Confirmations required for execution (threshold of the Safe at this tx's nonce):
+        ``SafeStatus`` at the tx nonce, falling back to the current ``SafeLastStatus``.
+
+        Returns ``None`` when neither status is indexed (e.g. Safe not yet indexed or
+        being reprocessed after a reorg).
+
+        :return: Number of confirmations required, or ``None`` if not known
+        """
         threshold = (
             SafeStatus.objects.filter(address=self.safe, nonce=self.nonce)
             .order_by("-internal_tx_id")

--- a/safe_transaction_service/history/services/event_service.py
+++ b/safe_transaction_service/history/services/event_service.py
@@ -24,6 +24,7 @@ from safe_transaction_service.history.models import (
     MultisigTransaction,
     SafeContract,
     SafeContractDelegate,
+    SafeLastStatus,
     TokenTransfer,
     TransactionServiceEventType,
 )
@@ -110,6 +111,21 @@ def _filter_not_safe_transfers(
     return payloads
 
 
+def _get_safe_threshold(safe_address: str) -> int | None:
+    """
+    Current threshold of the Safe from ``SafeLastStatus``. Safe messages are not tied
+    to a nonce, so the current threshold is the correct value.
+
+    :param safe_address:
+    :return: Threshold, or `None` if the Safe has no indexed status yet
+    """
+    return (
+        SafeLastStatus.objects.filter(address=safe_address)
+        .values_list("threshold", flat=True)
+        .first()
+    )
+
+
 def build_event_payload(
     sender: type[Model],
     instance: TokenTransfer
@@ -136,6 +152,8 @@ def build_event_payload(
                 "type": TransactionServiceEventType.NEW_CONFIRMATION.name,
                 "owner": instance.owner,
                 "safeTxHash": to_0x_hex_str(HexBytes(instance.multisig_transaction_id)),
+                "confirmationsRequired": instance.multisig_transaction.get_confirmations_required(),
+                "confirmationsCount": instance.multisig_transaction.confirmations.count(),
             }
         ]
     elif sender == MultisigTransaction and deleted:
@@ -165,6 +183,7 @@ def build_event_payload(
             payload["failed"] = json.dumps(instance.failed)
             payload["isFailed"] = instance.failed
             payload["txHash"] = to_0x_hex_str(HexBytes(instance.ethereum_tx_id))
+            payload["executor"] = instance.ethereum_tx._from
         else:
             # Off-chain event (not yet executed): use the proposal creation time,
             # kept first for readability
@@ -245,6 +264,7 @@ def build_event_payload(
                 "address": instance.safe,
                 "type": TransactionServiceEventType.MESSAGE_CREATED.name,
                 "messageHash": to_0x_hex_str(HexBytes(instance.message_hash)),
+                "threshold": _get_safe_threshold(instance.safe),
             }
         ]
     elif sender == SafeMessageConfirmation:
@@ -255,6 +275,8 @@ def build_event_payload(
                 "address": instance.safe_message.safe,  # This could make a db call
                 "type": TransactionServiceEventType.MESSAGE_CONFIRMATION.name,
                 "messageHash": to_0x_hex_str(HexBytes(instance.safe_message_id)),
+                "threshold": _get_safe_threshold(instance.safe_message.safe),
+                "owner": instance.owner,
             }
         ]
 

--- a/safe_transaction_service/history/services/event_service.py
+++ b/safe_transaction_service/history/services/event_service.py
@@ -114,7 +114,7 @@ def _filter_not_safe_transfers(
 def _get_safe_threshold(safe_address: str) -> int | None:
     """
     Current threshold of the Safe from ``SafeLastStatus``. Safe messages are not tied
-    to a nonce, so the current threshold is the correct value.
+    to a nonce, so using the last known threshold value.
 
     :param safe_address:
     :return: Threshold, or `None` if the Safe has no indexed status yet

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -107,7 +107,16 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
         self.assertEqual(payload["timestamp"], int(confirmation.created.timestamp()))
         self.assertEqual(payload["owner"], confirmation.owner)
-        self.assertEqual(payload["confirmationsRequired"], 1)
+        # No SafeStatus/SafeLastStatus indexed: confirmationsRequired is unknown (None),
+        # rather than a guessed value. confirmationsCount is always the real count.
+        self.assertIsNone(payload["confirmationsRequired"])
+        self.assertEqual(payload["confirmationsCount"], 1)
+
+        # With a SafeLastStatus, confirmationsRequired reflects the Safe threshold
+        multisig_transaction = confirmation.multisig_transaction
+        SafeLastStatusFactory(address=multisig_transaction.safe, threshold=3)
+        payload = build_event_payload(MultisigConfirmation, confirmation)[0]
+        self.assertEqual(payload["confirmationsRequired"], 3)
         self.assertEqual(payload["confirmationsCount"], 1)
 
         multisig_transaction = MultisigTransactionFactory()
@@ -387,6 +396,7 @@ class TestSignals(SafeTestCaseMixin, TestCase):
             "failed": "false",
             "isFailed": False,
             "txHash": multisig_tx.ethereum_tx_id,
+            "executor": multisig_tx.ethereum_tx._from,
             "chainId": str(EthereumNetwork.GANACHE.value),
         }
         send_event_mock.assert_called_with(pending_multisig_transaction_payload)

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -50,6 +50,7 @@ from .factories import (
     MultisigTransactionFactory,
     SafeContractDelegateFactory,
     SafeContractFactory,
+    SafeLastStatusFactory,
 )
 
 
@@ -105,17 +106,20 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         )
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
         self.assertEqual(payload["timestamp"], int(confirmation.created.timestamp()))
+        self.assertEqual(payload["owner"], confirmation.owner)
+        self.assertEqual(payload["confirmationsRequired"], 1)
+        self.assertEqual(payload["confirmationsCount"], 1)
 
+        multisig_transaction = MultisigTransactionFactory()
         # EXECUTED_MULTISIG_TRANSACTION is on-chain (tier 2): no timestamp yet
-        payload = build_event_payload(
-            MultisigTransaction, MultisigTransactionFactory()
-        )[0]
+        payload = build_event_payload(MultisigTransaction, multisig_transaction)[0]
         self.assertEqual(
             payload["type"],
             TransactionServiceEventType.EXECUTED_MULTISIG_TRANSACTION.name,
         )
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
         self.assertNotIn("timestamp", payload)
+        self.assertEqual(payload["executor"], multisig_transaction.ethereum_tx._from)
 
         # PENDING_MULTISIG_TRANSACTION: off-chain, timestamp from `created`
         pending_multisig_tx = MultisigTransactionFactory(ethereum_tx=None)
@@ -159,6 +163,7 @@ class TestSignals(SafeTestCaseMixin, TestCase):
 
         safe_address = self.deploy_test_safe().address
         safe_message = SafeMessageFactory(safe=safe_address)
+
         payload = build_event_payload(SafeMessage, safe_message)[0]
         self.assertEqual(
             payload["type"], TransactionServiceEventType.MESSAGE_CREATED.name
@@ -167,6 +172,10 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         self.assertEqual(payload["messageHash"], safe_message.message_hash)
         self.assertEqual(payload["chainId"], str(EthereumNetwork.GANACHE.value))
         self.assertEqual(payload["timestamp"], int(safe_message.created.timestamp()))
+        self.assertIsNone(payload["threshold"])
+        SafeLastStatusFactory(address=safe_address, threshold=2)
+        payload = build_event_payload(SafeMessage, safe_message)[0]
+        self.assertEqual(payload["threshold"], 2)
 
         safe_message_confirmation = SafeMessageConfirmationFactory(
             safe_message=safe_message
@@ -184,6 +193,8 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         self.assertEqual(
             payload["timestamp"], int(safe_message_confirmation.created.timestamp())
         )
+        self.assertEqual(payload["threshold"], 2)
+        self.assertEqual(payload["owner"], safe_message_confirmation.owner)
 
     @factory.django.mute_signals(post_save)
     def test_build_event_payload_transfer_id_and_timestamp(self):

--- a/safe_transaction_service/safe_messages/tests/test_signals.py
+++ b/safe_transaction_service/safe_messages/tests/test_signals.py
@@ -37,21 +37,27 @@ class TestSafeMessageSignals(SafeTestCaseMixin, TestCase):
             "address": safe_address,
             "type": TransactionServiceEventType.MESSAGE_CREATED.name,
             "messageHash": safe_message.message_hash,
+            # No SafeLastStatus indexed for the deployed Safe -> threshold is None
+            "threshold": None,
             "chainId": str(EthereumNetwork.GANACHE.value),
         }
 
         send_event_mock.assert_called_with(message_created_payload)
 
-        {
-            "address": safe_address,
-            "type": TransactionServiceEventType.MESSAGE_CONFIRMATION.name,
-            "messageHash": safe_message.message_hash,
-            "chainId": str(EthereumNetwork.GANACHE.value),
-        }
         safe_message_confirmation = SafeMessageConfirmationFactory(
             safe_message=safe_message
         )
         process_event(SafeMessageConfirmation, safe_message_confirmation, True)
+        message_confirmation_payload = {
+            "timestamp": int(safe_message_confirmation.created.timestamp()),
+            "address": safe_address,
+            "type": TransactionServiceEventType.MESSAGE_CONFIRMATION.name,
+            "messageHash": safe_message.message_hash,
+            "threshold": None,
+            "owner": safe_message_confirmation.owner,
+            "chainId": str(EthereumNetwork.GANACHE.value),
+        }
+        send_event_mock.assert_called_with(message_confirmation_payload)
 
     @mock.patch.object(QueueService, "send_event")
     def test_signals_are_correctly_fired(self, send_event_mock: MagicMock):
@@ -63,6 +69,8 @@ class TestSafeMessageSignals(SafeTestCaseMixin, TestCase):
             "address": safe_address,
             "type": TransactionServiceEventType.MESSAGE_CREATED.name,
             "messageHash": safe_message.message_hash,
+            # No SafeLastStatus indexed for the deployed Safe -> threshold is None
+            "threshold": None,
             "chainId": str(EthereumNetwork.GANACHE.value),
         }
 
@@ -77,6 +85,8 @@ class TestSafeMessageSignals(SafeTestCaseMixin, TestCase):
             "address": safe_address,
             "type": TransactionServiceEventType.MESSAGE_CONFIRMATION.name,
             "messageHash": safe_message.message_hash,
+            "threshold": None,
+            "owner": safe_message_confirmation.owner,
             "chainId": str(EthereumNetwork.GANACHE.value),
         }
         send_event_mock.assert_called_with(message_confirmation_payload)


### PR DESCRIPTION

### Make sure these boxes are checked! 📦✅

- [x] You ran `./run_tests.sh`
- [x] You ran `pre-commit run -a`
- [ ] NA ~If you want to add your network to `setup_service.py`, provide a link to your
    [safe-deployments PR](https://github.com/safe-global/safe-deployments/pulls) and check network name
    exists in [safe-eth-py](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py)~

### What was wrong? 👾

Closes https://linear.app/safe-global/issue/PLA-1432/enrich-webhook-payloads-to-reduce-follow-up-api-calls


### How was it fixed? 🎯

- Enrich events as follow:
    - `NEW_CONFIRMATION`: +confirmationsRequired (nullable int), +confirmationsCount (int)
    - `MESSAGE_CREATED`: +threshold (nullable int)
    - `MESSAGE_CONFIRMATION`: +threshold (nullable int), +owner
    - `EXECUTED_MULTISIG_TRANSACTION`: +executor