### PR TITLE
Remove deprecated failed string field from EXECUTED_MULTISIG_TRANSACTION event

### DIFF
--- a/safe_transaction_service/history/services/event_service.py
+++ b/safe_transaction_service/history/services/event_service.py
@@ -3,7 +3,6 @@
 Build event payloads for the queue
 """
 
-import json
 from datetime import timedelta
 from logging import getLogger
 from typing import Any, Literal, TypedDict
@@ -161,8 +160,6 @@ def build_event_payload(
             payload["type"] = (
                 TransactionServiceEventType.EXECUTED_MULTISIG_TRANSACTION.name
             )
-            # Deprecated: stringified boolean kept for legacy clients, use `isFailed` instead
-            payload["failed"] = json.dumps(instance.failed)
             payload["isFailed"] = instance.failed
             payload["txHash"] = to_0x_hex_str(HexBytes(instance.ethereum_tx_id))
         else:

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -376,7 +376,6 @@ class TestSignals(SafeTestCaseMixin, TestCase):
             "data": (
                 to_0x_hex_str(HexBytes(multisig_tx.data)) if multisig_tx.data else None
             ),
-            "failed": "false",
             "isFailed": False,
             "txHash": multisig_tx.ethereum_tx_id,
             "chainId": str(EthereumNetwork.GANACHE.value),


### PR DESCRIPTION
## What

Remove the deprecated stringified `failed` field from the `EXECUTED_MULTISIG_TRANSACTION` webhook event payload. Only the boolean `isFailed` field remains.

## Why

`isFailed` was added in #2907 alongside `failed` to give clients a migration window. The `failed` string existed only because Firebase required string values ("true"/"false"), and Firebase is no longer used. The deprecation window is over, so the string field is now removed.

## Changes

- Drop `payload["failed"]` (the `json.dumps(...)` stringified boolean) from `build_event_payload`. Removed the now-unused `import json`.
- Update `test_signals.py` to stop asserting `failed`.

The model-level `MultisigTransaction.failed` field and its API/admin/filter usages are untouched — this only affects the event payload.

Docs in safe-events-service are aligned in a separate PR.

Refs PLA-1787
