### PR TITLE
Parallelize trace_transactions chunks

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -592,6 +592,9 @@ ETH_INTERNAL_NO_FILTER = env.bool(
 ETH_INTERNAL_TRACE_TXS_BATCH_SIZE = env.int(
     "ETH_INTERNAL_TRACE_TXS_BATCH_SIZE", default=0
 )  # Number of `trace_transaction` calls allowed in the same RPC batch call, as results can be quite big
+ETH_INTERNAL_TXS_TRACE_TXS_CONCURRENCY = env.int(
+    "ETH_INTERNAL_TXS_TRACE_TXS_CONCURRENCY", default=3
+)  # Number of concurrent `trace_transactions` batch requests
 ETH_INTERNAL_TX_DECODED_PROCESS_BATCH = env.int(
     "ETH_INTERNAL_TX_DECODED_PROCESS_BATCH", default=500
 )  # Number of InternalTxDecoded to process together. Keep it low to be memory friendly

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -594,7 +594,7 @@ ETH_INTERNAL_TRACE_TXS_BATCH_SIZE = env.int(
 )  # Number of `trace_transaction` calls allowed in the same RPC batch call, as results can be quite big
 ETH_INTERNAL_TRACE_TXS_CONCURRENCY = env.int(
     "ETH_INTERNAL_TRACE_TXS_CONCURRENCY", default=3
-)  # Number of concurrent `trace_transactions` batch requests
+)  # Number of concurrent `trace_transactions` batch requests (floored at 1: 0/negative runs serially)
 ETH_INTERNAL_TX_DECODED_PROCESS_BATCH = env.int(
     "ETH_INTERNAL_TX_DECODED_PROCESS_BATCH", default=500
 )  # Number of InternalTxDecoded to process together. Keep it low to be memory friendly

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -592,8 +592,8 @@ ETH_INTERNAL_NO_FILTER = env.bool(
 ETH_INTERNAL_TRACE_TXS_BATCH_SIZE = env.int(
     "ETH_INTERNAL_TRACE_TXS_BATCH_SIZE", default=0
 )  # Number of `trace_transaction` calls allowed in the same RPC batch call, as results can be quite big
-ETH_INTERNAL_TXS_TRACE_TXS_CONCURRENCY = env.int(
-    "ETH_INTERNAL_TXS_TRACE_TXS_CONCURRENCY", default=3
+ETH_INTERNAL_TRACE_TXS_CONCURRENCY = env.int(
+    "ETH_INTERNAL_TRACE_TXS_CONCURRENCY", default=3
 )  # Number of concurrent `trace_transactions` batch requests
 ETH_INTERNAL_TX_DECODED_PROCESS_BATCH = env.int(
     "ETH_INTERNAL_TX_DECODED_PROCESS_BATCH", default=500

--- a/safe_transaction_service/history/indexers/events_indexer.py
+++ b/safe_transaction_service/history/indexers/events_indexer.py
@@ -123,9 +123,14 @@ class EventsIndexer(EthereumIndexer):
                 for single_parameters in multiple_parameters
             ]
 
-            with self.auto_adjust_block_limit(from_block_number, to_block_number):
-                # Check how long all the jobs take
-                gevent.joinall(jobs, raise_error=True)
+            try:
+                with self.auto_adjust_block_limit(from_block_number, to_block_number):
+                    # Check how long all the jobs take
+                    gevent.joinall(jobs, raise_error=True)
+            finally:
+                # `joinall` raises on the first failed job without stopping the others,
+                # so kill any job still in flight
+                gevent.killall(jobs)
 
             return [log_receipt for job in jobs for log_receipt in job.get()]
         else:

--- a/safe_transaction_service/history/indexers/internal_tx_indexer.py
+++ b/safe_transaction_service/history/indexers/internal_tx_indexer.py
@@ -76,9 +76,7 @@ class InternalTxIndexer(EthereumIndexer):
 
         self.trace_txs_batch_size: int = settings.ETH_INTERNAL_TRACE_TXS_BATCH_SIZE
         # Number of concurrent `trace_transactions` batch requests
-        self.trace_txs_concurrency: int = (
-            settings.ETH_INTERNAL_TXS_TRACE_TXS_CONCURRENCY
-        )
+        self.trace_txs_concurrency: int = settings.ETH_INTERNAL_TRACE_TXS_CONCURRENCY
         self.number_trace_blocks: int = settings.ETH_INTERNAL_TXS_NUMBER_TRACE_BLOCKS
         self.tx_decoder = get_safe_tx_decoder()
 
@@ -292,16 +290,12 @@ class InternalTxIndexer(EthereumIndexer):
             return []
 
         batch_size = batch_size or len(tx_hashes)  # If `0`, don't use batches
-        tx_hash_chunks = [
-            list(tx_hash_chunk) for tx_hash_chunk in chunks(list(tx_hashes), batch_size)
-        ]
-
         gevent_pool = pool.Pool(self.trace_txs_concurrency)
         jobs = [
             gevent_pool.spawn(
                 self.ethereum_client.tracing.trace_transactions, tx_hash_chunk
             )
-            for tx_hash_chunk in tx_hash_chunks
+            for tx_hash_chunk in chunks(list(tx_hashes), batch_size)
         ]
 
         try:

--- a/safe_transaction_service/history/indexers/internal_tx_indexer.py
+++ b/safe_transaction_service/history/indexers/internal_tx_indexer.py
@@ -313,6 +313,10 @@ class InternalTxIndexer(EthereumIndexer):
                 exc_info=True,
             )
             raise
+        finally:
+            # `joinall` raises on the first failed job without stopping the others,
+            # so kill any job still in flight
+            gevent.killall(jobs)
 
         # Concatenate per-chunk results in chunk order to preserve tx_hashes ordering
         return [traces for job in jobs for traces in job.get()]

--- a/safe_transaction_service/history/indexers/internal_tx_indexer.py
+++ b/safe_transaction_service/history/indexers/internal_tx_indexer.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 from collections import OrderedDict
-from collections.abc import Generator, Iterable, Sequence
+from collections.abc import Generator, Sequence
 from logging import getLogger
 
 from django.conf import settings
 from django.db import transaction
 
+import gevent
 from eth_typing import ChecksumAddress, HexStr
+from gevent import pool
 from hexbytes import HexBytes
 from safe_eth.eth import EthereumClient
 from safe_eth.util.util import to_0x_hex_str
@@ -73,6 +75,10 @@ class InternalTxIndexer(EthereumIndexer):
         super().__init__(*args, **kwargs)
 
         self.trace_txs_batch_size: int = settings.ETH_INTERNAL_TRACE_TXS_BATCH_SIZE
+        # Number of concurrent `trace_transactions` batch requests
+        self.trace_txs_concurrency: int = (
+            settings.ETH_INTERNAL_TXS_TRACE_TXS_CONCURRENCY
+        )
         self.number_trace_blocks: int = settings.ETH_INTERNAL_TXS_NUMBER_TRACE_BLOCKS
         self.tx_decoder = get_safe_tx_decoder()
 
@@ -271,22 +277,46 @@ class InternalTxIndexer(EthereumIndexer):
 
     def trace_transactions(
         self, tx_hashes: Sequence[HexStr], batch_size: int
-    ) -> Iterable[list[FilterTrace]]:
+    ) -> list[list[FilterTrace]]:
+        """
+        Fetch traces for the provided ``tx_hashes`` in parallel batches.
+
+        Chunks are fetched concurrently using a gevent pool, but results are returned
+        in the same order as the input ``tx_hashes`` so callers can safely ``zip`` them.
+
+        :param tx_hashes:
+        :param batch_size: Number of txs per RPC batch call. `0` == single batch
+        :return: List of traces per tx hash, in the same order as ``tx_hashes``
+        """
+        if not tx_hashes:
+            return []
+
         batch_size = batch_size or len(tx_hashes)  # If `0`, don't use batches
