### PR TITLE
Lazily fetch token metadata on tokens detail endpoint miss

### DIFF
--- a/safe_transaction_service/tokens/tests/test_views.py
+++ b/safe_transaction_service/tokens/tests/test_views.py
@@ -10,17 +10,31 @@ from eth_account import Account
 from rest_framework import status
 from rest_framework.exceptions import ErrorDetail
 from rest_framework.test import APITestCase
-from safe_eth.eth.ethereum_client import Erc20Manager, InvalidERC20Info
+from safe_eth.eth.ethereum_client import (
+    Erc20Info,
+    Erc20Manager,
+    Erc721Manager,
+    InvalidERC20Info,
+    InvalidERC721Info,
+)
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 
-from ..models import Token
+from ..models import Token, TokenNotValid
 from .factories import TokenFactory, TokenListFactory
 
 logger = logging.getLogger(__name__)
 
 
 class TestTokenViews(SafeTestCaseMixin, APITestCase):
-    def test_token_view(self):
+    @mock.patch.object(
+        Erc721Manager, "get_info", autospec=True, side_effect=InvalidERC721Info
+    )
+    @mock.patch.object(
+        Erc20Manager, "get_info", autospec=True, side_effect=InvalidERC20Info
+    )
+    def test_token_view(
+        self, erc20_get_info_mock: MagicMock, erc721_get_info_mock: MagicMock
+    ):
         invalid_address = "0x1234"
         response = self.client.get(reverse("v1:tokens:detail", args=(invalid_address,)))
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
@@ -69,18 +83,64 @@ class TestTokenViews(SafeTestCaseMixin, APITestCase):
             },
         )
 
-    @mock.patch.object(Erc20Manager, "get_info", autospec=True)
-    def test_token_view_missing(self, get_token_info_mock: MagicMock):
-        get_token_info_mock.side_effect = InvalidERC20Info
+    @mock.patch.object(
+        Erc721Manager, "get_info", autospec=True, side_effect=InvalidERC721Info
+    )
+    @mock.patch.object(
+        Erc20Manager, "get_info", autospec=True, side_effect=InvalidERC20Info
+    )
+    def test_token_view_missing(
+        self, erc20_get_info_mock: MagicMock, erc721_get_info_mock: MagicMock
+    ):
+        # Not indexed and not a valid token on-chain: 404 and recorded as invalid
         random_address = Account.create().address
         self.assertEqual(Token.objects.count(), 0)
-        response = self.client.get(reverse("v1:tokens:detail", args=(random_address,)))
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(Token.objects.count(), 0)
+        self.assertEqual(TokenNotValid.objects.count(), 0)
 
         response = self.client.get(reverse("v1:tokens:detail", args=(random_address,)))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(Token.objects.count(), 0)
+        self.assertEqual(
+            TokenNotValid.objects.filter(address=random_address).count(), 1
+        )
+
+        # Second request short-circuits on TokenNotValid without another RPC call
+        response = self.client.get(reverse("v1:tokens:detail", args=(random_address,)))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        erc20_get_info_mock.assert_called_once()
+
+    @mock.patch.object(
+        Erc20Manager,
+        "get_info",
+        autospec=True,
+        return_value=Erc20Info(name="Gnosis", symbol="GNO", decimals=18),
+    )
+    def test_token_view_lazy_creation(self, erc20_get_info_mock: MagicMock):
+        # An unindexed but valid token is fetched from the blockchain on first request
+        random_address = Account.create().address
+        self.assertEqual(Token.objects.count(), 0)
+
+        response = self.client.get(reverse("v1:tokens:detail", args=(random_address,)))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Token.objects.count(), 1)
+        self.assertEqual(response.data["type"], "ERC20")
+        self.assertEqual(response.data["address"], random_address)
+        self.assertEqual(response.data["name"], "Gnosis")
+        self.assertEqual(response.data["symbol"], "GNO")
+        self.assertEqual(response.data["decimals"], 18)
+
+    @mock.patch.object(Erc20Manager, "get_info", autospec=True, side_effect=IOError)
+    def test_token_view_blockchain_error(self, erc20_get_info_mock: MagicMock):
+        # A node/RPC failure degrades to 404 (not 5xx) and is not blacklisted
+        random_address = Account.create().address
+        with self.assertLogs("safe_transaction_service.tokens.views", level="WARNING"):
+            response = self.client.get(
+                reverse("v1:tokens:detail", args=(random_address,))
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(Token.objects.count(), 0)
+        self.assertEqual(TokenNotValid.objects.count(), 0)
+        erc20_get_info_mock.assert_called_once()
 
     def test_tokens_view(self):
         response = self.client.get(reverse("v1:tokens:list"))

--- a/safe_transaction_service/tokens/views.py
+++ b/safe_transaction_service/tokens/views.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
+import logging
+
+from django.http import Http404
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 
@@ -13,6 +16,8 @@ from ..history.serializers import CodeErrorResponse
 from . import filters, serializers
 from .models import Token, TokenList
 
+logger = logging.getLogger(__name__)
+
 
 @extend_schema(
     responses={
@@ -26,6 +31,25 @@ class TokenView(RetrieveAPIView):
     serializer_class = serializers.TokenInfoResponseSerializer
     lookup_field = "address"
     queryset = Token.objects.all()
+
+    def get_object(self) -> Token:
+        try:
+            return super().get_object()
+        except Http404:
+            # Tokens are catalogued lazily (balances/collectibles), so ones seen
+            # only in transaction history are missing; fetch on demand.
+            address = self.kwargs[self.lookup_field]
+            try:
+                token = Token.objects.create_from_blockchain(address)
+            except Exception:
+                # Don't let an RPC failure turn this into a 5xx storm; 404 instead.
+                logger.warning(
+                    "Could not fetch token=%s from blockchain", address, exc_info=True
+                )
+                token = None
+            if token is None:
+                raise
+            return token
 
     @method_decorator(cache_page(60 * 60))  # Cache 1 hour, this does not change often
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
## Summary

`GET /api/v1/tokens/{address}/` (`TokenView`) only served tokens already catalogued by the balances/collectibles endpoints (which populate them lazily via `create_from_blockchain`). Addresses that appear only in a Safe's transaction history — fully-sent tokens, spam/airdrops, NFTs, tokens the Safe no longer holds — are never populated, so per-transaction metadata lookups (e.g. from the client gateway) miss.

In production this endpoint runs ~9.7k req/hr across the tx-service fleet with **~85% returning 404** (~4.3M req/month). Since Django's `cache_page` only caches 200s, every miss re-hits the DB and repeats on each client poll.

## Changes

- `TokenView.get_object`: on a miss, fetch the token from the blockchain via `Token.objects.create_from_blockchain` and return it (populating + caching it). Invalid tokens are still recorded in `TokenNotValid` and return 404.
- An RPC/node failure degrades to a 404 instead of a 5xx and is **not** blacklisted, so it retries once the node recovers (throttled by the client's negative cache).
- Tests for the three paths: valid → lazily created + 200, invalid → 404 + recorded + no repeat RPC, RPC failure → 404 + not blacklisted.

## Details

- Only the detail view is affected (`RetrieveAPIView.get_object`); the list views are untouched.
- Concurrent first-requests for the same token are already handled by the `IntegrityError` / `transaction.atomic` guard in `create_from_blockchain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
