### PR TITLE
Return HTTP 451 for banned Safes

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -789,6 +789,10 @@ SPECTACULAR_SETTINGS = {
     "SORT_OPERATION_PARAMETERS": False,
 }
 
+BANNED_SAFES_CACHE_TTL = env.int(
+    "BANNED_SAFES_CACHE_TTL", default=60 * 5
+)  # Seconds the in-memory set of banned Safe addresses is cached for (default 5m)
+
 # Addresses not allowed to interact with the service
 # List taken from https://www.ic3.gov/PSA/2025/PSA250226
 BANNED_EOAS: set[ChecksumAddress] = {

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -361,7 +361,7 @@ REST_FRAMEWORK = {
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
     "ALLOWED_VERSIONS": ["v1", "v2"],
     "EXCEPTION_HANDLER": "safe_transaction_service.history.exceptions.custom_exception_handler",
-    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_SCHEMA_CLASS": "safe_transaction_service.utils.swagger.SafeAutoSchema",
 }
 
 # CUSTOM LOGGERS LEVEL

--- a/safe_transaction_service/account_abstraction/tests/test_views.py
+++ b/safe_transaction_service/account_abstraction/tests/test_views.py
@@ -31,6 +31,7 @@ from safe_eth.safe.safe_signature import SafeSignatureEOA, SafeSignatureType
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 from safe_eth.util.util import to_0x_hex_str
 
+from safe_transaction_service.history.tests.factories import SafeContractFactory
 from safe_transaction_service.utils.utils import datetime_to_str
 
 from .. import models
@@ -1018,3 +1019,52 @@ class TestAccountAbstractionViews(SafeTestCaseMixin, APITestCase):
             response.json(),
             {"count": 1, "next": None, "previous": None, "results": [expected]},
         )
