### PR TITLE
Fix RabbitMQ transient_nonexcl_queues error using Celery config namespace

### DIFF
--- a/config/celery_app.py
+++ b/config/celery_app.py
@@ -20,7 +20,7 @@ def on_celery_setup_logging(**kwargs):
 
     # Patch all the code to use Celery logger (if not just logs inside tasks.py are displayed with the
     # task_id and task_name). This way every log will have the context information
-    if not settings.CELERY_ALWAYS_EAGER:
+    if not settings.CELERY_TASK_ALWAYS_EAGER:
         for _, logger in settings.LOGGING["loggers"].items():
             key = "handlers"
             if key in logger:
@@ -50,9 +50,11 @@ app = Celery("safe_transaction_service")
 # Using a string here means the worker doesn't have to serialize
 # the configuration object to child processes.
 # - namespace='CELERY' means all celery-related configuration keys
-#   should have a `CELERY_` prefix.
-app.config_from_object("django.conf:settings")
-# app.config_from_object("django.conf:settings", namespace="CELERY")
+#   should have a `CELERY_` prefix and use Celery's modern lowercase
+#   setting names (uppercased), e.g. `CELERY_TASK_ALWAYS_EAGER` for
+#   `task_always_eager`. Pre-4.0 aliases like `CELERY_ALWAYS_EAGER`
+#   are silently ignored.
+app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks()

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -252,16 +252,12 @@ CELERY_BROKER_POOL_LIMIT = env.int("CELERY_BROKER_POOL_LIMIT", default=0)
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-heartbeat
 CELERY_BROKER_HEARTBEAT = env.int("CELERY_BROKER_HEARTBEAT", default=120)
 
