### PR TITLE
fix: Add CELERY_CONTROL_QUEUE_DURABLE setting to fix worker liveness probe on RabbitMQ >=4.3

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -252,6 +252,17 @@ CELERY_BROKER_POOL_LIMIT = env.int("CELERY_BROKER_POOL_LIMIT", default=0)
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-heartbeat
 CELERY_BROKER_HEARTBEAT = env.int("CELERY_BROKER_HEARTBEAT", default=120)
 
+# Not in Celery's official docs, but supported in `celery.app.control.Control` and
+# `kombu.pidbox.Mailbox`. RabbitMQ >=4.3 denies the "transient, non-exclusive" queue
+# that Celery's control/inspect mailbox (used by `celery inspect ping`, our worker
+# liveness probe) declares by default, breaking the probe. Making the mailbox durable
+# instead of exclusive avoids that RabbitMQ restriction without tying it to a single
+# connection, which would crash a worker that restarts under the same hostname.
+# Defaults to true: durable+shared is RabbitMQ's oldest, universally-supported queue
+# type, so it's harmless on RabbitMQ <4.3 too, and every network eventually drifts
+# onto >=4.3 since the RabbitMQ image tag isn't pinned.
+CELERY_CONTROL_QUEUE_DURABLE = env.bool("CELERY_CONTROL_QUEUE_DURABLE", default=True)
+
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-broker_connection_max_retries
 CELERY_BROKER_CONNECTION_MAX_RETRIES = (
     value


### PR DESCRIPTION
## Summary

RabbitMQ 4.3.0 denies "transient, non-exclusive" queue declarations by default. Celery's `inspect ping` command — which our worker liveness probe calls — declares exactly that kind of queue for its control/pidbox mailbox, so on any network running RabbitMQ >=4.3 the probe fails every time,

This adds `CELERY_CONTROL_QUEUE_DURABLE` (defaults to `true`), which makes that mailbox durable instead of transient, escaping RabbitMQ's restriction without touching real task queues/routing/delivery.

## Why durable, not exclusive

The other option Celery offers (`control_queue_exclusive`) also escapes the restriction, but ties the mailbox to a single AMQP connection — reproduced against a real RabbitMQ 4.3.2 container that this **crashes a worker outright** (`ResourceLocked 405`) if it restarts under the same hostname while the broker still has the old connection registered.

## Why default `true`

Durable+shared is RabbitMQ's oldest, most universally-supported queue type, so it's harmless on RabbitMQ <4.3 too. 

### Make sure these boxes are checked! 📦✅

- [ ] You ran `./run_tests.sh`
- [ ] You ran `pre-commit run -a`
- [ ] If you want to add your network to `setup_service.py`, provide a link to your
    [safe-deployments PR](https://github.com/safe-global/safe-deployments/pulls) and check network name
    exists in [safe-eth-py](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py)

### What was wrong? 👾

Closes #

### How was it fixed? 🎯