+
+
+class TestBannedSafeViews(SafeTestCaseMixin, APITestCase):
+    """
+    Isolates the behavior for banned Safes (``SafeContract.banned``), which
+    must return HTTP 451 Unavailable For Legal Reasons on every Safe-scoped
+    endpoint
+    """
+
+    banned_response = {"detail": "Safe is unavailable for legal reasons"}
+
+    def test_banned_safe_operations_view(self):
+        safe_contract = SafeContractFactory()
+        response = self.client.get(
+            reverse(
+                "v1:account_abstraction:safe-operations", args=(safe_contract.address,)
+            )
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        banned_safe_contract = SafeContractFactory(banned=True)
+        url = reverse(
+            "v1:account_abstraction:safe-operations",
+            args=(banned_safe_contract.address,),
+        )
+        response = self.client.get(url)
+        self.assertEqual(
+            response.status_code, status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+        )
+        self.assertEqual(response.json(), self.banned_response)
+
+        response = self.client.post(url, format="json", data={})
+        self.assertEqual(
+            response.status_code, status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+        )
+        self.assertEqual(response.json(), self.banned_response)
+
+    def test_banned_user_operations_view(self):
+        banned_safe_contract = SafeContractFactory(banned=True)
+        response = self.client.get(
+            reverse(
+                "v1:account_abstraction:user-operations",
+                args=(banned_safe_contract.address,),
+            )
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+        )
+        self.assertEqual(response.json(), self.banned_response)

--- a/safe_transaction_service/account_abstraction/views.py
+++ b/safe_transaction_service/account_abstraction/views.py
@@ -7,6 +7,8 @@ from rest_framework.generics import ListAPIView, ListCreateAPIView, RetrieveAPIV
 from rest_framework.response import Response
 from safe_eth.eth.utils import fast_is_checksum_address
 
+from safe_transaction_service.utils.views.mixins import BannedSafeMixin
+
 from . import filters, pagination, serializers
 from .models import SafeOperation, SafeOperationConfirmation, UserOperation
 
@@ -25,7 +27,7 @@ class SafeOperationView(RetrieveAPIView):
     serializer_class = serializers.SafeOperationWithUserOperationResponseSerializer
 
 
-class SafeOperationsView(ListCreateAPIView):
+class SafeOperationsView(BannedSafeMixin, ListCreateAPIView):
     filter_backends = [
         django_filters.rest_framework.DjangoFilterBackend,
         OrderingFilter,
@@ -165,7 +167,7 @@ class UserOperationView(RetrieveAPIView):
     serializer_class = serializers.UserOperationWithSafeOperationResponseSerializer
 
 
-class UserOperationsView(ListAPIView):
+class UserOperationsView(BannedSafeMixin, ListAPIView):
     filter_backends = [
         django_filters.rest_framework.DjangoFilterBackend,
         OrderingFilter,

--- a/safe_transaction_service/history/exceptions.py
+++ b/safe_transaction_service/history/exceptions.py
@@ -69,6 +69,12 @@ class InternalValidationError(APIException):
     default_code = "internal_validation_error"
 
 
+class BannedSafeException(APIException):
+    status_code = status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+    default_detail = "Safe is unavailable for legal reasons"
+    default_code = "unavailable_for_legal_reasons"
+
+
 class SafeServiceException(Exception):
     pass
 

--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -469,9 +469,7 @@ class SafeTxProcessor(TxProcessor):
             internal_tx_decoded.internal_tx._from
             for internal_tx_decoded in internal_txs_decoded
         }
-        banned_addresses = set(
-            SafeContract.objects.get_banned_addresses(addresses=contract_addresses)
-        )
+        banned_addresses = SafeContract.objects.get_banned_addresses_cached()
 
         try:
             for internal_tx_decoded in internal_txs_decoded:

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -2402,12 +2402,11 @@ class SafeLastStatusManager(models.Manager):
     def addresses_for_module(self, module_address: str) -> QuerySet[str]:
         """
         :param module_address:
-        :return: Safes where the provided `module_address` is enabled
+        :return: Safes where the provided `module_address` is enabled.
+            Banned Safes are excluded
         """
 
-        return self.filter(enabled_modules__contains=[module_address]).values_list(
-            "address", flat=True
-        )
+        return self.safes_for_module(module_address).values_list("address", flat=True)
 
     def addresses_for_owner(self, owner_address: str) -> QuerySet[str]:
         """
@@ -2425,15 +2424,18 @@ class SafeLastStatusManager(models.Manager):
             Banned Safes are excluded
         """
         return self.filter(owners__contains=[owner_address]).exclude(
-            address__in=SafeContract.objects.banned().values("address")
+            address__in=SafeContract.objects.get_banned_addresses()
         )
 
     def safes_for_module(self, module_address: str) -> QuerySet["SafeLastStatus"]:
         """
         :param module_address:
-        :return: SafeLastStatus queryset where the provided `module_address` is enabled
+        :return: SafeLastStatus queryset where the provided `module_address` is enabled.
+            Banned Safes are excluded
         """
-        return self.filter(enabled_modules__contains=[module_address])
+        return self.filter(enabled_modules__contains=[module_address]).exclude(
+            address__in=SafeContract.objects.get_banned_addresses()
+        )
 
 
 class SafeLastStatus(SafeStatusBase):

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 import datetime
 import json
+import operator
 from collections.abc import Iterator, Sequence
 from decimal import Decimal
 from enum import Enum
 from functools import cache, lru_cache
 from itertools import islice
 from logging import getLogger
+from threading import Condition, Lock
 from typing import (
     Any,
     Optional,
@@ -46,6 +48,7 @@ from django.db.models.signals import Signal
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from cachetools import TTLCache, cachedmethod
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
 from model_utils.models import TimeStampedModel
@@ -2027,10 +2030,34 @@ class SafeMasterCopy(MonitoredAddress):
 
 
 class SafeContractManager(models.Manager):
+    # Shared by every manager instance, like the model table it caches.
+    # The condition prevents a stampede of concurrent queries refilling the cache
+    _banned_addresses_cache: TTLCache = TTLCache(
+        maxsize=1, ttl=settings.BANNED_SAFES_CACHE_TTL
+    )
+    _banned_addresses_lock = Lock()
+    _banned_addresses_condition = Condition(_banned_addresses_lock)
+
     def get_banned_addresses(
         self, addresses: list[ChecksumAddress] | None = None
     ) -> QuerySet[ChecksumAddress]:
         return self.banned(addresses=addresses).values_list("address", flat=True)
+
+    @cachedmethod(
+        cache=operator.attrgetter("_banned_addresses_cache"),
+        lock=operator.attrgetter("_banned_addresses_lock"),
+        condition=operator.attrgetter("_banned_addresses_condition"),
+    )
+    def get_banned_addresses_cached(self) -> frozenset[ChecksumAddress]:
+        """
+        :return: Set with the addresses of every banned Safe. Cached in memory
+            for ``BANNED_SAFES_CACHE_TTL`` seconds.
+        """
+        return frozenset(self.get_banned_addresses())
+
+    def clear_banned_addresses_cache(self) -> None:
+        with self._banned_addresses_lock:
+            self._banned_addresses_cache.clear()
 
     def get_minimum_creation_block_number(
         self, addresses: list[ChecksumAddress]
@@ -2385,19 +2412,21 @@ class SafeLastStatusManager(models.Manager):
     def addresses_for_owner(self, owner_address: str) -> QuerySet[str]:
         """
         :param owner_address:
-        :return: Safes where the provided `owner_address` is an owner
+        :return: Safes where the provided `owner_address` is an owner.
+            Banned Safes are excluded
         """
 
-        return self.filter(owners__contains=[owner_address]).values_list(
-            "address", flat=True
-        )
+        return self.safes_for_owner(owner_address).values_list("address", flat=True)
 
     def safes_for_owner(self, owner_address: str) -> QuerySet["SafeLastStatus"]:
         """
         :param owner_address:
-        :return: SafeLastStatus queryset where the provided `owner_address` is an owner
+        :return: SafeLastStatus queryset where the provided `owner_address` is an owner.
+            Banned Safes are excluded
         """
-        return self.filter(owners__contains=[owner_address])
+        return self.filter(owners__contains=[owner_address]).exclude(
+            address__in=SafeContract.objects.banned().values("address")
+        )
 
     def safes_for_module(self, module_address: str) -> QuerySet["SafeLastStatus"]:
         """

--- a/safe_transaction_service/history/services/event_service.py
+++ b/safe_transaction_service/history/services/event_service.py
@@ -264,6 +264,27 @@ def build_event_payload(
     return payloads
 
 
+def filter_banned_payloads(payloads: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Exclude event payloads addressed to a banned Safe (``SafeContract.banned``),
+    so no events are emitted for them. Payloads without an ``address`` (e.g.
+    global delegates) are kept.
+
+    :param payloads:
+    :return: Payloads not addressed to a banned Safe
+    """
+    if not payloads:
+        return payloads
+    banned_addresses = SafeContract.objects.get_banned_addresses_cached()
+    if not banned_addresses:
+        return payloads
+    return [
+        payload
+        for payload in payloads
+        if payload.get("address") not in banned_addresses
+    ]
+
+
 def is_relevant_event(
     sender: type[Model],
     instance: TokenTransfer | InternalTx | MultisigConfirmation | MultisigTransaction,

--- a/safe_transaction_service/history/signals.py
+++ b/safe_transaction_service/history/signals.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 
 from logging import getLogger
+from typing import Any
 
 from django.conf import settings
+from django.db import transaction
 from django.db.models import Model
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
@@ -29,6 +31,7 @@ from .services.event_service import (
     build_delete_delegate_payload,
     build_event_payload,
     build_save_delegate_payload,
+    filter_banned_payloads,
     is_relevant_event,
 )
 
@@ -121,6 +124,51 @@ def safe_master_copy_clear_cache(
     SafeMasterCopy.objects.get_version_for_address.cache_clear()
 
 
+@receiver(
+    post_save,
+    sender=SafeContract,
+    dispatch_uid="safe_contract.clear_banned_addresses_cache",
+)
+@receiver(
+    post_delete,
+    sender=SafeContract,
+    dispatch_uid="safe_contract.clear_banned_addresses_cache",
+)
+def safe_contract_clear_banned_addresses_cache(
+    sender: type[Model],
+    instance: SafeContract,
+    **kwargs,
+) -> None:
+    """
+    Clear the in-memory banned Safes cache when a `SafeContract` changes.
+    Cleared right away so the change is visible in this process, and again on
+    transaction commit because a concurrent request could refill the cache
+    from the not-yet-committed database snapshot. Other processes refresh
+    when the cache TTL expires
+
+    :param sender:
+    :param instance:
+    :param kwargs:
+    :return:
+    """
+    SafeContract.objects.clear_banned_addresses_cache()
+    transaction.on_commit(SafeContract.objects.clear_banned_addresses_cache)
+
+
+def send_payloads_on_commit(payloads: list[dict[str, Any]]) -> None:
+    """
+    Publish the payloads when the current database transaction commits,
+    excluding payloads addressed to a banned Safe. Payloads without an
+    ``address`` are kept (e.g. delegate events not tied to a Safe). Every
+    event producer must publish through here so banned Safes never leak
+
+    :param payloads:
+    :return:
+    """
+    if payloads_to_send := filter_banned_payloads(payloads):
+        get_queue_service().send_events_on_commit(payloads_to_send)
+
+
 def _process_event(
     sender: type[Model],
     instance: TokenTransfer
@@ -172,10 +220,7 @@ def _process_event(
     logger.debug(
         "End building payloads %s for created=%s object=%s", payloads, created, instance
     )
-    payloads_to_send = [payload for payload in payloads if payload.get("address")]
-    if not payloads_to_send:
-        return None
-    get_queue_service().send_events_on_commit(payloads_to_send)
+    send_payloads_on_commit([payload for payload in payloads if payload.get("address")])
 
 
 # `dispatch_uid` uniqueness is per signal, so the same uid can be shared by
@@ -281,7 +326,7 @@ def process_save_delegate_user_event(
     **kwargs,
 ):
     payload_event = build_save_delegate_payload(instance, created)
-    get_queue_service().send_events_on_commit([payload_event])
+    send_payloads_on_commit([payload_event])
 
 
 @receiver(
@@ -293,4 +338,4 @@ def process_delete_delegate_user_event(
     sender: type[Model], instance: SafeContractDelegate, *args, **kwargs
 ):
     payload_event = build_delete_delegate_payload(instance)
-    get_queue_service().send_events_on_commit([payload_event])
+    send_payloads_on_commit([payload_event])

--- a/safe_transaction_service/history/signals.py
+++ b/safe_transaction_service/history/signals.py
@@ -158,15 +158,27 @@ def safe_contract_clear_banned_addresses_cache(
 def send_payloads_on_commit(payloads: list[dict[str, Any]]) -> None:
     """
     Publish the payloads when the current database transaction commits,
-    excluding payloads addressed to a banned Safe. Payloads without an
+    excluding payloads addressed to a banned Safe. The banned check runs at
+    commit time using the cached banned set, so a Safe banned inside the open
+    transaction is enforced in this process and bans propagate to other
+    processes within ``BANNED_SAFES_CACHE_TTL`` at worst. Payloads without an
     ``address`` are kept (e.g. delegate events not tied to a Safe). Every
-    event producer must publish through here so banned Safes never leak
+    event producer must publish through here
 
     :param payloads:
     :return:
     """
-    if payloads_to_send := filter_banned_payloads(payloads):
-        get_queue_service().send_events_on_commit(payloads_to_send)
+    if not payloads:
+        return None
+
+    def filter_and_send() -> None:
+        if payloads_to_send := filter_banned_payloads(payloads):
+            # Outside of the transaction already, so events are sent right away
+            get_queue_service().send_events_on_commit(payloads_to_send)
+
+    # `robust=True` so an unexpected failure here cannot prevent sibling
+    # `on_commit` callbacks, mirroring `send_events_on_commit`
+    transaction.on_commit(filter_and_send, robust=True)
 
 
 def _process_event(

--- a/safe_transaction_service/history/signals.py
+++ b/safe_transaction_service/history/signals.py
@@ -4,7 +4,6 @@ from logging import getLogger
 from typing import Any
 
 from django.conf import settings
-from django.db import transaction
 from django.db.models import Model
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
@@ -124,61 +123,19 @@ def safe_master_copy_clear_cache(
     SafeMasterCopy.objects.get_version_for_address.cache_clear()
 
 
-@receiver(
-    post_save,
-    sender=SafeContract,
-    dispatch_uid="safe_contract.clear_banned_addresses_cache",
-)
-@receiver(
-    post_delete,
-    sender=SafeContract,
-    dispatch_uid="safe_contract.clear_banned_addresses_cache",
-)
-def safe_contract_clear_banned_addresses_cache(
-    sender: type[Model],
-    instance: SafeContract,
-    **kwargs,
-) -> None:
-    """
-    Clear the in-memory banned Safes cache when a `SafeContract` changes.
-    Cleared right away so the change is visible in this process, and again on
-    transaction commit because a concurrent request could refill the cache
-    from the not-yet-committed database snapshot. Other processes refresh
-    when the cache TTL expires
-
-    :param sender:
-    :param instance:
-    :param kwargs:
-    :return:
-    """
-    SafeContract.objects.clear_banned_addresses_cache()
-    transaction.on_commit(SafeContract.objects.clear_banned_addresses_cache)
-
-
 def send_payloads_on_commit(payloads: list[dict[str, Any]]) -> None:
     """
     Publish the payloads when the current database transaction commits,
-    excluding payloads addressed to a banned Safe. The banned check runs at
-    commit time using the cached banned set, so a Safe banned inside the open
-    transaction is enforced in this process and bans propagate to other
-    processes within ``BANNED_SAFES_CACHE_TTL`` at worst. Payloads without an
-    ``address`` are kept (e.g. delegate events not tied to a Safe). Every
-    event producer must publish through here
+    excluding payloads addressed to a banned Safe. The banned set is cached
+    in memory, so bans propagate within ``BANNED_SAFES_CACHE_TTL``. Payloads
+    without an ``address`` are kept (e.g. delegate events not tied to a
+    Safe). Every event producer must publish through here
 
     :param payloads:
     :return:
     """
-    if not payloads:
-        return None
-
-    def filter_and_send() -> None:
-        if payloads_to_send := filter_banned_payloads(payloads):
-            # Outside of the transaction already, so events are sent right away
-            get_queue_service().send_events_on_commit(payloads_to_send)
-
-    # `robust=True` so an unexpected failure here cannot prevent sibling
-    # `on_commit` callbacks, mirroring `send_events_on_commit`
-    transaction.on_commit(filter_and_send, robust=True)
+    if payloads_to_send := filter_banned_payloads(payloads):
+        get_queue_service().send_events_on_commit(payloads_to_send)
 
 
 def _process_event(

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -1834,14 +1834,19 @@ class TestBannedSafeContractManager(TestCase):
             SafeContract.objects.get_banned_addresses_cached(), frozenset()
         )
 
-        # Saving a SafeContract clears the cache in the same process
+        # Banning a Safe is not visible until the cache expires or is cleared
         banned_safe_contract = SafeContractFactory(banned=True)
+        self.assertEqual(
+            SafeContract.objects.get_banned_addresses_cached(), frozenset()
+        )
+
+        SafeContract.objects.clear_banned_addresses_cache()
         self.assertEqual(
             SafeContract.objects.get_banned_addresses_cached(),
             frozenset([banned_safe_contract.address]),
         )
 
-        # `update` does not fire signals, so the previous value is still cached
+        # Same for unbanning
         SafeContract.objects.filter(pk=banned_safe_contract.address).update(
             banned=False
         )

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -1822,3 +1822,35 @@ class TestMultisigTransactions(TestCase):
             MultisigTransaction.objects.last_valid_transaction(safe_address),
             multisig_transaction_2,
         )
+
+
+class TestBannedSafeContractManager(TestCase):
+    def setUp(self):
+        SafeContract.objects.clear_banned_addresses_cache()
+        self.addCleanup(SafeContract.objects.clear_banned_addresses_cache)
+
+    def test_get_banned_addresses_cached(self):
+        self.assertEqual(
+            SafeContract.objects.get_banned_addresses_cached(), frozenset()
+        )
+
+        # Saving a SafeContract clears the cache in the same process
+        banned_safe_contract = SafeContractFactory(banned=True)
+        self.assertEqual(
+            SafeContract.objects.get_banned_addresses_cached(),
+            frozenset([banned_safe_contract.address]),
+        )
+
+        # `update` does not fire signals, so the previous value is still cached
+        SafeContract.objects.filter(pk=banned_safe_contract.address).update(
+            banned=False
+        )
+        self.assertEqual(
+            SafeContract.objects.get_banned_addresses_cached(),
+            frozenset([banned_safe_contract.address]),
+        )
+
+        SafeContract.objects.clear_banned_addresses_cache()
+        self.assertEqual(
+            SafeContract.objects.get_banned_addresses_cached(), frozenset()
+        )

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -653,6 +653,17 @@ class TestBannedSafeEvents(SafeTestCaseMixin, TestCase):
         send_events_mock.assert_not_called()
 
     @mock.patch.object(QueueService, "send_events")
+    def test_events_not_sent_for_safe_banned_before_commit(
+        self, send_events_mock: MagicMock
+    ):
+        # The Safe is banned after the event is scheduled but before the
+        # transaction commits: the ban must still be enforced
+        with self.captureOnCommitCallbacks(execute=True):
+            multisig_tx = MultisigTransactionFactory(trusted=True)
+            SafeContractFactory(address=multisig_tx.safe, banned=True)
+        send_events_mock.assert_not_called()
+
+    @mock.patch.object(QueueService, "send_events")
     def test_message_events_not_sent_for_banned_safe(self, send_events_mock: MagicMock):
         safe_address = self.deploy_test_safe().address
         SafeContractFactory(address=safe_address, banned=True)

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -33,10 +33,11 @@ from ..models import (
     ModuleTransaction,
     MultisigConfirmation,
     MultisigTransaction,
+    SafeContract,
     TransactionServiceEventType,
     post_bulk_create,
 )
-from ..services.event_service import set_safe_membership
+from ..services.event_service import filter_banned_payloads, set_safe_membership
 from ..signals import (
     _process_event,
     build_event_payload,
@@ -612,3 +613,64 @@ class TestSignals(SafeTestCaseMixin, TestCase):
                 TransactionServiceEventType.OUTGOING_TOKEN.name,
             ],
         )
+
+
+class TestBannedSafeEvents(SafeTestCaseMixin, TestCase):
+    """
+    Isolates the behavior for banned Safes (``SafeContract.banned``): no
+    events must be emitted for them
+    """
+
+    def setUp(self):
+        super().setUp()
+        SafeContract.objects.clear_banned_addresses_cache()
+        self.addCleanup(SafeContract.objects.clear_banned_addresses_cache)
+
+    def test_filter_banned_payloads(self):
+        banned_safe_contract = SafeContractFactory(banned=True)
+        safe_contract = SafeContractFactory()
+        no_address_payload = {"type": "NEW_DELEGATE", "address": None}
+        payloads = [
+            {"address": banned_safe_contract.address},
+            {"address": safe_contract.address},
+            no_address_payload,
+        ]
+        self.assertEqual(
+            filter_banned_payloads(payloads),
+            [{"address": safe_contract.address}, no_address_payload],
+        )
+
+    @mock.patch.object(QueueService, "send_events")
+    def test_events_not_sent_for_banned_safe(self, send_events_mock: MagicMock):
+        with self.captureOnCommitCallbacks(execute=True):
+            multisig_tx = MultisigTransactionFactory(trusted=True)
+        send_events_mock.assert_called()
+
+        send_events_mock.reset_mock()
+        SafeContractFactory(address=multisig_tx.safe, banned=True)
+        with self.captureOnCommitCallbacks(execute=True):
+            MultisigTransactionFactory(safe=multisig_tx.safe, trusted=True)
+        send_events_mock.assert_not_called()
+
+    @mock.patch.object(QueueService, "send_events")
+    def test_message_events_not_sent_for_banned_safe(self, send_events_mock: MagicMock):
+        safe_address = self.deploy_test_safe().address
+        SafeContractFactory(address=safe_address, banned=True)
+        with self.captureOnCommitCallbacks(execute=True):
+            SafeMessageFactory(safe=safe_address)
+        send_events_mock.assert_not_called()
+
+    @mock.patch.object(QueueService, "send_events")
+    def test_delegate_events_not_sent_for_banned_safe(
+        self, send_events_mock: MagicMock
+    ):
+        banned_safe_contract = SafeContractFactory(banned=True)
+        with self.captureOnCommitCallbacks(execute=True):
+            safe_contract_delegate = SafeContractDelegateFactory(
+                safe_contract=banned_safe_contract
+            )
+        send_events_mock.assert_not_called()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            safe_contract_delegate.delete()
+        send_events_mock.assert_not_called()

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -648,19 +648,10 @@ class TestBannedSafeEvents(SafeTestCaseMixin, TestCase):
 
         send_events_mock.reset_mock()
         SafeContractFactory(address=multisig_tx.safe, banned=True)
+        # Bans only propagate when the cached banned set expires or is cleared
+        SafeContract.objects.clear_banned_addresses_cache()
         with self.captureOnCommitCallbacks(execute=True):
             MultisigTransactionFactory(safe=multisig_tx.safe, trusted=True)
-        send_events_mock.assert_not_called()
-
-    @mock.patch.object(QueueService, "send_events")
-    def test_events_not_sent_for_safe_banned_before_commit(
-        self, send_events_mock: MagicMock
-    ):
-        # The Safe is banned after the event is scheduled but before the
-        # transaction commits: the ban must still be enforced
-        with self.captureOnCommitCallbacks(execute=True):
-            multisig_tx = MultisigTransactionFactory(trusted=True)
-            SafeContractFactory(address=multisig_tx.safe, banned=True)
         send_events_mock.assert_not_called()
 
     @mock.patch.object(QueueService, "send_events")

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -315,6 +315,7 @@ class TestTasks(TestCase):
             internal_tx___from=safe_address,
         )
         SafeContractFactory(address=safe_address, banned=True)
+        SafeContract.objects.clear_banned_addresses_cache()
         self.assertTrue(SafeContract.objects.get(address=safe_address).banned)
         self.assertFalse(internal_tx_decoded.processed)
         process_decoded_internal_txs_task.delay()

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -5364,3 +5364,119 @@ class TestViewsV111(TestViewsV150):
         :return: Deploy last available Safe
         """
         return self.deploy_test_safe_v1_1_1(*args, **kwargs)
+
+
+class TestBannedSafeViews(SafeTestCaseMixin, APITestCase):
+    """
+    Isolates the behavior for banned Safes (``SafeContract.banned``), which
+    must return HTTP 451 Unavailable For Legal Reasons on every Safe-scoped
+    endpoint and be excluded from the owners endpoints
+    """
+
+    banned_response = {"detail": "Safe is unavailable for legal reasons"}
+
+    def test_get_safe_info_banned(self):
+        safe_contract = SafeContractFactory()
+        response = self.client.get(
+            reverse("v1:history:safe-info", args=(safe_contract.address,))
+        )
+        self.assertNotEqual(
+            response.status_code, status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+        )
+
+        banned_safe_contract = SafeContractFactory(banned=True)
+        response = self.client.get(
+            reverse("v1:history:safe-info", args=(banned_safe_contract.address,))
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+        )
+        self.assertEqual(response.json(), self.banned_response)
+
+    def test_get_multisig_transactions_banned(self):
+        safe_contract = SafeContractFactory()
+        response = self.client.get(
+            reverse("v1:history:multisig-transactions", args=(safe_contract.address,))
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        banned_safe_contract = SafeContractFactory(banned=True)
+        url = reverse(
+            "v1:history:multisig-transactions", args=(banned_safe_contract.address,)
+        )
+        response = self.client.get(url)
+        self.assertEqual(
+            response.status_code, status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+        )
+        self.assertEqual(response.json(), self.banned_response)
+
+    def test_post_multisig_transactions_banned(self):
+        banned_safe_contract = SafeContractFactory(banned=True)
+        response = self.client.post(
+            reverse(
+                "v1:history:multisig-transactions",
+                args=(banned_safe_contract.address,),
+            ),
+            format="json",
+            data={},
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+        )
+        self.assertEqual(response.json(), self.banned_response)
+
+    def test_banned_safe_views(self):
+        banned_safe_contract = SafeContractFactory(banned=True)
+        get_url_names = (
+            "v1:history:all-transactions",
+            "v1:history:incoming-transfers",
+            "v1:history:transfers",
+            "v1:history:module-transactions",
+            "v1:history:safe-creation",
+            "v1:history:safe-balances",
+            "v1:history:safe-export",
+        )
+        for url_name in get_url_names:
+            with self.subTest(url_name=url_name):
+                response = self.client.get(
+                    reverse(url_name, args=(banned_safe_contract.address,))
+                )
+                self.assertEqual(
+                    response.status_code,
+                    status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS,
+                )
+                self.assertEqual(response.json(), self.banned_response)
+
+        response = self.client.post(
+            reverse(
+                "v1:history:multisig-transaction-estimate",
+                args=(banned_safe_contract.address,),
+            ),
+            format="json",
+            data={},
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+        )
+
+        response = self.client.delete(
+            reverse(
+                "v1:history:safe-delegate",
+                args=(banned_safe_contract.address, Account.create().address),
+            )
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+        )
+
+    def test_owners_view_excludes_banned(self):
+        owner_address = Account.create().address
+        safe_last_status = SafeLastStatusFactory(owners=[owner_address])
+        banned_safe_last_status = SafeLastStatusFactory(owners=[owner_address])
+        SafeContractFactory(address=banned_safe_last_status.address, banned=True)
+
+        response = self.client.get(
+            reverse("v1:history:owners", args=(owner_address,)), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["safes"], [safe_last_status.address])

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -5480,3 +5480,17 @@ class TestBannedSafeViews(SafeTestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["safes"], [safe_last_status.address])
+
+    def test_modules_view_excludes_banned(self):
+        module_address = Account.create().address
+        safe_last_status = SafeLastStatusFactory(enabled_modules=[module_address])
+        banned_safe_last_status = SafeLastStatusFactory(
+            enabled_modules=[module_address]
+        )
+        SafeContractFactory(address=banned_safe_last_status.address, banned=True)
+
+        response = self.client.get(
+            reverse("v1:history:modules", args=(module_address,)), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["safes"], [safe_last_status.address])

--- a/safe_transaction_service/history/tests/test_views_v2.py
+++ b/safe_transaction_service/history/tests/test_views_v2.py
@@ -3003,3 +3003,20 @@ class TestBannedSafeViews(SafeTestCaseMixin, APITestCase):
         self.assertEqual(
             response.data["results"][0]["address"], safe_last_status.address
         )
+
+    def test_modules_view_excludes_banned(self):
+        module_address = Account.create().address
+        safe_last_status = SafeLastStatusFactory(enabled_modules=[module_address])
+        banned_safe_last_status = SafeLastStatusFactory(
+            enabled_modules=[module_address]
+        )
+        SafeContractFactory(address=banned_safe_last_status.address, banned=True)
+
+        response = self.client.get(
+            reverse("v2:history:modules", args=(module_address,)), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["address"], safe_last_status.address
+        )

--- a/safe_transaction_service/history/tests/test_views_v2.py
+++ b/safe_transaction_service/history/tests/test_views_v2.py
@@ -2939,3 +2939,67 @@ class TestViewsV2V130(TestViewsV2V150):
         :return: Deploy last available Safe
         """
         return self.deploy_test_safe_v1_3_0(*args, **kwargs)
+
+
+class TestBannedSafeViews(SafeTestCaseMixin, APITestCase):
+    """
+    Isolates the behavior for banned Safes (``SafeContract.banned``), which
+    must return HTTP 451 Unavailable For Legal Reasons on every Safe-scoped
+    endpoint and be excluded from the owners endpoints
+    """
+
+    banned_response = {"detail": "Safe is unavailable for legal reasons"}
+
+    def test_banned_safe_views(self):
+        banned_safe_contract = SafeContractFactory(banned=True)
+        get_url_names = (
+            "v2:history:safe-collectibles",
+            "v2:history:safe-balances",
+            "v2:history:multisig-transactions",
+            "v2:history:all-transactions",
+        )
+        for url_name in get_url_names:
+            with self.subTest(url_name=url_name):
+                response = self.client.get(
+                    reverse(url_name, args=(banned_safe_contract.address,))
+                )
+                self.assertEqual(
+                    response.status_code,
+                    status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS,
+                )
+                self.assertEqual(response.json(), self.banned_response)
+
+        response = self.client.post(
+            reverse(
+                "v2:history:multisig-transactions",
+                args=(banned_safe_contract.address,),
+            ),
+            format="json",
+            data={},
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+        )
+        self.assertEqual(response.json(), self.banned_response)
+
+    def test_get_multisig_transactions_not_banned(self):
+        safe_contract = SafeContractFactory()
+        response = self.client.get(
+            reverse("v2:history:multisig-transactions", args=(safe_contract.address,))
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_owners_view_excludes_banned(self):
+        owner_address = Account.create().address
+        safe_last_status = SafeLastStatusFactory(owners=[owner_address])
+        banned_safe_last_status = SafeLastStatusFactory(owners=[owner_address])
+        SafeContractFactory(address=banned_safe_last_status.address, banned=True)
+
+        response = self.client.get(
+            reverse("v2:history:owners", args=(owner_address,)), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["address"], safe_last_status.address
+        )

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -38,6 +38,7 @@ from safe_eth.safe.safe_deployments import safe_deployments
 from safe_transaction_service import __version__
 from safe_transaction_service.utils.ethereum import get_chain_id
 from safe_transaction_service.utils.utils import parse_boolean_query_param
+from safe_transaction_service.utils.views.mixins import BannedSafeMixin
 
 from ..loggers.custom_logger import http_request_log
 from . import filters, pagination, serializers
@@ -275,7 +276,7 @@ class SafeDeploymentsView(ListAPIView):
     },
 )
 @extend_schema(deprecated=True)
-class AllTransactionsListView(ListAPIView):
+class AllTransactionsListView(BannedSafeMixin, ListAPIView):
     filter_backends = (
         django_filters.rest_framework.DjangoFilterBackend,
         OrderingFilter,
@@ -470,7 +471,7 @@ class SafeModuleTransactionView(RetrieveAPIView):
         ),
     },
 )
-class SafeModuleTransactionListView(ListAPIView):
+class SafeModuleTransactionListView(BannedSafeMixin, ListAPIView):
     filter_backends = (
         django_filters.rest_framework.DjangoFilterBackend,
         OrderingFilter,
@@ -643,7 +644,7 @@ class SafeMultisigTransactionDetailView(RetrieveAPIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class SafeMultisigTransactionListView(ListAPIView):
+class SafeMultisigTransactionListView(BannedSafeMixin, ListAPIView):
     filter_backends = (
         django_filters.rest_framework.DjangoFilterBackend,
         OrderingFilter,
@@ -698,6 +699,9 @@ class SafeMultisigTransactionListView(ListAPIView):
                 response=serializers.CodeErrorResponse,
                 description="Invalid ethereum address",
             ),
+            451: OpenApiResponse(
+                description="Safe is unavailable for legal reasons (banned)"
+            ),
         },
     )
     @cache_txs_view_for_address(
@@ -736,6 +740,9 @@ class SafeMultisigTransactionListView(ListAPIView):
                 response=serializers.CodeErrorResponse,
                 description="Invalid ethereum address | User is not an owner | Invalid safeTxHash |"
                 "Invalid signature | Nonce already executed | Sender is not an owner",
+            ),
+            451: OpenApiResponse(
+                description="Safe is unavailable for legal reasons (banned)"
             ),
         },
     )
@@ -794,7 +801,7 @@ def swagger_assets_parameters():
     ]
 
 
-class SafeBalanceView(GenericAPIView):
+class SafeBalanceView(BannedSafeMixin, GenericAPIView):
     serializer_class = serializers.SafeBalanceResponseSerializer
     pagination_class = None  # Don't show limit/offset in swagger
 
@@ -942,7 +949,7 @@ class TransferView(RetrieveAPIView):
         return Response(status=status.HTTP_200_OK, data=serializer.data)
 
 
-class SafeTransferListView(ListAPIView):
+class SafeTransferListView(BannedSafeMixin, ListAPIView):
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
     filterset_class = filters.TransferListFilter
     serializer_class = serializers.TransferWithTokenInfoResponseSerializer
@@ -1065,7 +1072,7 @@ class SafeIncomingTransferListView(SafeTransferListView):
         ).order_by("-execution_date")
 
 
-class SafeCreationView(GenericAPIView):
+class SafeCreationView(BannedSafeMixin, GenericAPIView):
     serializer_class = serializers.SafeCreationInfoResponseSerializer
     pagination_class = None  # Don't show limit/offset in swagger
 
@@ -1105,7 +1112,7 @@ class SafeCreationView(GenericAPIView):
         return Response(status=status.HTTP_200_OK, data=serializer.data)
 
 
-class SafeInfoView(GenericAPIView):
+class SafeInfoView(BannedSafeMixin, GenericAPIView):
     serializer_class = serializers.SafeInfoResponseSerializer
     pagination_class = None  # Don't show limit/offset in swagger
 
@@ -1115,6 +1122,9 @@ class SafeInfoView(GenericAPIView):
             404: OpenApiResponse(description="Safe not found"),
             422: OpenApiResponse(
                 description="code = 1: Checksum address validation failed\ncode = 50: Cannot get Safe info"
+            ),
+            451: OpenApiResponse(
+                description="Safe is unavailable for legal reasons (banned)"
             ),
         }
     )