-        for tx_hash_chunk in chunks(list(tx_hashes), batch_size):
-            tx_hash_chunk = list(tx_hash_chunk)
-            try:
-                yield from self.ethereum_client.tracing.trace_transactions(
-                    tx_hash_chunk
-                )
-            except OSError:
-                logger.error(
-                    "Problem calling `trace_transactions` with %d txs. "
-                    "Try lowering ETH_INTERNAL_TRACE_TXS_BATCH_SIZE",
-                    len(tx_hash_chunk),
-                    exc_info=True,
-                )
-                raise
+        tx_hash_chunks = [
+            list(tx_hash_chunk) for tx_hash_chunk in chunks(list(tx_hashes), batch_size)
+        ]
+
+        gevent_pool = pool.Pool(self.trace_txs_concurrency)
+        jobs = [
+            gevent_pool.spawn(
+                self.ethereum_client.tracing.trace_transactions, tx_hash_chunk
+            )
+            for tx_hash_chunk in tx_hash_chunks
+        ]
+
+        try:
+            gevent.joinall(jobs, raise_error=True)
+        except OSError:
+            logger.error(
+                "Problem calling `trace_transactions` with %d txs. "
+                "Try lowering ETH_INTERNAL_TRACE_TXS_BATCH_SIZE",
+                len(tx_hashes),
+                exc_info=True,
+            )
+            raise
+
+        # Concatenate per-chunk results in chunk order to preserve tx_hashes ordering
+        return [traces for job in jobs for traces in job.get()]
 
     def build_safe_relevant_txs(
         self, internal_txs: Generator[InternalTx]

--- a/safe_transaction_service/history/indexers/internal_tx_indexer.py
+++ b/safe_transaction_service/history/indexers/internal_tx_indexer.py
@@ -75,8 +75,13 @@ class InternalTxIndexer(EthereumIndexer):
         super().__init__(*args, **kwargs)
 
         self.trace_txs_batch_size: int = settings.ETH_INTERNAL_TRACE_TXS_BATCH_SIZE
-        # Number of concurrent `trace_transactions` batch requests
-        self.trace_txs_concurrency: int = settings.ETH_INTERNAL_TRACE_TXS_CONCURRENCY
+        # Number of concurrent `trace_transactions` batch requests. Floor at 1:
+        # a 0/negative value (a plausible way to try to disable parallelism) would
+        # build a `gevent.pool.Pool(0)`, which never accepts a greenlet and would
+        # deadlock the first spawn. 1 means serial, the original behavior.
+        self.trace_txs_concurrency: int = max(
+            1, settings.ETH_INTERNAL_TRACE_TXS_CONCURRENCY
+        )
         self.number_trace_blocks: int = settings.ETH_INTERNAL_TXS_NUMBER_TRACE_BLOCKS
         self.tx_decoder = get_safe_tx_decoder()
 

--- a/safe_transaction_service/history/tests/test_internal_tx_indexer.py
+++ b/safe_transaction_service/history/tests/test_internal_tx_indexer.py
@@ -61,6 +61,16 @@ class TestInternalTxIndexer(TestCase):
                 (InternalTxIndexer, InternalTxIndexerWithTraceBlock),
             )
 
