### PR TITLE
Fix erc20 indexer getting stuck when a reorged block is served as valid

### DIFF
--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -5,7 +5,6 @@ from collections.abc import Iterator, Sequence
 from logging import getLogger
 from typing import NamedTuple
 
-from django.db import transaction
 from django.db.models import QuerySet
 from django.db.models.query import EmptyQuerySet
 
@@ -223,32 +222,31 @@ class Erc20EventsIndexer(EventsIndexer):
             self._prefetch_ethereum_txs(tx_hashes)
             logger.debug("Storing TokenTransfer objects")
             logger.debug("Storing Transfer Events")
-            # Store transfers and SafeRelevantTransactions in one transaction,
-            # so transfer events (sent on commit by the `post_bulk_create`
-            # receivers) are never published before all the data is visible
-            with transaction.atomic():
-                result_erc20 = ERC20Transfer.objects.bulk_create_from_generator(
-                    self.events_to_erc20_transfer(not_processed_log_receipts),
+            # SafeRelevantTransactions are stored first, as they don't
+            # publish events, so when the ERC20/721 events are published
+            # everything is ready on the database
+            result_safe_relevant_transaction = (
+                SafeRelevantTransaction.objects.bulk_create_from_generator(
+                    self.events_to_safe_relevant_transaction(
+                        not_processed_log_receipts
+                    ),
                     ignore_conflicts=True,
                 )
-                logger.debug("Stored %d ERC20 Events", result_erc20)
-                result_erc721 = ERC721Transfer.objects.bulk_create_from_generator(
-                    self.events_to_erc721_transfer(not_processed_log_receipts),
-                    ignore_conflicts=True,
-                )
-                logger.debug("Stored %d ERC721 Events", result_erc721)
-                result_safe_relevant_transaction = (
-                    SafeRelevantTransaction.objects.bulk_create_from_generator(
-                        self.events_to_safe_relevant_transaction(
-                            not_processed_log_receipts
-                        ),
-                        ignore_conflicts=True,
-                    )
-                )
-                logger.debug(
-                    "Stored %d Safe Relevant Transactions",
-                    result_safe_relevant_transaction,
-                )
+            )
+            logger.debug(
+                "Stored %d Safe Relevant Transactions",
+                result_safe_relevant_transaction,
+            )
+            result_erc20 = ERC20Transfer.objects.bulk_create_from_generator(
+                self.events_to_erc20_transfer(not_processed_log_receipts),
+                ignore_conflicts=True,
+            )
+            logger.debug("Stored %d ERC20 Events", result_erc20)
+            result_erc721 = ERC721Transfer.objects.bulk_create_from_generator(
+                self.events_to_erc721_transfer(not_processed_log_receipts),
+                ignore_conflicts=True,
+            )
+            logger.debug("Stored %d ERC721 Events", result_erc721)
             logger.debug("Marking events as processed")
             self._mark_log_receipts_processed(not_processed_log_receipts)
             logger.debug("Marked events as processed")

--- a/safe_transaction_service/history/tests/test_erc20_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_erc20_events_indexer.py
@@ -1,11 +1,18 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 from django.test import TestCase
 
+from hexbytes import HexBytes
 from safe_eth.eth.tests.ethereum_test_case import EthereumTestCaseMixin
 
 from ..indexers import Erc20EventsIndexerProvider
 from ..indexers.erc20_events_indexer import AddressesCache
-from ..models import ERC20Transfer, EthereumTx, IndexingStatus, SafeRelevantTransaction
+from ..models import (
+    ERC20Transfer,
+    EthereumBlock,
+    EthereumTx,
+    IndexingStatus,
+    SafeRelevantTransaction,
+)
 from .factories import EthereumTxFactory, SafeContractFactory
 from .mocks.mocks_erc20_events_indexer import log_receipt_mock
 
@@ -14,9 +21,15 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
     def setUp(self) -> None:
         Erc20EventsIndexerProvider.del_singleton()
         self.erc20_events_indexer = Erc20EventsIndexerProvider()
+        EthereumBlock.objects.get_timestamp_by_hash.cache_clear()
 
     def tearDown(self) -> None:
         Erc20EventsIndexerProvider.del_singleton()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        EthereumBlock.objects.get_timestamp_by_hash.cache_clear()
+        return super().tearDownClass()
 
     def test_erc20_events_indexer(self):
         erc20_events_indexer = self.erc20_events_indexer
@@ -106,6 +119,45 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
         self.assertEqual(
             len(self.erc20_events_indexer.process_elements(log_receipt_mock)), 1
         )
+
+    def test_process_elements_reorged_block_is_flagged_not_confirmed(self):
+        """
+        A reorg can move an already-indexed tx to a new block. The event then
+        references a block hash missing from database while the tx is still
+        stored under the stale block. Processing must fail so the range is
+        retried without marking the events as processed, but the stale block
+        must be left as not confirmed even though the storing transaction
+        rolls back, otherwise `check_reorgs_task` will never detect the reorg
+        and the indexer will retry the same range forever.
+        """
+        log_receipt = log_receipt_mock[0]
+        ethereum_tx = EthereumTxFactory(
+            tx_hash=log_receipt["transactionHash"],
+            block__confirmed=True,  # Deep enough block, not checked for reorgs
+        )
+        stale_block = ethereum_tx.block
+        self.assertNotEqual(
+            HexBytes(stale_block.block_hash), HexBytes(log_receipt["blockHash"])
+        )
+
+        with self.assertRaises(EthereumBlock.DoesNotExist):
+            self.erc20_events_indexer.process_elements(log_receipt_mock)
+
+        # Events were not marked as processed, so they will be retried
+        self.assertEqual(
+            len(
+                self.erc20_events_indexer._filter_not_processed_log_receipts(
+                    log_receipt_mock
+                )
+            ),
+            1,
+        )
+
+        # The stale block must be flagged, so `check_reorgs_task` can
+        # detect the reorg, delete the block (cascading to the tx) and
+        # trigger reindexing
+        stale_block.refresh_from_db()
+        self.assertFalse(stale_block.confirmed)
 
     def test_events_to_transfer_annotates_safe_membership(self):
         indexer = self.erc20_events_indexer


### PR DESCRIPTION
## Problem

Staging mainnet erc20 indexer got stuck retrying the same block range for 13+ hours (since 2026-07-22 21:40 UTC):

```
Block with hash=0x0ac0ea5e... does not exist on database
Task index_erc20_events_task raised unexpected: DoesNotExist('EthereumBlock matching query does not exist.')
```

A reorg moved an already-indexed tx to a new block. The RPC (eRPC) kept serving the stale block as valid for block-by-number queries (finalized-cache poisoning, see PLA-1782), so `check_reorgs_task` saw the stale DB block matching the chain, marked it confirmed and never re-validated it.

The last-resort recovery in the transfer builders (`TokenTransfer._prepare_parameters_from_decoded_event` / `SafeRelevantTransaction.from_erc20_721_event`) does handle this: flag the stale block as not confirmed and raise, so `check_reorgs_task` deletes it (cascading to the tx) and reindexes. But the flag was rolled back together with the database transaction wrapping the erc20 inserts (added in #2938), so the reorg was never detected and the range was retried forever.

## Fix

- Remove the database transaction around the erc20/721 inserts, so the not-confirmed flag commits when the builders raise. `ignore_conflicts` makes retrying the range idempotent, so atomicity is not needed.
- Reorder the inserts: `SafeRelevantTransaction` first, then `ERC20Transfer`, then `ERC721Transfer`. This keeps the guarantee #2938 introduced: transfer events (sent by the `post_bulk_create` receivers when each bulk create commits) always find the `SafeRelevantTransaction` rows already visible. `SafeRelevantTransaction` publishes no events, so storing it first has no visibility requirement of its own.
- This also keeps the address cache reload (millions of rows) out of an open database transaction, reducing exposure to `idle-in-transaction` timeouts and deadlocks seen on Polygon staging.

## Test

`test_process_elements_reorged_block_is_flagged_not_confirmed` reproduces the wedge: tx in database under a stale confirmed block, event referencing a block hash missing from database. Asserts processing raises, events are not marked as processed (range is retried) and the stale block ends as not confirmed. Verified failing before the fix (flag rolled back) and passing after.

Also clears the `get_timestamp_by_hash` lru_cache in `setUp`, as it lives on the manager and leaks block timestamps across tests.

Linear: PLA-1782