@@ -1269,7 +1279,7 @@ class DataDecoderView(GenericAPIView):
                 return Response(status=status.HTTP_404_NOT_FOUND, data=data_decoded)
 
 
-class SafeMultisigTransactionEstimateView(GenericAPIView):
+class SafeMultisigTransactionEstimateView(BannedSafeMixin, GenericAPIView):
     serializer_class = serializers.SafeMultisigTransactionEstimateSerializer
     response_serializer = serializers.SafeMultisigTransactionEstimateResponseSerializer
 
@@ -1449,7 +1459,7 @@ class DelegateDeleteView(GenericAPIView):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
 
-class SafeDelegateDestroyView(DestroyAPIView):
+class SafeDelegateDestroyView(BannedSafeMixin, DestroyAPIView):
     """
 
     .. deprecated:: 4.38.0
@@ -1554,7 +1564,7 @@ class SafeDelegateDestroyView(DestroyAPIView):
         ),
     },
 )
-class SafeExportView(GenericAPIView):
+class SafeExportView(BannedSafeMixin, GenericAPIView):
     """
     Export endpoint for CSV export feature - optimized for large datasets
     """

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -699,9 +699,6 @@ class SafeMultisigTransactionListView(BannedSafeMixin, ListAPIView):
                 response=serializers.CodeErrorResponse,
                 description="Invalid ethereum address",
             ),
-            451: OpenApiResponse(
-                description="Safe is unavailable for legal reasons (banned)"
-            ),
         },
     )
     @cache_txs_view_for_address(
@@ -740,9 +737,6 @@ class SafeMultisigTransactionListView(BannedSafeMixin, ListAPIView):
                 response=serializers.CodeErrorResponse,
                 description="Invalid ethereum address | User is not an owner | Invalid safeTxHash |"
                 "Invalid signature | Nonce already executed | Sender is not an owner",
-            ),
-            451: OpenApiResponse(
-                description="Safe is unavailable for legal reasons (banned)"
             ),
         },
     )
@@ -1122,9 +1116,6 @@ class SafeInfoView(BannedSafeMixin, GenericAPIView):
             404: OpenApiResponse(description="Safe not found"),
             422: OpenApiResponse(
                 description="code = 1: Checksum address validation failed\ncode = 50: Cannot get Safe info"
-            ),
-            451: OpenApiResponse(
-                description="Safe is unavailable for legal reasons (banned)"
             ),
         }
     )

--- a/safe_transaction_service/history/views_v2.py
+++ b/safe_transaction_service/history/views_v2.py
@@ -428,9 +428,6 @@ class SafeMultisigTransactionListView(BannedSafeMixin, ListAPIView):
                 response=serializers.CodeErrorResponse,
                 description="Invalid ethereum address",
             ),
-            451: OpenApiResponse(
-                description="Safe is unavailable for legal reasons (banned)"
-            ),
         },
     )
     @cache_txs_view_for_address(
@@ -468,9 +465,6 @@ class SafeMultisigTransactionListView(BannedSafeMixin, ListAPIView):
                 response=serializers.CodeErrorResponse,
                 description="Invalid ethereum address | User is not an owner | Invalid safeTxHash |"
                 "Invalid signature | Nonce already executed | Sender is not an owner",
-            ),
-            451: OpenApiResponse(
-                description="Safe is unavailable for legal reasons (banned)"
             ),
         },
     )

--- a/safe_transaction_service/history/views_v2.py
+++ b/safe_transaction_service/history/views_v2.py
@@ -20,6 +20,7 @@ from rest_framework.response import Response
 from safe_eth.eth.utils import fast_is_checksum_address
 
 from safe_transaction_service.utils.utils import parse_boolean_query_param
+from safe_transaction_service.utils.views.mixins import BannedSafeMixin
 
 from ..loggers.custom_logger import http_request_log
 from . import filters, pagination, serializers
@@ -74,7 +75,7 @@ def swagger_pagination_parameters():
         ),
     },
 )
-class SafeCollectiblesView(GenericAPIView):
+class SafeCollectiblesView(BannedSafeMixin, GenericAPIView):
     serializer_class = serializers.SafeCollectibleResponseSerializer
 
     def get(self, request, address):
@@ -237,7 +238,7 @@ class DelegateDeleteView(GenericAPIView):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
 
-class SafeBalanceView(GenericAPIView):
+class SafeBalanceView(BannedSafeMixin, GenericAPIView):
     serializer_class = serializers.SafeBalanceResponseSerializer
 
     def get_parameters(self) -> tuple[bool, bool]:
@@ -373,7 +374,7 @@ class SafeMultisigTransactionDetailView(RetrieveAPIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class SafeMultisigTransactionListView(ListAPIView):
+class SafeMultisigTransactionListView(BannedSafeMixin, ListAPIView):
     filter_backends = (
         django_filters.rest_framework.DjangoFilterBackend,
         OrderingFilter,
@@ -427,6 +428,9 @@ class SafeMultisigTransactionListView(ListAPIView):
                 response=serializers.CodeErrorResponse,
                 description="Invalid ethereum address",
             ),
+            451: OpenApiResponse(
+                description="Safe is unavailable for legal reasons (banned)"
+            ),
         },
     )
     @cache_txs_view_for_address(
@@ -465,6 +469,9 @@ class SafeMultisigTransactionListView(ListAPIView):
                 description="Invalid ethereum address | User is not an owner | Invalid safeTxHash |"
                 "Invalid signature | Nonce already executed | Sender is not an owner",
             ),
+            451: OpenApiResponse(
+                description="Safe is unavailable for legal reasons (banned)"
+            ),
         },
     )
     def post(self, request, address, format=None):
@@ -497,7 +504,7 @@ class SafeMultisigTransactionListView(ListAPIView):
             return Response(status=status.HTTP_201_CREATED)
 
 
-class AllTransactionsListView(ListAPIView):
+class AllTransactionsListView(BannedSafeMixin, ListAPIView):
     filter_backends = (
         django_filters.rest_framework.DjangoFilterBackend,
         OrderingFilter,

--- a/safe_transaction_service/safe_messages/signals.py
+++ b/safe_transaction_service/safe_messages/signals.py
@@ -6,8 +6,8 @@ from django.db.models import Model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from safe_transaction_service.events.services.queue_service import get_queue_service
 from safe_transaction_service.history.services.event_service import build_event_payload
+from safe_transaction_service.history.signals import send_payloads_on_commit
 from safe_transaction_service.safe_messages.models import (
     SafeMessage,
     SafeMessageConfirmation,
@@ -40,7 +40,4 @@ def process_event(
     logger.debug(
         "End building payloads %s for created=%s object=%s", payloads, created, instance
     )
-    payloads_to_send = [payload for payload in payloads if payload.get("address")]
-    if not payloads_to_send:
-        return None
-    get_queue_service().send_events_on_commit(payloads_to_send)
+    send_payloads_on_commit([payload for payload in payloads if payload.get("address")])

--- a/safe_transaction_service/safe_messages/tests/test_views.py
+++ b/safe_transaction_service/safe_messages/tests/test_views.py
@@ -813,3 +813,36 @@ class TestMessageViews(SafeTestCaseMixin, APITestCase):
         self.assertEqual(record.delegate, delegate.address)
         self.assertEqual(record.delegator, safe2.address)
         self.assertEqual(record.safe_contract_id, safe3.address)
+
+
+class TestBannedSafeViews(SafeTestCaseMixin, APITestCase):
+    """
+    Isolates the behavior for banned Safes (``SafeContract.banned``), which
+    must return HTTP 451 Unavailable For Legal Reasons on every Safe-scoped
+    endpoint
+    """
+
+    banned_response = {"detail": "Safe is unavailable for legal reasons"}
+
+    def test_banned_safe_messages_view(self):
+        safe_contract = SafeContractFactory()
+        response = self.client.get(
+            reverse("v1:safe_messages:safe-messages", args=(safe_contract.address,))
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        banned_safe_contract = SafeContractFactory(banned=True)
+        url = reverse(
+            "v1:safe_messages:safe-messages", args=(banned_safe_contract.address,)
+        )
+        response = self.client.get(url)
+        self.assertEqual(
+            response.status_code, status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+        )
+        self.assertEqual(response.json(), self.banned_response)
+
+        response = self.client.post(url, format="json", data={})
+        self.assertEqual(
+            response.status_code, status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+        )
+        self.assertEqual(response.json(), self.banned_response)

--- a/safe_transaction_service/safe_messages/views.py
+++ b/safe_transaction_service/safe_messages/views.py
@@ -11,6 +11,8 @@ from rest_framework.generics import CreateAPIView, ListCreateAPIView, RetrieveAP
 from rest_framework.response import Response
 from safe_eth.eth.utils import fast_is_checksum_address
 
+from safe_transaction_service.utils.views.mixins import BannedSafeMixin
+
 from . import pagination, serializers
 from .models import SafeMessage
 
@@ -63,7 +65,7 @@ class SafeMessageSignatureView(CreateAPIView):
         return Response(status=status.HTTP_201_CREATED)
 
 
-class SafeMessagesView(ListCreateAPIView):
+class SafeMessagesView(BannedSafeMixin, ListCreateAPIView):
     filter_backends = [
         django_filters.rest_framework.DjangoFilterBackend,
         OrderingFilter,

--- a/safe_transaction_service/utils/swagger.py
+++ b/safe_transaction_service/utils/swagger.py
@@ -9,6 +9,25 @@ from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.plumbing import camelize_operation
 from drf_spectacular.settings import spectacular_settings
 
+from safe_transaction_service.utils.views.mixins import BannedSafeMixin
+
+
+class SafeAutoSchema(AutoSchema):
+    """
+    Service-wide schema customizations. Documents the HTTP 451 response on
+    every view guarded by ``BannedSafeMixin``, so the OpenAPI schema always
+    matches the behavior without documenting it on each view
+    """
+
+    def _get_response_bodies(self, direction="response"):
+        response_bodies = super()._get_response_bodies(direction)
+        if direction == "response" and isinstance(self.view, BannedSafeMixin):
+            response_bodies.setdefault(
+                "451",
+                {"description": "Safe is unavailable for legal reasons (banned)"},
+            )
+        return response_bodies
+
 
 class IgnoreVersionSchemaGenerator(SchemaGenerator):
     def get_schema(self, request=None, public=False):

--- a/safe_transaction_service/utils/tests/test_swagger.py
+++ b/safe_transaction_service/utils/tests/test_swagger.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory, TestCase
+
+from ..swagger import IgnoreVersionSchemaGenerator
+
+
+class TestSafeAutoSchema(TestCase):
+    def test_banned_safe_views_document_451(self):
+        request = RequestFactory().get("/")
+        request.user = AnonymousUser()
+        request.auth = None
+        schema = IgnoreVersionSchemaGenerator().get_schema(request=request, public=True)
+        paths = schema["paths"]
+
+        def get_operation(path: str, method: str) -> dict:
+            self.assertIn(path, paths)
+            return paths[path][method]
+
+        # Every view guarded by BannedSafeMixin documents the 451 response
+        for path, method in (
+            ("/api/v1/safes/{address}/", "get"),
+            ("/api/v1/safes/{address}/balances/", "get"),
+            ("/api/v1/safes/{address}/multisig-transactions/", "get"),
+            ("/api/v1/safes/{address}/multisig-transactions/", "post"),
+            ("/api/v1/safes/{address}/messages/", "post"),
+            ("/api/v1/safes/{address}/safe-operations/", "get"),
+            ("/api/v2/safes/{address}/collectibles/", "get"),
+        ):
+            with self.subTest(path=path, method=method):
+                self.assertIn("451", get_operation(path, method)["responses"])
+
+        # Views not guarded by the mixin don't
+        for path, method in (
+            ("/api/v1/owners/{address}/safes/", "get"),
+            ("/api/v1/modules/{address}/safes/", "get"),
+            ("/api/v1/about/", "get"),
+        ):
+            with self.subTest(path=path, method=method):
+                self.assertNotIn("451", get_operation(path, method)["responses"])

--- a/safe_transaction_service/utils/views/__init__.py
+++ b/safe_transaction_service/utils/views/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: FSL-1.1-MIT

--- a/safe_transaction_service/utils/views/mixins.py
+++ b/safe_transaction_service/utils/views/mixins.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+from safe_eth.eth.utils import fast_is_checksum_address
+
+from safe_transaction_service.history.exceptions import BannedSafeException
+from safe_transaction_service.history.models import SafeContract
+
+
+class BannedSafeMixin:
+    """
+    Rejects any request for a banned Safe (``SafeContract.banned``) with
+    HTTP 451 Unavailable For Legal Reasons. The Safe is resolved from the
+    ``address`` URL kwarg and checked with a single indexed database lookup
+    (not the cached banned set, so a ban is enforced on the API immediately),
+    no RPC calls are involved.
+    """
+
+    def initial(self, request, *args, **kwargs) -> None:
+        super().initial(request, *args, **kwargs)
+        address = kwargs.get("address")
+        if (
+            address
+            and fast_is_checksum_address(address)
+            and SafeContract.objects.banned(addresses=[address]).exists()
+        ):
+            raise BannedSafeException()


### PR DESCRIPTION
### What was wrong? 👾

Fixes PLA-1785

`SafeContract.banned` only stopped indexing. A banned Safe kept serving (stale) data on every endpoint, could still propose transactions, appeared in `/owners/{address}/safes/` and kept emitting queue events. EU sanctions (Regulation (EU) 2026/1848, effective 2026-08-23) require the identified Safes to not be served at all.

### How was it fixed? 🎯

- New `BannedSafeMixin` applied to every Safe-scoped endpoint (v1, v2, messages, 4337): requests for a banned Safe return `451 Unavailable For Legal Reasons` with body `{"detail": "Safe is unavailable for legal reasons"}`. The check is a single indexed DB lookup (not cached), so a ban is enforced immediately. It runs before the view cache, so a 451 is never cached or served from cache.
- Queue events are not published for banned Safes. All producers publish through a new `send_payloads_on_commit()` chokepoint that filters banned payloads.
- Banned Safes are excluded from `/v1|v2/owners/{address}/safes/`. Checked with `EXPLAIN (ANALYZE, BUFFERS)`: the GIN `owners @>` index scan stays the driver, the exclusion only adds a hashed subplan on the tiny partial banned index.
- New in-memory cached banned address set (`BANNED_SAFES_CACHE_TTL`, default 5 minutes) following the `TokenService.get_trusted_token_addresses` pattern. Used by event filtering and `SafeTxProcessor` (replaces the per-batch query). Cleared on `SafeContract` save/delete in the same process, other processes refresh on TTL.
- 451 documented on OpenAPI for `getSafe` and multisig-transactions endpoints so CGW can rely on it.

Out of scope (agreed): hash-keyed detail endpoints (`/multisig-transactions/{safe_tx_hash}/`, messages by hash, 4337 by hash) don't check the ban.

New tests are isolated in `TestBannedSafeViews` classes per app, so this behavior can be adjusted easily if regulatory requirements change.