### PR TITLE
Load monitored-Safe-address set as raw bytes to skip keccak on cold load

### DIFF
--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -91,9 +91,9 @@ class Erc20EventsIndexer(EventsIndexer):
     @property
     def database_queryset(self) -> QuerySet:
         # Annotate the address as raw 20 bytes so loaders can skip the per-row
-        # keccak EIP-55 checksumming that `EthereumAddressBinaryField.from_db_value`
-        # performs. The address set is only used for membership tests, so the
-        # checksum is not needed.
+        # keccak EIP-55 checksumming done by `EthereumAddressBinaryField.from_db_value`.
+        # The addresses are used only as lookup keys (membership tests, event
+        # filtering), never displayed, so the checksum is not needed.
         return SafeContract.objects.all().annotate(
             address_bytes=Cast("address", output_field=BinaryField())
         )

--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -90,7 +90,13 @@ class Erc20EventsIndexer(EventsIndexer):
 
     @property
     def database_queryset(self) -> QuerySet:
-        return SafeContract.objects.all()
+        # Annotate the address as raw 20 bytes so loaders can skip the per-row
+        # keccak EIP-55 checksumming that `EthereumAddressBinaryField.from_db_value`
+        # performs. The address set is only used for membership tests, so the
+        # checksum is not needed.
+        return SafeContract.objects.all().annotate(
+            address_bytes=Cast("address", output_field=BinaryField())
+        )
 
     def _do_node_query(
         self,
@@ -300,11 +306,7 @@ class Erc20EventsIndexer(EventsIndexer):
         """
         created: datetime.datetime | None = None
         for i, (created, address) in enumerate(
-            # Load the address as raw 20 bytes to avoid the per-row keccak EIP-55
-            # checksumming that `EthereumAddressBinaryField.from_db_value` performs.
-            # The set is only used for membership tests, so the checksum is not needed.
-            query.annotate(address_bytes=Cast("address", output_field=BinaryField()))
-            .values_list("created", "address_bytes")
+            query.values_list("created", "address_bytes")
             .order_by("created")
             .iterator(chunk_size=self.eth_erc20_load_addresses_chunk_size)
         ):
@@ -323,6 +325,18 @@ class Erc20EventsIndexer(EventsIndexer):
 
         logger.debug("%s: Retrieved monitored addresses", self.__class__.__name__)
         return addresses
+
+    def get_monitored_addresses(self) -> set[bytes]:
+        """
+        :return: Every monitored Safe address as raw 20-byte values (no keccak),
+            matching how the set is held in memory (see ``get_almost_updated_addresses``)
+        """
+        return {
+            bytes(address)
+            for address in self.database_queryset.values_list(
+                "address_bytes", flat=True
+            )
+        }
 
     def get_not_updated_addresses(self, current_block_number: int) -> EmptyQuerySet:
         """

--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -335,7 +335,7 @@ class Erc20EventsIndexer(EventsIndexer):
             bytes(address)
             for address in self.database_queryset.values_list(
                 "address_bytes", flat=True
-            )
+            ).iterator(chunk_size=self.eth_erc20_load_addresses_chunk_size)
         }
 
     def get_not_updated_addresses(self, current_block_number: int) -> EmptyQuerySet:

--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -5,10 +5,12 @@ from collections.abc import Iterator, Sequence
 from logging import getLogger
 from typing import NamedTuple
 
-from django.db.models import QuerySet
+from django.db.models import BinaryField, QuerySet
+from django.db.models.functions import Cast
 from django.db.models.query import EmptyQuerySet
 
 from eth_typing import ChecksumAddress
+from hexbytes import HexBytes
 from safe_eth.eth import EthereumClient
 from web3.contract.contract import ContractEvent
 from web3.types import EventData, LogReceipt
@@ -29,7 +31,7 @@ logger = getLogger(__name__)
 
 
 class AddressesCache(NamedTuple):
-    addresses: set[ChecksumAddress]
+    addresses: set[bytes]
     last_checked: datetime.datetime | None
 
 
@@ -92,7 +94,7 @@ class Erc20EventsIndexer(EventsIndexer):
 
     def _do_node_query(
         self,
-        addresses: set[ChecksumAddress],
+        addresses: set[bytes],
         from_block_number: int,
         to_block_number: int,
     ) -> list[LogReceipt]:
@@ -133,8 +135,8 @@ class Erc20EventsIndexer(EventsIndexer):
             if transfer_event["blockHash"]
             != transfer_event["transactionHash"]  # CELO ERC20 rewards
             and (
-                transfer_event["args"]["to"] in addresses
-                or transfer_event["args"]["from"] in addresses
+                HexBytes(transfer_event["args"]["to"]) in addresses
+                or HexBytes(transfer_event["args"]["from"]) in addresses
             )
         ]
 