-# Not in Celery's official docs, but supported in `celery.app.control.Control` and
-# `kombu.pidbox.Mailbox`. RabbitMQ >=4.3 denies the "transient, non-exclusive" queue
-# that Celery's control/inspect mailbox (used by `celery inspect ping`, our worker
-# liveness probe) declares by default, breaking the probe. Making the mailbox durable
-# instead of exclusive avoids that RabbitMQ restriction without tying it to a single
-# connection, which would crash a worker that restarts under the same hostname.
-# Defaults to true: durable+shared is RabbitMQ's oldest, universally-supported queue
-# type, so it's harmless on RabbitMQ <4.3 too, and every network eventually drifts
-# onto >=4.3 since the RabbitMQ image tag isn't pinned.
+# Control and event queues must be durable, as RabbitMQ >=4.3 denies declaring
+# transient non-exclusive queues
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-control_queue_durable
 CELERY_CONTROL_QUEUE_DURABLE = env.bool("CELERY_CONTROL_QUEUE_DURABLE", default=True)
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-event_queue_durable
+CELERY_EVENT_QUEUE_DURABLE = env.bool("CELERY_EVENT_QUEUE_DURABLE", default=True)
 
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-broker_connection_max_retries
 CELERY_BROKER_CONNECTION_MAX_RETRIES = (
@@ -286,19 +282,19 @@ CELERY_TASK_SERIALIZER = "json"
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_serializer
 CELERY_RESULT_SERIALIZER = "json"
 # We are not interested in keeping results of tasks
-CELERY_IGNORE_RESULT = True
+CELERY_TASK_IGNORE_RESULT = True
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_always_eager
-CELERY_ALWAYS_EAGER = False
+CELERY_TASK_ALWAYS_EAGER = False
 # https://docs.celeryproject.org/en/latest/userguide/configuration.html#task-default-priority
 # Higher = more priority on RabbitMQ, opposite on Redis ¯\_(ツ)_/¯
 CELERY_TASK_DEFAULT_PRIORITY = 5
 # https://docs.celeryproject.org/en/stable/userguide/configuration.html#task-queue-max-priority
-CELERY_TASK_QUEUE_MAX_PRIORITY = 10
+CELERY_TASK_QUEUE_MAX_PRIORITY = None
 # https://docs.celeryproject.org/en/latest/userguide/configuration.html#broker-transport-options
 CELERY_BROKER_TRANSPORT_OPTIONS = {}
 
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_routes
-CELERY_ROUTES = (
+CELERY_TASK_ROUTES = (
     [
         (
             "safe_transaction_service.history.tasks.retry_get_metadata_task",

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -36,7 +36,7 @@ CACHES = {
 PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
 # CELERY
-CELERY_ALWAYS_EAGER = True
+CELERY_TASK_ALWAYS_EAGER = True
 
 # Ganache #2 private key
 ETHEREUM_TEST_PRIVATE_KEY = (


### PR DESCRIPTION
Fix RabbitMQ transient_nonexcl_queues error using Celery config namespace

## Problem

Production shows this error on RabbitMQ >=4.3:

```
amqp.exceptions.InternalError: Queue.declare: (541) INTERNAL_ERROR - Feature `transient_nonexcl_queues` is deprecated.
```

RabbitMQ >=4.3 denies declaring transient (non-durable), non-exclusive queues. Celery declares two of them: the control mailbox queues (used by `celery inspect ping`, our worker liveness probe) and the `celeryev.*` queues used by Flower.

## Root cause

`CELERY_CONTROL_QUEUE_DURABLE` (#2943) never worked. The app loaded Django settings with `config_from_object("django.conf:settings")` without a namespace, so Celery only read settings matching a pre-4.0 name. Settings without a pre-4.0 alias were silently ignored: `control_queue_durable` and every `broker_*` setting (`broker_url`, `broker_pool_limit`, etc.) were running on Celery defaults.

## Changes

- Load Django settings with `config_from_object("django.conf:settings", namespace="CELERY")`, as [Celery docs recommend](https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html). Every `CELERY_<setting>` name now maps to the Celery setting `<setting>` (lowercase).
- Rename pre-4.0 setting names to their modern equivalents (support for old names is removed in Celery 6.0):
  - `CELERY_IGNORE_RESULT` -> `CELERY_TASK_IGNORE_RESULT`
  - `CELERY_ALWAYS_EAGER` -> `CELERY_TASK_ALWAYS_EAGER`
  - `CELERY_ROUTES` -> `CELERY_TASK_ROUTES`
- Add `CELERY_EVENT_QUEUE_DURABLE` (default `True`) so Flower event queues are durable. Abandoned queues are still removed by `event_queue_expires` (60s default).
- Set `CELERY_TASK_QUEUE_MAX_PRIORITY` to `None`, so task queues are declared with the same arguments production queues already have (redeclaring an existing queue with new arguments fails with `PRECONDITION_FAILED`).

Env var names do not change, so no deployment configuration needs to be updated.

## Behavior changes on deploy

Settings that were silently ignored before and now apply:

- `control_queue_durable`: `False` -> `True` (the fix)
- `event_queue_durable`: -> `True`
- `broker_pool_limit`: `10` (Celery default) -> `0` (intended since #4355 workaround)
- `broker_connection_max_retries`: `100` -> unlimited
- `broker_channel_error_retry`: `False` -> `True`
- `broker_url` is now also read from Django settings (same value as the env var the CLI already used)
- `task_default_priority`: unset -> `5`. Publish-side only, RabbitMQ ignores message priority on queues without `x-max-priority`, so this is inert until priority queues are enabled.

## Testing

- Validated every `CELERY_*` Django setting against the resolved `app.conf` value after importing the app: all match.
- Routed every registered task through `app.amqp.router` before and after the change: routing is identical (queues and per-route options).
- Control mailbox and event receiver queues now declare `durable=True`, `auto_delete=False`.
- `config.celery_app` still imports without a configured database (worker lazy-import contract, covered by `test_celery_app.py`).
- Test suite parity with `main` (same passes/failures locally).

Fixes PLA-1775.