### PR TITLE
Halve block_process_limit on error instead of resetting to 1

### DIFF
--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -453,9 +453,9 @@ class EthereumIndexer(ABC):
             ValueError,
             Web3RPCError,
         ) as e:
-            self.block_process_limit = 1  # Set back to the very minimum
+            self.block_process_limit = max(self.block_process_limit // 2, 1)
             logger.info(
-                "%s: block_process_limit set back to %d",
+                "%s: block_process_limit halved to %d after error",
                 self.__class__.__name__,
                 self.block_process_limit,
             )


### PR DESCRIPTION
## Problem

In `EthereumIndexer.process_addresses`, any transient RPC error (`FindRelevantElementsException`, `Timeout`, `ValueError`, `Web3RPCError`, ...) reset `block_process_limit` from potentially thousands of blocks all the way to `1`. Recovery only happens by doubling in `auto_adjust_block_limit`, so a single hiccup costs ~log2(N) extra RPC round-trips with tiny ranges, and a repeatedly-flaky node keeps re-triggering the reset — pinning the indexer near 1 block per query.

## Fix

This is congestion control, so back off multiplicatively instead of flooring to 1:

```python
self.block_process_limit = max(self.block_process_limit // 2, 1)
```

`raise e` and all other behavior are unchanged.