+    def test_trace_txs_concurrency_floored_at_one(self):
+        # A 0/negative value must not build a gevent.pool.Pool(0), which would
+        # deadlock the first spawn. It must fall back to serial (1).
+        for configured in (0, -1):
+            InternalTxIndexerProvider.del_singleton()
+            with self.settings(ETH_INTERNAL_TRACE_TXS_CONCURRENCY=configured):
+                indexer = InternalTxIndexerProvider()
+                self.assertEqual(indexer.trace_txs_concurrency, 1)
+        InternalTxIndexerProvider.del_singleton()
+
     def test_is_relevant_trace(self):
         indexer = self.internal_tx_indexer
 


### PR DESCRIPTION
## Problem

`trace_transaction` is the most expensive call in the tracing indexing path, and `InternalTxIndexer.trace_transactions` fetched its chunks sequentially — the batches don't depend on each other, so this is wasted wall-clock on mainnet/gnosis catch-up.

## Fix

Fetch the chunks concurrently with a gevent pool, mirroring `EventsIndexer._do_node_query`'s existing `get_logs` parallelization: chunks are spawned into a `gevent.pool.Pool(...)`, joined with `raise_error=True`, and results are concatenated in chunk order so callers can still `zip` them against `tx_hashes_missing_traces`. The existing `OSError` logging / re-raise behavior is preserved.

Concurrency is controlled by a new setting `ETH_INTERNAL_TXS_TRACE_TXS_CONCURRENCY` (default `3`), wired the same way as `ETH_EVENTS_GET_LOGS_CONCURRENCY`.

## Deferred follow-up

A related `MultisigConfirmation` N+1 in `tx_processor` was **intentionally left out** of this PR. Both `get_or_create` sites carry update semantics (back-fill `ethereum_tx`, rewrite changed signatures) plus within-batch read-after-write, so a naive `bulk_create(ignore_conflicts=True)` would silently drop those updates when the row already exists (common via the queue-service flow) — a correctness regression. A proper fix needs its own PR: accumulate intended confirmations, one existence query per batch, then split into `bulk_create` + `bulk_update` with within-batch dedup.
