### PR TITLE
Restore CELERY_BROKER_POOL_LIMIT default to 10

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -247,8 +247,7 @@ INSTALLED_APPS += [
 CELERY_BROKER_URL = env("CELERY_BROKER_URL", default="django://")
 # https://docs.celeryproject.org/en/stable/userguide/optimizing.html#broker-connection-pools
 # https://docs.celeryq.dev/en/latest/userguide/optimizing.html#broker-connection-pools
-# Configured to 0 due to connection issues https://github.com/celery/celery/issues/4355
-CELERY_BROKER_POOL_LIMIT = env.int("CELERY_BROKER_POOL_LIMIT", default=0)
+CELERY_BROKER_POOL_LIMIT = env.int("CELERY_BROKER_POOL_LIMIT", default=10)
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-heartbeat
 CELERY_BROKER_HEARTBEAT = env.int("CELERY_BROKER_HEARTBEAT", default=120)
 


### PR DESCRIPTION
## Problem

The Celery config namespace switch in #2951 (`config_from_object(..., namespace="CELERY")`) started applying broker settings that were silently ignored before. `CELERY_BROKER_POOL_LIMIT=0` finally took effect and disabled broker connection pooling.

Under the old no-namespace config that setting was ignored, so Celery used its default of `10` (pooled connections). The `0` was never actually live, despite being in the settings for years.

## Impact

With pooling disabled, every publish opens and closes a fresh connection. On the `polygon-safe-transaction-worker-indexer` this made erc20 event processing about **3x slower per block** (~7 ms/event to ~18 ms/event).

Throughput was still tracking the chain in steady state, so it was not obvious, but catch-up dropped from ~2 blocks/s to ~0.7 blocks/s, barely above Polygon block rate. Every worker restart opens a ~150-block gap (cold address-cache reload), and the indexer could no longer close it, so it got stuck processing huge slow batches (100-280s tasks, 70-200 block ranges) instead of small fast ones.

## Fix

Restore the default to `10` to match the behavior that was actually running before the namespace switch.