### PR TITLE
Decode Safe ProxyFactory 1.5.0 creation methods

### DIFF
--- a/safe_transaction_service/history/indexers/proxy_factory_indexer.py
+++ b/safe_transaction_service/history/indexers/proxy_factory_indexer.py
@@ -57,6 +57,9 @@ class ProxyFactoryIndexer(EventsIndexer):
             # event ProxyCreation(GnosisSafeProxy proxy, address singleton)
             proxy_factory_v1_3_0_contract.events.ProxyCreation(),
             # event ProxyCreation(SafeProxy indexed proxy, address singleton)
+            # v1.5.0 emits this same ProxyCreation signature (also from its
+            # createProxyWithNonceL2 / createChainSpecificProxyWithNonceL2 methods),
+            # so the v1.4.1 entry decodes 1.5.0 proxy creations too.
             proxy_factory_v_1_4_1_contract.events.ProxyCreation(),
         ]
 

--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -528,6 +528,8 @@ class SafeEventsIndexer(EventsIndexer):
                 # Change Master Copy
                 safe_v1_1_1_contract.events.ChangedMasterCopy(),
                 # Proxy creation
+                # v1.5.0 emits the same ProxyCreation signature as v1.4.1, so the
+                # v1.4.1 entry decodes 1.5.0 proxy creations too.
                 proxy_factory_v1_4_1_contract.events.ProxyCreation(),
                 proxy_factory_v1_3_0_contract.events.ProxyCreation(),
             )

--- a/safe_transaction_service/history/services/safe_service.py
+++ b/safe_transaction_service/history/services/safe_service.py
@@ -11,6 +11,7 @@ from safe_eth.eth.contracts import (
     get_cpk_factory_contract,
     get_proxy_factory_V1_3_0_contract,
     get_proxy_factory_V1_4_1_contract,
+    get_proxy_factory_V1_5_0_contract,
 )
 from safe_eth.safe import Safe
 from safe_eth.safe.exceptions import CannotRetrieveSafeInfoException
@@ -93,6 +94,7 @@ class SafeService:
         self.ethereum_client = ethereum_client
         self.ethereum_tracing_client = ethereum_tracing_client
         dummy_w3 = Web3()  # Not needed, just used to decode contracts
+        self.proxy_factory_v1_5_0_contract = get_proxy_factory_V1_5_0_contract(dummy_w3)
         self.proxy_factory_v1_4_1_contract = get_proxy_factory_V1_4_1_contract(dummy_w3)
         self.proxy_factory_v1_3_0_contract = get_proxy_factory_V1_3_0_contract(dummy_w3)
         self.cpk_proxy_factory_contract = get_cpk_factory_contract(dummy_w3)
@@ -320,25 +322,31 @@ class SafeService:
 
     def _decode_proxy_factory(self, data: bytes) -> ProxyCreationData | None:
         """
-        Decode contract creation function for Safe ProxyFactory 1.3.0 and 1.4.1 deployments
+        Decode contract creation function for Safe ProxyFactory 1.3.0, 1.4.1 and 1.5.0 deployments.
+
+        1.5.0 adds ``createProxyWithNonceL2`` and ``createChainSpecificProxyWithNonceL2``, only decodable
+        with the 1.5.0 ABI. The legacy ``createProxyWithNonce`` keeps the same signature across versions.
 
         :param data:
         :return: `ProxyCreationData`, `None` if it cannot be decoded
         """
         if not data:
             return None
-        try:
-            _, data_decoded = self.proxy_factory_v1_3_0_contract.decode_function_input(
-                data
-            )
-        except ValueError:
+
+        data_decoded = None
+        for proxy_factory_contract in (
+            self.proxy_factory_v1_3_0_contract,
+            self.proxy_factory_v1_4_1_contract,
+            self.proxy_factory_v1_5_0_contract,
+        ):
             try:
-                (
-                    _,
-                    data_decoded,
-                ) = self.proxy_factory_v1_4_1_contract.decode_function_input(data)
+                _, data_decoded = proxy_factory_contract.decode_function_input(data)
+                break
             except ValueError:
