### PR TITLE
Fix erc20 out-of-sync loop, conditional-indexing FK gap, batch delete

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -634,6 +634,10 @@ ETH_REORG_BLOCKS = env.int(
 ETH_REINDEX_MAX_RETRIES = env.int(
     "ETH_REINDEX_MAX_RETRIES", default=5
 )  # Number of consecutive failures of the same block range during reindex
+ERC20_INDEX_MAX_CONSECUTIVE_FAILURES = env.int(
+    "ERC20_INDEX_MAX_CONSECUTIVE_FAILURES", default=3
+)  # Consecutive failures before aborting the out-of-sync erc20/721 indexing loop,
+# so a persistently failing RPC does not spin forever until the Celery timeout
 ETH_ERC20_LOAD_ADDRESSES_CHUNK_SIZE = env.int(
     "ETH_ERC20_LOAD_ADDRESSES_CHUNK_SIZE", default=500_000
 )  # Load Safe addresses for the ERC20 indexer with a database iterator with the defined `chunk_size`

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -634,8 +634,8 @@ ETH_REORG_BLOCKS = env.int(
 ETH_REINDEX_MAX_RETRIES = env.int(
     "ETH_REINDEX_MAX_RETRIES", default=5
 )  # Number of consecutive failures of the same block range during reindex
-ERC20_INDEX_MAX_CONSECUTIVE_FAILURES = env.int(
-    "ERC20_INDEX_MAX_CONSECUTIVE_FAILURES", default=3
+ETH_ERC20_INDEX_MAX_CONSECUTIVE_FAILURES = env.int(
+    "ETH_ERC20_INDEX_MAX_CONSECUTIVE_FAILURES", default=3
 )  # Consecutive failures before aborting the out-of-sync erc20/721 indexing loop,
 # so a persistently failing RPC does not spin forever until the Celery timeout
 ETH_ERC20_LOAD_ADDRESSES_CHUNK_SIZE = env.int(

--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -228,21 +228,45 @@ class SafeEventsIndexer(EventsIndexer):
         ]
 
         # 11. Fetch receipts and store ONLY for txs with processable events
+        stored_fetched_tx_hashes: set[bytes] = set()
         if allowed_fetched_txs_filtered:
-            number_allowed_txs_inserted = self._fetch_receipts_and_store(
+            stored_fetched_tx_hashes = self._fetch_receipts_and_store(
                 allowed_fetched_txs_filtered
             )
             logger.debug(
-                "Conditional indexing: %d txs with processable events inserted",
-                number_allowed_txs_inserted,
+                "Conditional indexing: %d txs with processable events stored",
+                len(stored_fetched_tx_hashes),
             )
 
-        # 12. Process only the processable events
-        # (filtering already done by _get_processable_events)
+        # Txs whose receipt fetch failed were NOT stored. Processing their events
+        # would create InternalTx rows pointing at a missing EthereumTx
+        # (IntegrityError), so drop those events and leave their log receipts
+        # unprocessed so they get retried on a later run.
+        tx_hashes_present_in_db = set(db_txs.keys()) | stored_fetched_tx_hashes
+        failed_tx_hashes = {
+            HexBytes(tx["hash"]) for tx in allowed_fetched_txs_filtered
+        } - stored_fetched_tx_hashes
+        if failed_tx_hashes:
+            logger.warning(
+                "Conditional indexing: %d txs missing a receipt, their events "
+                "will be retried on a later run",
+                len(failed_tx_hashes),
+            )
+
+        # 12. Process only processable events whose tx is actually present in the DB
+        processable_events = [
+            event
+            for event in processable_events
+            if HexBytes(event["transactionHash"]) in tx_hashes_present_in_db
+        ]
         processed_elements = self._process_decoded_elements(processable_events)
 
-        # 13. Mark ALL original receipts as processed (so we don't re-fetch blocked ones)
+        # 13. Mark original receipts as processed (so we don't re-fetch blocked or
+        # filtered-out ones), except those belonging to txs whose receipt fetch
+        # failed, which must be retried.
         for log_receipt in not_processed_log_receipts:
+            if HexBytes(log_receipt["transactionHash"]) in failed_tx_hashes:
+                continue
             self._mark_processed(
                 log_receipt["transactionHash"],
                 log_receipt["blockHash"],
@@ -807,6 +831,9 @@ class SafeEventsIndexer(EventsIndexer):
         )
         # Track Safe addresses and their creation tx hashes for SafeContract creation
         created_safe_address_with_tx_hash: dict[ChecksumAddress, bytes] = {}
+        # Safes whose proxy was created in a previous block, so their old InternalTx
+        # must be deleted in a single batch before storing the new ones
+        addresses_to_delete: set[ChecksumAddress] = set()
 
         for safe_address in addresses_to_index:
             events = safe_addresses_with_creation_events[safe_address]
@@ -837,15 +864,9 @@ class SafeEventsIndexer(EventsIndexer):
                 if not proxy_creation_event:
                     # SafeSetup without ProxyCreation means proxy was created in a previous block
                     # ProxyCreation is also emitted when ProxyCreationL2 or ChainSpecificProxyCreationL2 are emitted on v1.5.0.
-                    logger.debug(
-                        "[%s] Proxy was created in previous blocks, deleting the old InternalTx",
-                        safe_address,
-                    )
-                    InternalTx.objects.filter(contract_address=safe_address).delete()
-                    logger.debug(
-                        "[%s] Proxy was created in previous blocks, old InternalTx deleted",
-                        safe_address,
-                    )
+                    # Collect the address to delete the old InternalTx in a single
+                    # batch after the loop, before storing the new ones.
+                    addresses_to_delete.add(safe_address)
 
                 # Determine trace_address and singleton based on whether ProxyCreation exists
                 if proxy_creation_event:
@@ -887,6 +908,15 @@ class SafeEventsIndexer(EventsIndexer):
                 ]
 
         logger.debug("InternalTx and InternalTxDecoded objects for creation were built")
+
+        # Delete old InternalTx for Safes whose proxy was created in a previous
+        # block, in a single query before storing the new ones
+        if addresses_to_delete:
+            logger.debug(
+                "Deleting old InternalTx for %d Safes whose proxy was created in previous blocks",
+                len(addresses_to_delete),
+            )
+            InternalTx.objects.filter(contract_address__in=addresses_to_delete).delete()
 
         stored_internal_txs = InternalTx.objects.store_internal_txs_and_decoded_in_db(
             internal_txs, internal_txs_decoded
@@ -957,16 +987,19 @@ class SafeEventsIndexer(EventsIndexer):
 
         return txs
 
-    def _fetch_receipts_and_store(self, txs: list[TxData]) -> int:
+    def _fetch_receipts_and_store(self, txs: list[TxData]) -> set[bytes]:
         """
         Fetch receipts for allowed transactions and store them in the database.
         Called after filtering by tx._from to avoid fetching receipts for blocklisted txs.
 
+        Transactions whose receipt could not be fetched are skipped and NOT stored,
+        so they can be retried on a later run.
+
         :param txs: List of allowed transactions to fetch receipts for and store
-        :return: Number of transactions inserted
+        :return: Set of tx hashes (as ``HexBytes``) that were actually stored in the DB
         """
         if not txs:
-            return 0
+            return set()
 
         tx_hashes = [tx["hash"] for tx in txs]
 
@@ -995,7 +1028,7 @@ class SafeEventsIndexer(EventsIndexer):
                 )
 
         if not txs_with_receipts:
-            return 0
+            return set()
 
         # Collect block hashes only from txs with successful receipts
         block_hashes = {to_0x_hex_str(tx["blockHash"]) for tx, _ in txs_with_receipts}
@@ -1012,9 +1045,13 @@ class SafeEventsIndexer(EventsIndexer):
             EthereumTx.objects.from_tx_dict(tx, receipt)
             for tx, receipt in txs_with_receipts
         ]
-        return EthereumTx.objects.bulk_create_from_generator(
+        EthereumTx.objects.bulk_create_from_generator(
             iter(ethereum_txs_to_insert), ignore_conflicts=True
         )
+        # Return every tx that is now present in the DB. `ignore_conflicts` means
+        # a conflict just implies the row already existed, so all txs with a
+        # receipt end up stored regardless of the inserted count.
+        return {HexBytes(tx["hash"]) for tx, _ in txs_with_receipts}
 
     def _process_decoded_elements(
         self, decoded_elements: list[EventData]

--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -242,7 +242,6 @@ class SafeEventsIndexer(EventsIndexer):
         # would create InternalTx rows pointing at a missing EthereumTx
         # (IntegrityError), so drop those events and leave their log receipts
         # unprocessed so they get retried on a later run.
-        tx_hashes_present_in_db = set(db_txs.keys()) | stored_fetched_tx_hashes
         failed_tx_hashes = {
             HexBytes(tx["hash"]) for tx in allowed_fetched_txs_filtered
         } - stored_fetched_tx_hashes
@@ -253,19 +252,22 @@ class SafeEventsIndexer(EventsIndexer):
                 len(failed_tx_hashes),
             )
 
-        # 12. Process only processable events whose tx is actually present in the DB
+        # 12. Process every processable event except those whose tx receipt fetch
+        # failed (their tx is not in the DB, so an InternalTx would dangle)
         processable_events = [
             event
             for event in processable_events
-            if HexBytes(event["transactionHash"]) in tx_hashes_present_in_db
+            if HexBytes(event["transactionHash"]) not in failed_tx_hashes
         ]
         processed_elements = self._process_decoded_elements(processable_events)
 
         # 13. Mark original receipts as processed (so we don't re-fetch blocked or
         # filtered-out ones), except those belonging to txs whose receipt fetch
-        # failed, which must be retried.
-        for log_receipt in not_processed_log_receipts:
-            if HexBytes(log_receipt["transactionHash"]) in failed_tx_hashes:
+        # failed, which must be retried. Reuse the tx hashes normalized in step 1.
+        for log_receipt, tx_hash in zip(
+            not_processed_log_receipts, not_processed_tx_hashes_by_index, strict=True
+        ):
+            if tx_hash in failed_tx_hashes:
                 continue
             self._mark_processed(
                 log_receipt["transactionHash"],

--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -37,6 +37,7 @@ from ..models import (
     SafeRelevantTransaction,
 )
 from ..services.event_service import set_safe_membership
+from ..services.index_service import TransactionNotFoundException
 from .events_indexer import EventsIndexer
 
 logger = getLogger(__name__)
@@ -227,48 +228,30 @@ class SafeEventsIndexer(EventsIndexer):
             if HexBytes(tx["hash"]) in tx_hashes_to_create
         ]
 
-        # 11. Fetch receipts and store ONLY for txs with processable events
-        stored_fetched_tx_hashes: set[bytes] = set()
+        # 11. Fetch receipts and store the txs with processable events. If any
+        # receipt cannot be fetched, `_fetch_receipts_and_store` raises and the
+        # whole block range is retried on a later run instead of advancing past a
+        # tx whose EthereumTx is missing (which would leave a dangling InternalTx).
+        # This mirrors the non-conditional path, where
+        # `txs_create_or_update_from_tx_hashes` raises `TransactionNotFoundException`.
         if allowed_fetched_txs_filtered:
-            stored_fetched_tx_hashes = self._fetch_receipts_and_store(
+            number_txs_inserted = self._fetch_receipts_and_store(
                 allowed_fetched_txs_filtered
             )
             logger.debug(
-                "Conditional indexing: %d txs with processable events stored",
-                len(stored_fetched_tx_hashes),
+                "Conditional indexing: %d txs with processable events inserted",
+                number_txs_inserted,
             )
 
-        # Txs whose receipt fetch failed were NOT stored. Processing their events
-        # would create InternalTx rows pointing at a missing EthereumTx
-        # (IntegrityError), so drop those events and leave their log receipts
-        # unprocessed so they get retried on a later run.
-        failed_tx_hashes = {
-            HexBytes(tx["hash"]) for tx in allowed_fetched_txs_filtered
-        } - stored_fetched_tx_hashes
-        if failed_tx_hashes:
-            logger.warning(
-                "Conditional indexing: %d txs missing a receipt, their events "
-                "will be retried on a later run",
-                len(failed_tx_hashes),
-            )
-
-        # 12. Process every processable event except those whose tx receipt fetch
-        # failed (their tx is not in the DB, so an InternalTx would dangle)
-        processable_events = [
-            event
-            for event in processable_events
-            if HexBytes(event["transactionHash"]) not in failed_tx_hashes
-        ]
+        # 12. Process the processable events. Every referenced tx is now in the DB:
+        # existing ones from `db_txs`, the rest inserted in step 11 (a missing
+        # receipt would have raised above).
         processed_elements = self._process_decoded_elements(processable_events)
 
-        # 13. Mark original receipts as processed (so we don't re-fetch blocked or
-        # filtered-out ones), except those belonging to txs whose receipt fetch
-        # failed, which must be retried. Reuse the tx hashes normalized in step 1.
-        for log_receipt, tx_hash in zip(
-            not_processed_log_receipts, not_processed_tx_hashes_by_index, strict=True
-        ):
-            if tx_hash in failed_tx_hashes:
-                continue
+        # 13. Mark ALL original receipts as processed so blocked/filtered-out ones
+        # are never re-fetched. Receipt-fetch failures never reach here (they raise
+        # in step 11), so nothing that still needs indexing is marked here.
+        for log_receipt in not_processed_log_receipts:
             self._mark_processed(
                 log_receipt["transactionHash"],
                 log_receipt["blockHash"],
@@ -989,19 +972,22 @@ class SafeEventsIndexer(EventsIndexer):
 
         return txs
 
-    def _fetch_receipts_and_store(self, txs: list[TxData]) -> set[bytes]:
+    def _fetch_receipts_and_store(self, txs: list[TxData]) -> int:
         """
         Fetch receipts for allowed transactions and store them in the database.
         Called after filtering by tx._from to avoid fetching receipts for blocklisted txs.
 
-        Transactions whose receipt could not be fetched are skipped and NOT stored,
-        so they can be retried on a later run.
+        If a receipt cannot be fetched, raises ``TransactionNotFoundException`` so the
+        caller retries the whole block range instead of advancing past a tx whose
+        events would otherwise dangle. This matches the non-conditional path in
+        ``IndexService.txs_create_or_update_from_tx_hashes``.
 
         :param txs: List of allowed transactions to fetch receipts for and store
-        :return: Set of tx hashes (as ``HexBytes``) that were actually stored in the DB
+        :return: Number of transactions inserted
+        :raises TransactionNotFoundException: if any receipt cannot be fetched
         """
         if not txs:
-            return set()
+            return 0
 
         tx_hashes = [tx["hash"] for tx in txs]
 
@@ -1011,7 +997,6 @@ class SafeEventsIndexer(EventsIndexer):
             len(tx_hashes),
         )
 
-        # Build list of (tx, receipt) pairs, only including successful receipt fetches
         txs_with_receipts: list[tuple[TxData, TxReceipt]] = []
         for tx, tx_receipt in zip(
             txs,
@@ -1021,18 +1006,13 @@ class SafeEventsIndexer(EventsIndexer):
             tx_receipt = tx_receipt or self.ethereum_client.get_transaction_receipt(
                 tx["hash"]
             )  # Retry if failed
-            if tx_receipt:
-                txs_with_receipts.append((tx, tx_receipt))
-            else:
-                logger.warning(
-                    "Conditional indexing: failed to fetch receipt for tx %s",
-                    to_0x_hex_str(tx["hash"]),
+            if not tx_receipt:
+                raise TransactionNotFoundException(
+                    f"Cannot find tx-receipt with tx-hash={to_0x_hex_str(HexBytes(tx['hash']))}"
                 )
+            txs_with_receipts.append((tx, tx_receipt))
 
-        if not txs_with_receipts:
-            return set()
-
-        # Collect block hashes only from txs with successful receipts
+        # Every receipt was fetched, so collect block hashes from all txs
         block_hashes = {to_0x_hex_str(tx["blockHash"]) for tx, _ in txs_with_receipts}
 
         # Create blocks
@@ -1047,13 +1027,9 @@ class SafeEventsIndexer(EventsIndexer):
             EthereumTx.objects.from_tx_dict(tx, receipt)
             for tx, receipt in txs_with_receipts
         ]
-        EthereumTx.objects.bulk_create_from_generator(
+        return EthereumTx.objects.bulk_create_from_generator(
             iter(ethereum_txs_to_insert), ignore_conflicts=True
         )
-        # Return every tx that is now present in the DB. `ignore_conflicts` means
-        # a conflict just implies the row already existed, so all txs with a
-        # receipt end up stored regardless of the inserted count.
-        return {HexBytes(tx["hash"]) for tx, _ in txs_with_receipts}
 
     def _process_decoded_elements(
         self, decoded_elements: list[EventData]

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -48,6 +48,11 @@ from .services.event_service import build_reorg_payload
 
 logger = get_task_logger(__name__)
 
+# Max number of consecutive `FindRelevantElementsException` before aborting the
+# out-of-sync erc20 indexing loop, so a persistently failing RPC does not spin
+# forever hammering the node until the Celery timeout kills the task.
+MAX_CONSECUTIVE_FAILURES = 3
+
 
 @app.shared_task(bind=True)
 @task_timeout(timeout_seconds=LOCK_TIMEOUT)
@@ -151,6 +156,7 @@ def index_erc20_events_out_of_sync_task(
         )
         updated = False
         number_events_processed = 0
+        consecutive_failures = 0
         while not updated:
             try:
                 (
@@ -162,8 +168,17 @@ def index_erc20_events_out_of_sync_task(
                     addresses, current_block_number
                 )
                 number_events_processed += len(events_processed)
+                consecutive_failures = 0
             except FindRelevantElementsException:
-                pass
+                consecutive_failures += 1
+                if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                    logger.error(
+                        "Aborting out of sync erc20/721 indexing after %d "
+                        "consecutive failures for addresses %s",
+                        consecutive_failures,
+                        addresses,
+                    )
+                    break
 
         logger.info(
             "Indexing of erc20/721 events for out of sync addresses task processed %d events",

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -48,11 +48,6 @@ from .services.event_service import build_reorg_payload
 
 logger = get_task_logger(__name__)
 
-# Max number of consecutive `FindRelevantElementsException` before aborting the
-# out-of-sync erc20 indexing loop, so a persistently failing RPC does not spin
-# forever hammering the node until the Celery timeout kills the task.
-MAX_CONSECUTIVE_FAILURES = 3
-
 
 @app.shared_task(bind=True)
 @task_timeout(timeout_seconds=LOCK_TIMEOUT)
@@ -171,7 +166,10 @@ def index_erc20_events_out_of_sync_task(
                 consecutive_failures = 0
             except FindRelevantElementsException:
                 consecutive_failures += 1
-                if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                if (
+                    consecutive_failures
+                    >= settings.ERC20_INDEX_MAX_CONSECUTIVE_FAILURES
+                ):
                     logger.error(
                         "Aborting out of sync erc20/721 indexing after %d "
                         "consecutive failures for addresses %s",

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -168,7 +168,7 @@ def index_erc20_events_out_of_sync_task(
                 consecutive_failures += 1
                 if (
                     consecutive_failures
-                    >= settings.ERC20_INDEX_MAX_CONSECUTIVE_FAILURES
+                    >= settings.ETH_ERC20_INDEX_MAX_CONSECUTIVE_FAILURES
                 ):
                     logger.error(
                         "Aborting out of sync erc20/721 indexing after %d "

--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -36,6 +36,7 @@ from ..models import (
     SafeLastStatus,
     SafeStatus,
 )
+from ..services.index_service import TransactionNotFoundException
 from .factories import EthereumBlockFactory, EthereumTxFactory, SafeMasterCopyFactory
 from .mocks.mocks_safe_events_indexer import (
     proxy_creation_event_mock,
@@ -1403,9 +1404,10 @@ class SafeEventsIndexerBaseAbstractTestBase(SafeTestCaseMixin, TestCase, ABC):
     def test_conditional_indexing_receipt_fetch_failure(self):
         """
         When conditional indexing is enabled and a tx receipt cannot be fetched,
-        its events must NOT be processed (no InternalTx pointing at a missing
-        EthereumTx) and its log receipts must remain unprocessed so they are
-        retried on a later run.
+        `process_elements` must raise `TransactionNotFoundException` so the block
+        range is retried on a later run. No events must be processed (no InternalTx
+        pointing at a missing EthereumTx) and no log receipt must be marked
+        processed, since advancing past them would drop their events.
         """
         allowed_initiator = "0xA21E2615ED32CE9DdFc53A1B0ccFE689e9152f25"
         blocklisted_address = Account.create().address
@@ -1457,9 +1459,10 @@ class SafeEventsIndexerBaseAbstractTestBase(SafeTestCaseMixin, TestCase, ABC):
                 self.ethereum_client, "get_transaction_receipt", return_value=None
             ),
         ):
-            safe_events_indexer.process_elements(safe_events_mock)
+            with self.assertRaises(TransactionNotFoundException):
+                safe_events_indexer.process_elements(safe_events_mock)
 
-        # Receipt fetch failed for every tx: no InternalTx/InternalTxDecoded created
+        # Receipt fetch failed: no InternalTx/InternalTxDecoded created
         self.assertEqual(InternalTx.objects.count(), 0)
         self.assertEqual(InternalTxDecoded.objects.count(), 0)
 

--- a/safe_transaction_service/history/tests/test_safe_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_safe_events_indexer.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 from abc import ABC, abstractmethod
+from unittest import mock
 
 from django.test import TestCase
 from django.utils import timezone
@@ -1398,6 +1399,79 @@ class SafeEventsIndexerBaseAbstractTestBase(SafeTestCaseMixin, TestCase, ABC):
         self.assertEqual(
             InternalTx.objects.count(), 2
         )  # Only ProxyCreation and SafeSetup
+
+    def test_conditional_indexing_receipt_fetch_failure(self):
+        """
+        When conditional indexing is enabled and a tx receipt cannot be fetched,
+        its events must NOT be processed (no InternalTx pointing at a missing
+        EthereumTx) and its log receipts must remain unprocessed so they are
+        retried on a later run.
+        """
+        allowed_initiator = "0xA21E2615ED32CE9DdFc53A1B0ccFE689e9152f25"
+        blocklisted_address = Account.create().address
+
+        # Do NOT create EthereumTx rows: txs are missing and must be fetched from RPC
+        self.assertEqual(EthereumTx.objects.count(), 0)
+
+        # Build fake TxData (without receipt) for each unique tx hash in the mock
+        block_hash_by_tx_hash: dict[HexBytes, HexBytes] = {}
+        for safe_event in safe_events_mock:
+            block_hash_by_tx_hash.setdefault(
+                HexBytes(safe_event["transactionHash"]),
+                HexBytes(safe_event["blockHash"]),
+            )
+        fake_txs = {
+            tx_hash: AttributeDict(
+                {
+                    "hash": tx_hash,
+                    "from": allowed_initiator,
+                    "to": allowed_initiator,
+                    "blockHash": block_hash,
+                }
+            )
+            for tx_hash, block_hash in block_hash_by_tx_hash.items()
+        }
+
+        def get_transactions_mock(tx_hashes):
+            return [fake_txs[HexBytes(tx_hash)] for tx_hash in tx_hashes]
+
+        safe_events_indexer = SafeEventsIndexer(
+            self.ethereum_client,
+            confirmations=0,
+            blocks_to_reindex_again=0,
+            ignored_initiators={blocklisted_address},
+        )
+
+        with (
+            mock.patch.object(
+                self.ethereum_client,
+                "get_transactions",
+                side_effect=get_transactions_mock,
+            ),
+            mock.patch.object(
+                self.ethereum_client,
+                "get_transaction_receipts",
+                side_effect=lambda tx_hashes: [None] * len(tx_hashes),
+            ),
+            mock.patch.object(
+                self.ethereum_client, "get_transaction_receipt", return_value=None
+            ),
+        ):
+            safe_events_indexer.process_elements(safe_events_mock)
+
+        # Receipt fetch failed for every tx: no InternalTx/InternalTxDecoded created
+        self.assertEqual(InternalTx.objects.count(), 0)
+        self.assertEqual(InternalTxDecoded.objects.count(), 0)
+
+        # Log receipts must remain unprocessed so they are retried on a later run
+        for safe_event in safe_events_mock:
+            self.assertFalse(
+                safe_events_indexer._is_processed(
+                    safe_event["transactionHash"],
+                    safe_event["blockHash"],
+                    safe_event["logIndex"],
+                )
+            )
 
 
 class TestSafeEventsIndexerV1_5_0(SafeEventsIndexerBaseAbstractTestBase):

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -15,9 +15,11 @@ from safe_transaction_service.events.services import QueueService
 from ...utils.redis import get_redis
 from ..indexers import (
     Erc20EventsIndexerProvider,
+    FindRelevantElementsException,
     InternalTxIndexerProvider,
     SafeEventsIndexerProvider,
 )
+from ..indexers.erc20_events_indexer import Erc20EventsIndexer
 from ..models import (
     MultisigTransaction,
     SafeContract,
@@ -34,6 +36,7 @@ from ..services import (
 from ..services.collectibles_service import CollectibleWithMetadata
 from ..services.index_service import SpecificIndexingStatus
 from ..tasks import (
+    MAX_CONSECUTIVE_FAILURES,
     check_reorgs_task,
     check_sync_status_task,
     delete_expired_delegates_task,
@@ -119,6 +122,30 @@ class TestTasks(TestCase):
                 "Indexing of erc20/721 events for out of sync addresses task processed 0 events",
                 cm.output[1],
             )
+
+    @patch.object(task_logger, "error")
+    @patch.object(Erc20EventsIndexer, "process_addresses")
+    def test_index_erc20_events_out_of_sync_task_consecutive_failures(
+        self,
+        process_addresses_mock: MagicMock,
+        logger_error_mock: MagicMock,
+    ):
+        # `process_addresses` keeps failing, so the loop must abort after
+        # MAX_CONSECUTIVE_FAILURES instead of spinning forever
+        process_addresses_mock.side_effect = FindRelevantElementsException(
+            "RPC is down"
+        )
+        safe_contract = SafeContractFactory()
+
+        # Call the task synchronously (no result backend needed)
+        result = index_erc20_events_out_of_sync_task(addresses=[safe_contract.address])
+
+        # The loop must abort (no infinite spinning) and return 0 processed events
+        self.assertEqual(result, 0)
+        self.assertEqual(process_addresses_mock.call_count, MAX_CONSECUTIVE_FAILURES)
+        # The abort must be logged as an error
+        logger_error_mock.assert_called_once()
+        self.assertIn("consecutive failures", logger_error_mock.call_args.args[0])
 
     def test_index_internal_txs_task(self):
         self.assertEqual(index_internal_txs_task.delay().result, (0, 0))

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -130,7 +130,7 @@ class TestTasks(TestCase):
         logger_error_mock: MagicMock,
     ):
         # `process_addresses` keeps failing, so the loop must abort after
-        # ERC20_INDEX_MAX_CONSECUTIVE_FAILURES instead of spinning forever
+        # ETH_ERC20_INDEX_MAX_CONSECUTIVE_FAILURES instead of spinning forever
         max_consecutive_failures = 2
         process_addresses_mock.side_effect = FindRelevantElementsException(
             "RPC is down"
@@ -139,7 +139,7 @@ class TestTasks(TestCase):
 
         # Call the task synchronously (no result backend needed)
         with self.settings(
-            ERC20_INDEX_MAX_CONSECUTIVE_FAILURES=max_consecutive_failures
+            ETH_ERC20_INDEX_MAX_CONSECUTIVE_FAILURES=max_consecutive_failures
         ):
             result = index_erc20_events_out_of_sync_task(
                 addresses=[safe_contract.address]

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -36,7 +36,6 @@ from ..services import (
 from ..services.collectibles_service import CollectibleWithMetadata
 from ..services.index_service import SpecificIndexingStatus
 from ..tasks import (
-    MAX_CONSECUTIVE_FAILURES,
     check_reorgs_task,
     check_sync_status_task,
     delete_expired_delegates_task,
@@ -131,18 +130,24 @@ class TestTasks(TestCase):
         logger_error_mock: MagicMock,
     ):
         # `process_addresses` keeps failing, so the loop must abort after
-        # MAX_CONSECUTIVE_FAILURES instead of spinning forever
+        # ERC20_INDEX_MAX_CONSECUTIVE_FAILURES instead of spinning forever
+        max_consecutive_failures = 2
         process_addresses_mock.side_effect = FindRelevantElementsException(
             "RPC is down"
         )
         safe_contract = SafeContractFactory()
 
         # Call the task synchronously (no result backend needed)
-        result = index_erc20_events_out_of_sync_task(addresses=[safe_contract.address])
+        with self.settings(
+            ERC20_INDEX_MAX_CONSECUTIVE_FAILURES=max_consecutive_failures
+        ):
+            result = index_erc20_events_out_of_sync_task(
+                addresses=[safe_contract.address]
+            )
 
         # The loop must abort (no infinite spinning) and return 0 processed events
         self.assertEqual(result, 0)
-        self.assertEqual(process_addresses_mock.call_count, MAX_CONSECUTIVE_FAILURES)
+        self.assertEqual(process_addresses_mock.call_count, max_consecutive_failures)
         # The abort must be logged as an error
         logger_error_mock.assert_called_once()
         self.assertIn("consecutive failures", logger_error_mock.call_args.args[0])


### PR DESCRIPTION
Three related indexing fixes across `history/tasks.py` and `history/indexers/safe_events_indexer.py`.

## 1. Infinite loop in `index_erc20_events_out_of_sync_task`

The `while not updated:` loop swallowed `FindRelevantElementsException` with a bare `pass`. If the RPC kept failing, `updated` never became `True` and the loop spun forever, hammering the node until the Celery timeout killed the task. Added a consecutive-failure guard (`MAX_CONSECUTIVE_FAILURES = 3`): the counter resets after any successful `process_addresses`, and on the 3rd consecutive failure it logs an error and breaks, returning events processed so far.

## 2. FK integrity gap in conditional indexing

`_fetch_receipts_and_store` silently skipped any tx whose receipt fetch failed (warning only), but the corresponding events were still processed into `InternalTx` rows with `ethereum_tx_id` pointing at a tx that was never inserted → `IntegrityError`, forcing the slow one-by-one fallback and dropping the rows. Their blocks also missed the timestamp prefetch, hitting the `KeyError` error path.

Now `_fetch_receipts_and_store` returns the set of tx hashes actually stored. Events whose tx is not present in the DB (`db_txs` ∪ stored) are dropped before processing, and their log receipts are left **unmarked** so they get retried on a later run. Intentional drops (blocklisted / filtered-out receipts) stay marked as before — the exclusion is keyed on receipt-fetch failures only.

## 3. Per-Safe delete inside a loop

`_process_safe_creation_events` ran `InternalTx.objects.filter(contract_address=safe_address).delete()` once per Safe in the SafeSetup-without-ProxyCreation branch. Now the addresses are collected and deleted in a single `filter(contract_address__in=...).delete()` after the loop, before the store.
