### PR TITLE
Annotate Safe membership when reindexing erc20/721 events

### DIFF
--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -154,7 +154,11 @@ class Erc20EventsIndexer(EventsIndexer):
         for log_receipt in log_receipts:
             try:
                 transfer = ERC20Transfer.from_decoded_event(log_receipt)
-                self._annotate_safe_membership(transfer, safe_addresses)
+                set_safe_membership(
+                    transfer,
+                    to_is_a_safe=transfer.to in safe_addresses,
+                    from_is_a_safe=transfer._from in safe_addresses,
+                )
                 yield transfer
             except ValueError:
                 pass
@@ -166,38 +170,24 @@ class Erc20EventsIndexer(EventsIndexer):
         for log_receipt in log_receipts:
             try:
                 transfer = ERC721Transfer.from_decoded_event(log_receipt)
-                self._annotate_safe_membership(transfer, safe_addresses)
+                set_safe_membership(
+                    transfer,
+                    to_is_a_safe=transfer.to in safe_addresses,
+                    from_is_a_safe=transfer._from in safe_addresses,
+                )
                 yield transfer
             except ValueError:
                 pass
 
-    def _get_safe_addresses_for_membership(self) -> set[ChecksumAddress] | None:
+    def _get_safe_addresses_for_membership(self) -> set[ChecksumAddress]:
         """
-        :return: The full set of monitored Safe addresses held in memory, or ``None`` if the
-            address cache has not been populated yet (abnormal: ``process_elements`` invoked
-            outside the normal indexing cycle). ``None`` makes ``_annotate_safe_membership`` a
-            no-op, so `build_event_payload` logs a "lacking metadata" error rather than guessing.
+        :return: The full set of monitored Safe addresses held in memory, loading it from
+            database if the address cache is not populated yet (``process_elements`` invoked
+            outside the normal indexing cycle, e.g. when reindexing)
         """
-        return self.addresses_cache.addresses if self.addresses_cache else None
-
-    @staticmethod
-    def _annotate_safe_membership(
-        transfer: TokenTransfer, safe_addresses: set[ChecksumAddress] | None
-    ) -> None:
-        """
-        Tag the transfer with whether its `to` / `_from` side is a tracked Safe, so only the
-        Safe side gets a directional event. No-op when ``safe_addresses`` is ``None``.
-
-        :param transfer: Transfer about to be stored
-        :param safe_addresses: Monitored Safe addresses, or ``None`` if unavailable
-        """
-        if safe_addresses is None:
-            return
-        set_safe_membership(
-            transfer,
-            to_is_a_safe=transfer.to in safe_addresses,
-            from_is_a_safe=transfer._from in safe_addresses,
-        )
+        if self.addresses_cache:
+            return self.addresses_cache.addresses
+        return self.get_almost_updated_addresses(0)
 
     def events_to_safe_relevant_transaction(
         self, log_receipts: Sequence[EventData]

--- a/safe_transaction_service/history/tests/test_erc20_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_erc20_events_indexer.py
@@ -117,12 +117,19 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
                 block__block_hash=log_receipt["blockHash"],
             )
 
-        # Without a populated address cache the transfer is left unannotated, so
-        # build_event_payload will log the "lacking metadata" error rather than guess.
+        # Without a populated address cache (e.g. when reindexing) membership is
+        # loaded from database, where no Safe is stored yet
         indexer.addresses_cache = None
         (transfer,) = list(indexer.events_to_erc20_transfer(log_receipt_mock))
-        self.assertFalse(hasattr(transfer, "_to_is_a_safe"))
-        self.assertFalse(hasattr(transfer, "_from_is_a_safe"))
+        self.assertFalse(transfer._to_is_a_safe)
+        self.assertFalse(transfer._from_is_a_safe)
+
+        # With the recipient stored as a Safe, membership loaded from database detects it
+        SafeContractFactory(address=transfer.to)
+        indexer.addresses_cache = None
+        (transfer,) = list(indexer.events_to_erc20_transfer(log_receipt_mock))
+        self.assertTrue(transfer._to_is_a_safe)
+        self.assertFalse(transfer._from_is_a_safe)
 
         # With only the recipient tracked: incoming side is a Safe, outgoing side is not.
         indexer.addresses_cache = AddressesCache({transfer.to}, None)


### PR DESCRIPTION
Fixes https://linear.app/safe-global/issue/PLA-1772

Since #2904, transfer events are only sent when the indexer annotates the transfer with `set_safe_membership()`. `Erc20EventsIndexer` takes the membership from `addresses_cache`, but that cache is only populated by `get_almost_updated_addresses()` in the regular indexing loop.

`IndexService.reindex_erc20_events()` creates a new indexer instance and calls `find_relevant_elements()` + `process_elements()` directly, so `addresses_cache` was always `None` there. Every reindexed transfer was left without annotation, logging the fail-closed `Lacking metadata to build event for transfer` error and sending no event. The periodic `reindex_erc20_erc721_last_hours_task` was producing this error constantly since v6.6.0 (errors show in the `indexing` worker logs next to `reindex_master_copies`, so they looked like they came from master copies reindexing).

Changes:
- `_get_safe_addresses_for_membership()` loads the addresses from database (reusing `get_almost_updated_addresses()`, which also populates the cache, so it only happens once per reindex) instead of returning `None` when the cache is empty.
- Membership is always checked against all the Safes in database, so reindexing a subset of addresses still annotates counterparty Safes correctly.
- Remove `_annotate_safe_membership()` and its `None` no-op branch, not needed anymore.