### PR TITLE
Fix broken indexer log call, use monotonic clock, drop dead code

### DIFF
--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -153,10 +153,10 @@ class EthereumIndexer(ABC):
         processed_objects = []
         total_elements = len(elements)
         for i, element in enumerate(elements):
-            logger.info(
+            logger.debug(
                 "%s: Processing element %d/%d",
-                i + 1,
                 self.__class__.__name__,
+                i + 1,
                 total_elements,
             )
             processed_objects.append(self.process_element(element))
@@ -368,9 +368,9 @@ class EthereumIndexer(ABC):
             # Auto adjustment disabled
             yield
         else:
-            start = int(time.time())
+            start = time.monotonic()
             yield
-            delta = int(time.time()) - start
+            delta = time.monotonic() - start
             if delta > 30:
                 self.block_process_limit = max(self.block_process_limit // 2, 1)
                 logger.info(
@@ -559,8 +559,6 @@ class EthereumIndexer(ABC):
                     to_block_number,
                 )
                 total_number_processed_elements += number_processed_elements
-                if from_block_number is not None:
-                    from_block_number += 1
             if last_block is None or to_block_number > last_block:
                 last_block = to_block_number
         else:


### PR DESCRIPTION
Three small, independent fixes in `history/indexers/ethereum_indexer.py`.

## Changes

- **Broken log call in base `process_elements`.** The format string is `"%s: Processing element %d/%d"` but the args were passed as `(i + 1, self.__class__.__name__, total_elements)` — class name and index swapped, so every call raised a logging error instead of logging. It was also `logger.info` per element (noise on large batches). Fixed the arg order and demoted to `logger.debug`.
- **Wall clock in `auto_adjust_block_limit`.** Used `int(time.time())` for both `start` and `delta`; an NTP step could skew the congestion measurement and swing `block_process_limit` wildly. Switched to `time.monotonic()`.
- **Dead code in `start()`.** Removed `from_block_number += 1` in the not-updated loop — the variable is reassigned by the tuple-unpack at the top of the next iteration, so the mutation was never read.
