### PR TITLE
Fix race condition when creating tokens from blockchain

### DIFF
--- a/safe_transaction_service/tokens/models.py
+++ b/safe_transaction_service/tokens/models.py
@@ -8,7 +8,7 @@ from urllib.parse import parse_qsl, urlencode, urljoin, urlparse, urlunparse
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.storage import default_storage
-from django.db import models
+from django.db import IntegrityError, models, transaction
 from django.db.models import Q
 
 import requests
@@ -93,14 +93,19 @@ class TokenManager(models.Manager):
 
         ethereum_client = get_auto_ethereum_client()
         if token_address in ENS_CONTRACTS_WITH_TLD:  # Special case for ENS
-            return self.create(
-                address=token_address,
-                name="Ethereum Name Service",
-                symbol="ENS",
-                logo="tokens/logos/ENS.png",
-                decimals=None,
-                trusted=True,
-            )
+            try:
+                with transaction.atomic():
+                    return self.create(
+                        address=token_address,
+                        name="Ethereum Name Service",
+                        symbol="ENS",
+                        logo="tokens/logos/ENS.png",
+                        decimals=None,
+                        trusted=True,
+                    )
+            except IntegrityError:
+                # Token was created by another worker in the meantime
+                return self.get(address=token_address)
         try:
             logger.debug(
                 "Querying blockchain for info for erc20 token=%s", token_address
@@ -148,9 +153,14 @@ class TokenManager(models.Manager):
             name, symbol = symbol, name
 
         try:
-            return self.create(
-                address=token_address, name=name, symbol=symbol, decimals=decimals
-            )
+            with transaction.atomic():
+                return self.create(
+                    address=token_address, name=name, symbol=symbol, decimals=decimals
+                )
+        except IntegrityError:
+            # Token was created by another worker while this one was querying
+            # the blockchain
+            return self.get(address=token_address)
         except ValueError:
             logger.error(
                 "Problem creating token with address=%s name=%s symbol=%s decimals=%s",

--- a/safe_transaction_service/tokens/tests/test_models.py
+++ b/safe_transaction_service/tokens/tests/test_models.py
@@ -202,6 +202,25 @@ class TestModels(TestCase):
         self.assertIsNone(Token.objects.create_from_blockchain(address))
         self.assertEqual(TokenNotValid.objects.get(address=address).address, address)
 
+    @mock.patch.object(
+        Erc20Manager,
+        "get_info",
+        autospec=True,
+        return_value=Erc20Info(
+            name="PESETA",
+            symbol="PTA",
+            decimals=18,
+        ),
+    )
+    def test_create_from_blockchain_already_created(self, get_info: MagicMock):
+        # Simulate a race condition where the token is created by another
+        # worker while this one is querying the blockchain
+        existing_token = TokenFactory(name="PESETA", symbol="PTA", decimals=18)
+
+        token = Token.objects.create_from_blockchain(existing_token.address)
+        self.assertEqual(token, existing_token)
+        self.assertEqual(Token.objects.count(), 1)
+
     @mock.patch.object(TokenManager, "create", side_effect=ValueError)
     @mock.patch.object(
         Erc20Manager,


### PR DESCRIPTION
## Summary

Two concurrent requests could hit `Token.objects.create_from_blockchain()` for the same not-yet-stored token at the same time. Both pass the `Token.DoesNotExist` check in `BalanceService.get_token_info()`, and the loser fails with:

```
django.db.utils.IntegrityError: duplicate key value violates unique constraint "tokens_token_pkey"
```

returning HTTP 500 on `GET /api/v1/safes/{address}/balances/` (also reachable via the collectibles service).

## Changes

- Catch `IntegrityError` in `TokenManager.create_from_blockchain()` (both the ENS special case and the regular path) and return the already existing token instead of raising.
- Creation is wrapped in `transaction.atomic()` so the connection is not left in a broken state if a caller runs inside an outer transaction.
- Add a regression test simulating the race by pre-creating the token.

Part of PLA-1742