@@ -156,8 +158,8 @@ class Erc20EventsIndexer(EventsIndexer):
                 transfer = ERC20Transfer.from_decoded_event(log_receipt)
                 set_safe_membership(
                     transfer,
-                    to_is_a_safe=transfer.to in safe_addresses,
-                    from_is_a_safe=transfer._from in safe_addresses,
+                    to_is_a_safe=HexBytes(transfer.to) in safe_addresses,
+                    from_is_a_safe=HexBytes(transfer._from) in safe_addresses,
                 )
                 yield transfer
             except ValueError:
@@ -172,14 +174,14 @@ class Erc20EventsIndexer(EventsIndexer):
                 transfer = ERC721Transfer.from_decoded_event(log_receipt)
                 set_safe_membership(
                     transfer,
-                    to_is_a_safe=transfer.to in safe_addresses,
-                    from_is_a_safe=transfer._from in safe_addresses,
+                    to_is_a_safe=HexBytes(transfer.to) in safe_addresses,
+                    from_is_a_safe=HexBytes(transfer._from) in safe_addresses,
                 )
                 yield transfer
             except ValueError:
                 pass
 
-    def _get_safe_addresses_for_membership(self) -> set[ChecksumAddress]:
+    def _get_safe_addresses_for_membership(self) -> set[bytes]:
         """
         :return: The full set of monitored Safe addresses held in memory, loading it from
             database if the address cache is not populated yet (``process_elements`` invoked
@@ -254,9 +256,7 @@ class Erc20EventsIndexer(EventsIndexer):
                 result_erc20 + result_erc721
             )  # TODO Hack to prevent returning `TokenTransfer` and using too much RAM
 
-    def get_almost_updated_addresses(
-        self, current_block_number: int
-    ) -> set[ChecksumAddress]:
+    def get_almost_updated_addresses(self, current_block_number: int) -> set[bytes]:
         """
 
         :param current_block_number:
@@ -300,11 +300,15 @@ class Erc20EventsIndexer(EventsIndexer):
         """
         created: datetime.datetime | None = None
         for i, (created, address) in enumerate(
-            query.values_list("created", "address")
+            # Load the address as raw 20 bytes to avoid the per-row keccak EIP-55
+            # checksumming that `EthereumAddressBinaryField.from_db_value` performs.
+            # The set is only used for membership tests, so the checksum is not needed.
+            query.annotate(address_bytes=Cast("address", output_field=BinaryField()))
+            .values_list("created", "address_bytes")
             .order_by("created")
             .iterator(chunk_size=self.eth_erc20_load_addresses_chunk_size)
         ):
-            addresses.add(address)
+            addresses.add(bytes(address))
 
             # Store addresses in cache every chunk, just in case task is interrupted during address loading
             if i % self.eth_erc20_load_addresses_chunk_size == 0:

--- a/safe_transaction_service/history/indexers/ethereum_indexer.py
+++ b/safe_transaction_service/history/indexers/ethereum_indexer.py
@@ -244,6 +244,13 @@ class EthereumIndexer(ABC):
         )
         return minimum_block_number
 
+    def get_monitored_addresses(self) -> set[ChecksumAddress]:
+        """
+        :return: Every monitored address (e.g. for reindexing). Checksummed strings
+            by default; subclasses holding another representation override this.
+        """
+        return set(self.database_queryset.values_list("address", flat=True))
+
     def get_almost_updated_addresses(
         self, current_block_number: int
     ) -> set[ChecksumAddress]:

--- a/safe_transaction_service/history/services/index_service.py
+++ b/safe_transaction_service/history/services/index_service.py
@@ -11,6 +11,7 @@ import gevent
 from eth_typing import ChecksumAddress, Hash32
 from hexbytes import HexBytes
 from safe_eth.eth import EthereumClient, get_auto_ethereum_client
+from safe_eth.eth.utils import fast_to_checksum_address
 from safe_eth.util.util import to_0x_hex_str
 
 from ..models import (
@@ -603,7 +604,7 @@ class IndexService:
             # No issues on modifying the indexer as we should be provided with a new instance
             indexer.IGNORE_ADDRESSES_ON_LOG_FILTER = False
         else:
-            addresses = set(indexer.database_queryset.values_list("address", flat=True))
+            addresses = indexer.get_monitored_addresses()
 
         if not addresses:
             logger.warning("No addresses to process")
@@ -612,10 +613,17 @@ class IndexService:
         if block_process_limit is not None:
             indexer.block_process_limit = block_process_limit
 
-        # Don't log all the addresses
+        # Don't log all the addresses; checksum any raw-bytes ones for readability
         addresses_len = len(addresses)
         addresses_str = (
-            str(addresses) if addresses_len < 10 else f"{addresses_len} addresses..."
+            [
+                fast_to_checksum_address(address)
+                if isinstance(address, bytes)
+                else address
+                for address in addresses
+            ]
+            if addresses_len < 10
+            else f"{addresses_len} addresses..."
         )
         logger.info("Start reindexing addresses %s", addresses_str)
         current_block_number = self.ethereum_client.current_block_number

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from celery import app
 from celery.utils.log import get_task_logger
 from eth_typing import ChecksumAddress
+from hexbytes import HexBytes
 from redis.exceptions import LockError
 from safe_eth.eth.utils import fast_to_checksum_address
 
@@ -134,24 +135,31 @@ def index_erc20_events_out_of_sync_task(
         erc20_events_indexer.block_process_limit_max = block_process_limit_max
 
     current_block_number = erc20_events_indexer.ethereum_client.current_block_number
-    addresses: set[ChecksumAddress] = (
-        set(addresses)
+    # Query with raw-bytes addresses (what `_do_node_query` filters against);
+    # explicit addresses arrive as checksummed strings
+    addresses: set[bytes] = (
+        {HexBytes(address) for address in addresses}
         if addresses
-        else {
-            fast_to_checksum_address(address)
-            for address in islice(
+        else set(
+            islice(
                 erc20_events_indexer.get_almost_updated_addresses(current_block_number),
                 number_of_addresses,
             )
-        }
+        )
     )
 
     if not addresses:
         logger.info("No addresses to process")
     else:
+        # Log the addresses checksummed for readability, bounded like `_reindex`
+        addresses_str = (
+            [fast_to_checksum_address(address) for address in addresses]
+            if len(addresses) < 10
+            else f"{len(addresses)} addresses..."
+        )
         logger.info(
             "Start indexing of erc20/721 events for out of sync addresses %s",
-            addresses,
+            addresses_str,
         )
         updated = False
         number_events_processed = 0
@@ -178,7 +186,7 @@ def index_erc20_events_out_of_sync_task(
                         "Aborting out of sync erc20/721 indexing after %d "
                         "consecutive failures for addresses %s",
                         consecutive_failures,
-                        addresses,
+                        addresses_str,
                     )
                     break
 

--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -4,6 +4,7 @@ import dataclasses
 import datetime
 import json
 import random
+from itertools import islice
 
 from django.conf import settings
 from django.utils import timezone
@@ -12,6 +13,7 @@ from celery import app
 from celery.utils.log import get_task_logger
 from eth_typing import ChecksumAddress
 from redis.exceptions import LockError
+from safe_eth.eth.utils import fast_to_checksum_address
 
 from safe_transaction_service.utils.redis import get_redis
 
@@ -132,14 +134,16 @@ def index_erc20_events_out_of_sync_task(
         erc20_events_indexer.block_process_limit_max = block_process_limit_max
 
     current_block_number = erc20_events_indexer.ethereum_client.current_block_number
-    addresses = (
+    addresses: set[ChecksumAddress] = (
         set(addresses)
         if addresses
-        else set(
-            list(
-                erc20_events_indexer.get_almost_updated_addresses(current_block_number)
-            )[:number_of_addresses]
-        )
+        else {
+            fast_to_checksum_address(address)
+            for address in islice(
+                erc20_events_indexer.get_almost_updated_addresses(current_block_number),
+                number_of_addresses,
+            )
+        }
     )
 
     if not addresses:

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 
 from django_celery_beat.models import PeriodicTask
 from eth_account import Account
+from hexbytes import HexBytes
 from safe_eth.eth.account_abstraction import BundlerClient
 from safe_eth.eth.ethereum_client import EthereumClient, EthereumNetwork
 from safe_eth.safe import Safe
@@ -200,7 +201,7 @@ class TestCommands(SafeTestCaseMixin, TestCase):
                     f"--from-block-number={from_block_number}",
                     stdout=buf,
                 )
-                expected_addresses = {safe_master_copy.address}
+                expected_addresses = [safe_master_copy.address]
                 self.assertIn(
                     f"Start reindexing addresses {expected_addresses}",
                     cm.output[0],
@@ -243,7 +244,7 @@ class TestCommands(SafeTestCaseMixin, TestCase):
                         f"--from-block-number={from_block_number}",
                         stdout=buf,
                     )
-                    expected_addresses = {safe_l2_master_copy.address}
+                    expected_addresses = [safe_l2_master_copy.address]
                     self.assertIn(
                         f"Start reindexing addresses {expected_addresses}",
                         cm.output[0],
@@ -391,7 +392,7 @@ class TestCommands(SafeTestCaseMixin, TestCase):
                     f"--from-block-number={from_block_number}",
                     stdout=buf,
                 )
-                expected_addresses = {safe_contract.address}
+                expected_addresses = [safe_contract.address]
                 self.assertIn(
                     f"Start reindexing addresses {expected_addresses}",
                     cm.output[0],
@@ -401,13 +402,14 @@ class TestCommands(SafeTestCaseMixin, TestCase):
                     f"End reindexing addresses {expected_addresses}",
                     cm.output[3],
                 )
+                # The ERC20/721 indexer reindexes with raw-bytes addresses
                 find_relevant_elements_mock.assert_any_call(
-                    {safe_contract.address},
+                    {HexBytes(safe_contract.address)},
                     from_block_number,
                     from_block_number + block_process_limit - 1,
                 )
                 find_relevant_elements_mock.assert_any_call(
-                    {safe_contract.address},
+                    {HexBytes(safe_contract.address)},
                     from_block_number + block_process_limit,
                     current_block_number_mock.return_value,
                 )

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -118,7 +118,7 @@ class TestCommands(SafeTestCaseMixin, TestCase):
 
         with self.assertLogs(logger=task_logger) as cm:
             safe_contract = SafeContractFactory()
-            addresses = {safe_contract.address}
+            addresses = [safe_contract.address]
             buf = StringIO()
             call_command(command, stdout=buf)
             self.assertIn(
@@ -132,7 +132,7 @@ class TestCommands(SafeTestCaseMixin, TestCase):
 
         with self.assertLogs(logger=task_logger) as cm:
             safe_contract_2 = SafeContractFactory()
-            addresses = {safe_contract_2.address}
+            addresses = [safe_contract_2.address]
             buf = StringIO()
             call_command(command, f"--addresses={safe_contract_2.address}", stdout=buf)
             self.assertIn(
@@ -147,7 +147,7 @@ class TestCommands(SafeTestCaseMixin, TestCase):
         # Test sync task call
         with self.assertLogs(logger=task_logger) as cm:
             safe_contract_2 = SafeContractFactory()
-            addresses = {safe_contract_2.address}
+            addresses = [safe_contract_2.address]
             buf = StringIO()
             call_command(
                 command, f"--addresses={safe_contract_2.address}", "--sync", stdout=buf

--- a/safe_transaction_service/history/tests/test_erc20_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_erc20_events_indexer.py
@@ -184,13 +184,13 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
         self.assertFalse(transfer._from_is_a_safe)
 
         # With only the recipient tracked: incoming side is a Safe, outgoing side is not.
-        indexer.addresses_cache = AddressesCache({transfer.to}, None)
+        indexer.addresses_cache = AddressesCache({HexBytes(transfer.to)}, None)
         (transfer,) = list(indexer.events_to_erc20_transfer(log_receipt_mock))
         self.assertTrue(transfer._to_is_a_safe)
         self.assertFalse(transfer._from_is_a_safe)
 
         # With only the sender tracked: outgoing side is a Safe, incoming side is not.
-        indexer.addresses_cache = AddressesCache({transfer._from}, None)
+        indexer.addresses_cache = AddressesCache({HexBytes(transfer._from)}, None)
         (transfer,) = list(indexer.events_to_erc20_transfer(log_receipt_mock))
         self.assertFalse(transfer._to_is_a_safe)
         self.assertTrue(transfer._from_is_a_safe)
@@ -206,7 +206,11 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
         safe_contract_2 = SafeContractFactory()
         self.assertGreaterEqual(safe_contract_2.created, safe_contract_1.created)
 
-        expected_addresses = {safe_contract_1.address, safe_contract_2.address}
+        # Addresses are held in memory as raw bytes, not checksummed strings
+        expected_addresses = {
+            HexBytes(safe_contract_1.address),
+            HexBytes(safe_contract_2.address),
+        }
         self.assertEqual(
             self.erc20_events_indexer.get_almost_updated_addresses(0),
             expected_addresses,
@@ -224,7 +228,7 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
         safe_contract_3 = SafeContractFactory()
         self.assertGreater(safe_contract_3.created, safe_contract_2.created)
 
-        expected_addresses.add(safe_contract_3.address)
+        expected_addresses.add(HexBytes(safe_contract_3.address))
         self.assertEqual(
             self.erc20_events_indexer.get_almost_updated_addresses(0),
             expected_addresses,

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from eth_account import Account
+from hexbytes import HexBytes
 
 from safe_transaction_service.events.services import QueueService
 
@@ -112,7 +113,7 @@ class TestTasks(TestCase):
         with self.assertLogs(logger=task_logger) as cm:
             safe_contract = SafeContractFactory()
             index_erc20_events_out_of_sync_task.delay()
-            addresses = {safe_contract.address}
+            addresses = [safe_contract.address]
             self.assertIn(
                 f"Start indexing of erc20/721 events for out of sync addresses {addresses}",
                 cm.output[0],
@@ -121,6 +122,33 @@ class TestTasks(TestCase):
                 "Indexing of erc20/721 events for out of sync addresses task processed 0 events",
                 cm.output[1],
             )
+
+    @patch.object(Erc20EventsIndexer, "process_addresses")
+    def test_index_erc20_events_out_of_sync_task_queries_with_bytes(
+        self, process_addresses_mock: MagicMock
+    ):
+        # `process_addresses` must receive raw-bytes addresses so the bytes-only
+        # `_do_node_query` filter matches; checksummed strings would silently drop
+        # every event once the set exceeds `query_chunk_size`.
+        process_addresses_mock.return_value = ([], 0, 0, True)  # updated -> exit loop
+        safe_contract = SafeContractFactory()
+        expected = {HexBytes(safe_contract.address)}
+
+        # Auto-derived branch (no explicit addresses)
+        index_erc20_events_out_of_sync_task()
+        auto_addresses = process_addresses_mock.call_args.args[0]
+        self.assertEqual(auto_addresses, expected)
+        self.assertTrue(all(isinstance(address, bytes) for address in auto_addresses))
+
+        # Explicit --addresses branch (checksummed strings from the caller)
+        process_addresses_mock.reset_mock()
+        process_addresses_mock.return_value = ([], 0, 0, True)
+        index_erc20_events_out_of_sync_task(addresses=[safe_contract.address])
+        explicit_addresses = process_addresses_mock.call_args.args[0]
+        self.assertEqual(explicit_addresses, expected)
+        self.assertTrue(
+            all(isinstance(address, bytes) for address in explicit_addresses)
+        )
 
     @patch.object(task_logger, "error")
     @patch.object(Erc20EventsIndexer, "process_addresses")


### PR DESCRIPTION
# Load monitored-Safe-address set as raw bytes to skip keccak on cold load

## What

On a cold start `Erc20EventsIndexer.get_almost_updated_addresses` loads every
monitored `SafeContract.address` into memory. It read them via
`values_list("created", "address")`, so `EthereumAddressBinaryField.from_db_value`
ran `fast_bytes_to_checksum_address` (keccak256 + EIP-55 string build) **once per
row** — ~15M keccak hashes at production scale.

The set is only used for membership tests (never displayed), so the checksum is
wasted CPU. This holds it as raw 20-byte `bytes` instead:

- Read the column with `Cast("address", output_field=BinaryField())` so the
  base `BinaryField.from_db_value` (identity) runs instead of the keccak one.
- Convert the small event side with `HexBytes(...)` at the three membership
  sites (`_do_node_query`, `events_to_erc20_transfer`, `events_to_erc721_transfer`).
- `AddressesCache.addresses` and the related return types become `set[bytes]`.

## Why

Microbenchmark on 3M unique 20-byte addresses (per-row conversion cost):

| Path | 3M | extrapolated 15M |
| --- | --- | --- |
| checksum set (current `from_db_value`) | 25.16s | ~126s |
| raw-bytes set (this PR) | 0.89s | ~4.5s |
| checksum → back to binary | 31.99s | ~160s |

Checksumming is ~96% of the load cost; the raw-bytes load is ~28x faster and
uses ~40% less RAM. Converting to checksum and back to binary is slower than
doing nothing, so the fix reads raw binary straight from the DB.

## Notes

- No `safe-eth-py` change: the RPC path (`get_total_transfer_history`) already
  accepts bytes — Safe addresses go into the `eth_getLogs` topics via
  `eth_abi.encode(["address"], [addr])`.
- `HexBytes` subclasses `bytes`, so `HexBytes(addr) in {raw_bytes}` works; same
  pattern already used at `tx_processor.py:260-261`.
- Steady-state (warm incremental cache) is unaffected; only cold-load hydration
  changes.

## Test

`test_erc20_events_indexer.py` + `test_signals.py` pass, including the ganache
end-to-end `test_erc20_events_indexer` that exercises the RPC path and
Safe-membership annotation with a real ERC20 transfer.

Closes PLA-1778.