-                return None
+                continue
+
+        if data_decoded is None:
+            return None
 
         singleton = (
             data_decoded.get("masterCopy")

--- a/safe_transaction_service/history/tests/test_safe_service.py
+++ b/safe_transaction_service/history/tests/test_safe_service.py
@@ -5,9 +5,12 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 
 from eth_account import Account
+from hexbytes import HexBytes
 from safe_eth.eth.constants import NULL_ADDRESS
+from safe_eth.eth.contracts import get_proxy_factory_V1_5_0_contract
 from safe_eth.eth.ethereum_client import TracingManager
 from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
+from web3 import Web3
 
 from ..exceptions import CannotGetSafeInfoFromBlockchain, CannotGetSafeInfoFromDB
 from ..models import InternalTxType, SafeMasterCopy
@@ -293,3 +296,31 @@ class TestSafeService(SafeTestCaseMixin, TestCase):
                 f"[{random_safe_address}] Proxy creation data is not matching the proxies deployed {multiple_safes_same_tx_creation_mock['proxies_deployed']}",
                 cm.output[0],
             )
+
+    def test_decode_creation_data_v1_5_0(self):
+        """
+        1.5.0 ProxyFactory adds ``createProxyWithNonceL2`` and ``createChainSpecificProxyWithNonceL2``.
+        The legacy ``createProxyWithNonce`` keeps the same signature and must keep decoding too.
+        """
+        proxy_factory_contract = get_proxy_factory_V1_5_0_contract(Web3())
+        singleton = Account.create().address
+        initializer = b"\x12\x34\x56"
+        salt_nonce = 42
+
+        for function_name in (
+            "createProxyWithNonce",
+            "createProxyWithNonceL2",
+            "createChainSpecificProxyWithNonceL2",
+        ):
+            with self.subTest(function_name=function_name):
+                data = HexBytes(
+                    proxy_factory_contract.encode_abi(
+                        function_name, args=[singleton, initializer, salt_nonce]
+                    )
+                )
+                proxy_creation_data_list = self.safe_service._decode_creation_data(data)
+                self.assertEqual(len(proxy_creation_data_list), 1)
+                proxy_creation_data = proxy_creation_data_list[0]
+                self.assertEqual(proxy_creation_data.singleton, singleton)
+                self.assertEqual(bytes(proxy_creation_data.initializer), initializer)
+                self.assertEqual(proxy_creation_data.salt_nonce, salt_nonce)

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -291,7 +291,7 @@ class TestSignals(SafeTestCaseMixin, TestCase):
         ]
         for to_is_a_safe, from_is_a_safe, expected in cases:
             with self.subTest(to=to_is_a_safe, from_=from_is_a_safe):
-                internal_tx = InternalTxFactory()
+                internal_tx = InternalTxFactory(value=1)
                 set_safe_membership(
                     internal_tx,
                     to_is_a_safe=to_is_a_safe,


### PR DESCRIPTION
## What

Decode Safe `ProxyFactory` 1.5.0 creation methods in `get_safe_creation_info`.

1.5.0 adds `createProxyWithNonceL2` and `createChainSpecificProxyWithNonceL2`. `_decode_proxy_factory` only tried the 1.3.0 and 1.4.1 ABIs, so Safes created with the new methods returned no decoded creation info (singleton / initializer / saltNonce). The legacy `createProxyWithNonce` keeps the same signature across versions and was already decoding fine.

## Changes

- Build `proxy_factory_v1_5_0_contract` in `SafeService.__init__`.
- Rewrite `_decode_proxy_factory` to loop over the 1.3.0 → 1.4.1 → 1.5.0 ABIs, breaking on the first successful `decode_function_input`. The existing singleton/initializer/saltNonce extraction already covers the 1.5.0 arg names.
- Add `test_decode_creation_data_v1_5_0` covering `createProxyWithNonce`, `createProxyWithNonceL2`, and `createChainSpecificProxyWithNonceL2`.

## Notes

- The two new L2 methods internally call the non-L2 version, which still emits the standard `ProxyCreation(indexed proxy, singleton)` event. So the log-based multi-deployment matching in `_process_creation_data` and the indexers need no change — verified that the 1.5.0 `ProxyCreation` topic is identical to the existing one and that the extra `ProxyCreationL2` / `ChainSpecificProxyCreationL2` events are not double-counted.
- No selector collisions across the three ABIs, so loop order never mis-decodes.

Closes WA-2935.
