### PR TITLE
Skip redundant L2 re-index when adding a new master copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,8 @@
-# AGENTS.md
-
-## How Codex Uses This File
-Codex will read `AGENTS.md` for project-specific guidance, workflows, and conventions.
-It is the preferred place to capture shared context and expectations.
+## Linear
+All tickets go into `PLATFORM` team and with labels `Backend` and `Transaction Service`
 
 ## Indexer Architecture (Summary)
 This repository includes multiple indexers under `safe_transaction_service/history/indexers/`.
-
-## Linear
-- All tickets go into `PLATFORM` team and with labels `Backend` and `Transaction Service`
 
 ### Base Classes
 - `ethereum_indexer.py`
@@ -54,6 +48,9 @@ This repository includes multiple indexers under `safe_transaction_service/histo
 - `uv.lock` is the source of pinned truth and must be committed. Always run `uv lock` after editing `pyproject.toml`, then commit both files together.
 - All `uv sync` calls use `--frozen`. CI is the canonical way to update dependencies; never bypass the lockfile locally.
 - `[tool.uv] exclude-newer = "7 days"` rejects packages published less than 7 days ago. If `uv lock` fails due to a recently released pin, revert it to the previous version and re-pin after 7 days.
+
+## Docs
+- Use reST for annotating Python functions.
 
 ## Testing
 - Virtualenv is managed by uv at `.venv`. Activate with `source .venv/bin/activate` or prefix commands with `uv run`.

--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -232,38 +232,52 @@ class Command(BaseCommand):
         """
         Insert new ``SafeMasterCopy`` singletons.
 
-        A new L2 singleton whose deploy block is at or above the L2 scan floor starts at the
-        current L2 frontier (lowest ``tx_block_number`` among existing L2 singletons) instead of
-        its deploy block: those events are already covered by the shared topic scan (addresses are
-        ignored on L2), so a lower start would needlessly drag the scan window back. An L2 singleton
-        deployed below the scan floor, a fresh DB, or an L1 singleton fall back to the deploy block.
-        ``initial_block_number`` always records the real deploy block.
+        Only on an **L2 network** does ``SafeEventsIndexer`` run, filtering logs by topic while
+        ignoring addresses. There a new ``+L2`` singleton whose deploy block is at or above the
+        lowest block L2 indexing has scanned from starts at the current L2 indexing position
+        (lowest ``tx_block_number`` among existing L2 singletons), bounded below by its own deploy
+        block, instead of always the deploy block: those events are already covered by the shared
+        scan, so a lower start would needlessly drag the scan window back.
+
+        Everything else starts from the deploy block: an L1/tracing network (where
+        ``InternalTxIndexer`` matches traces by address, and ``+L2`` singletons are tracked too, so
+        skipping a range would lose them), a fresh DB, or a ``+L2`` singleton deployed below the
+        lowest scanned block (an unscanned gap exists). ``initial_block_number`` always records the
+        real deploy block.
 
         :param safe_singleton_addresses: ``(address, deploy_block_number, version)`` tuples
         """
-        # Frontier: highest fully-scanned block (lowest tx_block_number). Floor: lowest block
-        # ever scanned (lowest initial_block_number). Read once; a concurrent indexer run could
-        # leave the frontier slightly stale, which self-heals on the next scan.
-        l2_blocks = SafeMasterCopy.objects.l2().aggregate(
-            frontier=Min("tx_block_number"),
-            floor=Min("initial_block_number"),
-        )
-        l2_frontier_block_number = l2_blocks["frontier"]
-        l2_scan_floor_block_number = l2_blocks["floor"]
+        # The shortcut is only valid where SafeEventsIndexer (topic scan, addresses ignored) is
+        # the indexer, i.e. on L2 networks. `l2_current_block_number` is the current L2 indexing
+        # position (lowest tx_block_number); `l2_min_initial_block_number` is the lowest block L2
+        # indexing has scanned from (lowest initial_block_number). Read once; a concurrent indexer
+        # run could leave them slightly stale, which self-heals on the next scan.
+        if settings.ETH_L2_NETWORK:
+            l2_blocks = SafeMasterCopy.objects.l2().aggregate(
+                current_block_number=Min("tx_block_number"),
+                min_initial_block_number=Min("initial_block_number"),
+            )
+            l2_current_block_number = l2_blocks["current_block_number"]
+            l2_min_initial_block_number = l2_blocks["min_initial_block_number"]
+        else:
+            l2_current_block_number = l2_min_initial_block_number = None
 
         for address, initial_block_number, version in safe_singleton_addresses:
             is_l2 = version.endswith("+L2")
             if (
                 is_l2
-                and l2_frontier_block_number is not None
-                and initial_block_number >= l2_scan_floor_block_number
+                and l2_current_block_number is not None
+                and l2_min_initial_block_number is not None
+                and initial_block_number >= l2_min_initial_block_number
             ):
-                # Deploy block is within the already-scanned range, so its events are covered
-                # by the shared topic scan: start at the frontier, skipping a redundant re-scan.
-                tx_block_number = l2_frontier_block_number
+                # Deploy block is within the already-scanned range, so its events are covered by
+                # the shared topic scan: start at the current indexing position, skipping a
+                # redundant re-scan. Bounded below by the deploy block so tx_block_number stays
+                # >= initial_block_number while the chain is still catching up.
+                tx_block_number = max(l2_current_block_number, initial_block_number)
             else:
-                # L1, fresh DB, or an L2 singleton deployed below the scan floor (an unscanned
-                # gap exists): start from the deploy block.
+                # L1 network, fresh DB, non-`+L2` singleton, or a `+L2` singleton deployed below
+                # the lowest scanned block (an unscanned gap exists): start from the deploy block.
                 tx_block_number = initial_block_number
             safe_singleton_address, _ = SafeMasterCopy.objects.get_or_create(
                 address=address,

--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -229,14 +229,49 @@ class Command(BaseCommand):
     def _setup_safe_singleton_addresses(
         self, safe_singleton_addresses: Sequence[tuple[str, int, str]]
     ):
+        """
+        Insert new ``SafeMasterCopy`` singletons.
+
+        A new L2 singleton whose deploy block is at or above the L2 scan floor starts at the
+        current L2 frontier (lowest ``tx_block_number`` among existing L2 singletons) instead of
+        its deploy block: those events are already covered by the shared topic scan (addresses are
+        ignored on L2), so a lower start would needlessly drag the scan window back. An L2 singleton
+        deployed below the scan floor, a fresh DB, or an L1 singleton fall back to the deploy block.
+        ``initial_block_number`` always records the real deploy block.
+
+        :param safe_singleton_addresses: ``(address, deploy_block_number, version)`` tuples
+        """
+        # Frontier: highest fully-scanned block (lowest tx_block_number). Floor: lowest block
+        # ever scanned (lowest initial_block_number). Read once; a concurrent indexer run could
+        # leave the frontier slightly stale, which self-heals on the next scan.
+        l2_blocks = SafeMasterCopy.objects.l2().aggregate(
+            frontier=Min("tx_block_number"),
+            floor=Min("initial_block_number"),
+        )
+        l2_frontier_block_number = l2_blocks["frontier"]
+        l2_scan_floor_block_number = l2_blocks["floor"]
+
         for address, initial_block_number, version in safe_singleton_addresses:
+            is_l2 = version.endswith("+L2")
+            if (
+                is_l2
+                and l2_frontier_block_number is not None
+                and initial_block_number >= l2_scan_floor_block_number
+            ):
+                # Deploy block is within the already-scanned range, so its events are covered
+                # by the shared topic scan: start at the frontier, skipping a redundant re-scan.
+                tx_block_number = l2_frontier_block_number
+            else:
+                # L1, fresh DB, or an L2 singleton deployed below the scan floor (an unscanned
+                # gap exists): start from the deploy block.
+                tx_block_number = initial_block_number
             safe_singleton_address, _ = SafeMasterCopy.objects.get_or_create(
                 address=address,
                 defaults={
                     "initial_block_number": initial_block_number,
-                    "tx_block_number": initial_block_number,
+                    "tx_block_number": tx_block_number,
                     "version": version,
-                    "l2": version.endswith("+L2"),
+                    "l2": is_l2,
                 },
             )
             if (

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -7,6 +7,7 @@ from unittest import mock
 from unittest.mock import MagicMock, PropertyMock
 
 from django.core.management import CommandError, call_command
+from django.db.models import Min
 from django.test import TestCase
 from django.utils import timezone
 
@@ -20,6 +21,7 @@ from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 from safe_eth.util.util import to_0x_hex_str
 
 from ..indexers import Erc20EventsIndexer, InternalTxIndexer, SafeEventsIndexer
+from ..management.commands.setup_service import Command
 from ..models import (
     EthereumTx,
     IndexingStatus,
@@ -474,6 +476,82 @@ class TestCommands(SafeTestCaseMixin, TestCase):
             IndexingStatus.objects.get_erc20_721_indexing_status().block_number,
             first_safe_block_deployed + 20,
         )
+
+    def test_setup_safe_singleton_addresses_l2_frontier(self):
+        """
+        A new L2 singleton added to an already-synced chain must start at the current L2
+        frontier (lowest tx_block_number among L2 singletons), not its deploy block, so it
+        doesn't drag the shared topic-based scan window back. L1 singletons still start
+        from the deploy block.
+        """
+        # Already-synced chain: an existing L2 singleton indexed up to a high block
+        existing_l2 = SafeMasterCopyFactory(
+            l2=True, initial_block_number=100, tx_block_number=5000
+        )
+        l2_frontier = existing_l2.tx_block_number
+
+        new_l2_address = Account.create().address
+        new_l1_address = Account.create().address
+        deploy_block = 4000  # Lower than the frontier
+
+        Command()._setup_safe_singleton_addresses(
+            [
+                (new_l2_address, deploy_block, "1.5.0+L2"),
+                (new_l1_address, deploy_block, "1.5.0"),
+            ]
+        )
+
+        # New L2 singleton starts at the frontier; the real deploy block is kept as
+        # initial_block_number
+        new_l2 = SafeMasterCopy.objects.get(address=new_l2_address)
+        self.assertEqual(new_l2.tx_block_number, l2_frontier)
+        self.assertEqual(new_l2.initial_block_number, deploy_block)
+        self.assertTrue(new_l2.l2)
+
+        # The shared L2 scan window is not dragged back
+        self.assertEqual(
+            SafeMasterCopy.objects.l2().aggregate(m=Min("tx_block_number"))["m"],
+            l2_frontier,
+        )
+
+        # L1 singleton still starts from its deploy block
+        new_l1 = SafeMasterCopy.objects.get(address=new_l1_address)
+        self.assertEqual(new_l1.tx_block_number, deploy_block)
+        self.assertEqual(new_l1.initial_block_number, deploy_block)
+        self.assertFalse(new_l1.l2)
+
+        # Existing row is untouched
+        existing_l2.refresh_from_db()
+        self.assertEqual(existing_l2.tx_block_number, 5000)
+
+    def test_setup_safe_singleton_addresses_l2_fresh_db(self):
+        """
+        On a fresh DB (no L2 singletons yet) a new L2 singleton starts from its deploy block.
+        """
+        address = Account.create().address
+        deploy_block = 4000
+        Command()._setup_safe_singleton_addresses([(address, deploy_block, "1.4.1+L2")])
+
+        master_copy = SafeMasterCopy.objects.get(address=address)
+        self.assertEqual(master_copy.tx_block_number, deploy_block)
+        self.assertEqual(master_copy.initial_block_number, deploy_block)
+
+    def test_setup_safe_singleton_addresses_l2_below_scan_floor(self):
+        """
+        A new L2 singleton deployed below the scan floor (its deploy block is lower than the
+        lowest block ever scanned) starts from its deploy block, not the frontier, so events
+        in the never-scanned gap are not missed.
+        """
+        # Already-synced chain that was only ever scanned from block 2000 up to 8000
+        SafeMasterCopyFactory(l2=True, initial_block_number=2000, tx_block_number=8000)
+
+        address = Account.create().address
+        deploy_block = 1000  # Below the scan floor (2000)
+        Command()._setup_safe_singleton_addresses([(address, deploy_block, "1.3.0+L2")])
+
+        master_copy = SafeMasterCopy.objects.get(address=address)
+        self.assertEqual(master_copy.tx_block_number, deploy_block)
+        self.assertEqual(master_copy.initial_block_number, deploy_block)
 
     def test_setup_service_sepolia(self):
         self._test_setup_service(EthereumNetwork.SEPOLIA)

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, PropertyMock
 
 from django.core.management import CommandError, call_command
 from django.db.models import Min
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from django_celery_beat.models import PeriodicTask
@@ -477,11 +477,12 @@ class TestCommands(SafeTestCaseMixin, TestCase):
             first_safe_block_deployed + 20,
         )
 
+    @override_settings(ETH_L2_NETWORK=True)
     def test_setup_safe_singleton_addresses_l2_frontier(self):
         """
-        A new L2 singleton added to an already-synced chain must start at the current L2
-        frontier (lowest tx_block_number among L2 singletons), not its deploy block, so it
-        doesn't drag the shared topic-based scan window back. L1 singletons still start
+        On an L2 network a new +L2 singleton added to an already-synced chain must start at the
+        current L2 frontier (lowest tx_block_number among L2 singletons), not its deploy block, so
+        it doesn't drag the shared topic-based scan window back. L1-flavour singletons still start
         from the deploy block.
         """
         # Already-synced chain: an existing L2 singleton indexed up to a high block
@@ -524,9 +525,10 @@ class TestCommands(SafeTestCaseMixin, TestCase):
         existing_l2.refresh_from_db()
         self.assertEqual(existing_l2.tx_block_number, 5000)
 
+    @override_settings(ETH_L2_NETWORK=True)
     def test_setup_safe_singleton_addresses_l2_fresh_db(self):
         """
-        On a fresh DB (no L2 singletons yet) a new L2 singleton starts from its deploy block.
+        On a fresh DB (no L2 singletons yet) a new +L2 singleton starts from its deploy block.
         """
         address = Account.create().address
         deploy_block = 4000
@@ -536,11 +538,12 @@ class TestCommands(SafeTestCaseMixin, TestCase):
         self.assertEqual(master_copy.tx_block_number, deploy_block)
         self.assertEqual(master_copy.initial_block_number, deploy_block)
 
+    @override_settings(ETH_L2_NETWORK=True)
     def test_setup_safe_singleton_addresses_l2_below_scan_floor(self):
         """
-        A new L2 singleton deployed below the scan floor (its deploy block is lower than the
-        lowest block ever scanned) starts from its deploy block, not the frontier, so events
-        in the never-scanned gap are not missed.
+        On an L2 network a new +L2 singleton deployed below the scan floor (its deploy block is
+        lower than the lowest block ever scanned) starts from its deploy block, not the frontier,
+        so events in the never-scanned gap are not missed.
         """
         # Already-synced chain that was only ever scanned from block 2000 up to 8000
         SafeMasterCopyFactory(l2=True, initial_block_number=2000, tx_block_number=8000)
@@ -548,6 +551,45 @@ class TestCommands(SafeTestCaseMixin, TestCase):
         address = Account.create().address
         deploy_block = 1000  # Below the scan floor (2000)
         Command()._setup_safe_singleton_addresses([(address, deploy_block, "1.3.0+L2")])
+
+        master_copy = SafeMasterCopy.objects.get(address=address)
+        self.assertEqual(master_copy.tx_block_number, deploy_block)
+        self.assertEqual(master_copy.initial_block_number, deploy_block)
+
+    @override_settings(ETH_L2_NETWORK=True)
+    def test_setup_safe_singleton_addresses_l2_deploy_ahead_of_current(self):
+        """
+        While the chain is still catching up, a new +L2 singleton whose deploy block is ahead of
+        the current indexing position starts at its deploy block, never below it, so
+        tx_block_number stays >= initial_block_number.
+        """
+        # Chain scanned from block 100, currently only advanced to block 5000
+        SafeMasterCopyFactory(l2=True, initial_block_number=100, tx_block_number=5000)
+
+        address = Account.create().address
+        deploy_block = (
+            8000  # Ahead of the current position (5000), above the floor (100)
+        )
+        Command()._setup_safe_singleton_addresses([(address, deploy_block, "1.5.0+L2")])
+
+        master_copy = SafeMasterCopy.objects.get(address=address)
+        self.assertEqual(master_copy.tx_block_number, deploy_block)
+        self.assertEqual(master_copy.initial_block_number, deploy_block)
+
+    @override_settings(ETH_L2_NETWORK=False)
+    def test_setup_safe_singleton_addresses_l1_network_keeps_deploy_block(self):
+        """
+        On an L1/tracing network SafeEventsIndexer is disabled and InternalTxIndexer matches
+        traces by address. A +L2 singleton is tracked there too (e.g. on mainnet), so it must
+        start from its deploy block even with a synced L2 row present, or its traces in
+        [deploy, frontier] would never be indexed.
+        """
+        # An already-synced +L2 row (would-be frontier at block 5000)
+        SafeMasterCopyFactory(l2=True, initial_block_number=100, tx_block_number=5000)
+
+        address = Account.create().address
+        deploy_block = 4000  # Above the floor: the L2 shortcut would wrongly pick 5000
+        Command()._setup_safe_singleton_addresses([(address, deploy_block, "1.5.0+L2")])
 
         master_copy = SafeMasterCopy.objects.get(address=address)
         self.assertEqual(master_copy.tx_block_number, deploy_block)


### PR DESCRIPTION
## What

Stop `setup_service` from forcing a full L2 re-index when a new `SafeMasterCopy` is added (e.g. the 1.5.0 singleton).

## Why

`SafeEventsIndexer` sets `IGNORE_ADDRESSES_ON_LOG_FILTER = True`, so its `eth_getLogs` query filters by **topic only** — addresses are ignored. The address set feeds a single thing: the scan window, which is `Min(tx_block_number)` over `SafeMasterCopy.objects.l2()`.

`_setup_safe_singleton_addresses` created the new row with `tx_block_number = <deploy block>`. On an already-synced L2 that drags the window back to the (old) deploy block and forces a full topic re-scan from there to head. It's idempotent (dedup + `ignore_conflicts`) but fully redundant — every new-version Safe event shares an existing topic and was already indexed in that range.

L1 (`InternalTxIndexer`) genuinely needs the deploy block because it matches traces by master-copy address, so its behavior is unchanged.

## Change

- Read the L2 **frontier** (`Min(tx_block_number)`) and **scan floor** (`Min(initial_block_number)`) over `l2()` once.
- A new L2 singleton starts at the frontier **when its deploy block is at or above the scan floor** (its events were already covered by the shared topic scan → no re-scan).
- It falls back to the deploy block for L1, a fresh DB, or an L2 singleton deployed **below** the scan floor (an unscanned gap exists, so its early events must still be indexed).
- `initial_block_number` always keeps the real deploy block (it's the reported `deployed_block_number` and the admin reindex floor).
- Existing rows are never modified.

## Notes

- The frontier is read once and not synchronized with a running indexer; a concurrent `setup_service` run could seed a slightly stale value, which self-heals on the next scan. Accepted (documented inline).
- Not addressed here (deeper alternative, out of scope): tracking L2 event-indexing progress with a single `IndexingStatus` row instead of per-master-copy `tx_block_number`.
- Also documents the reST docstring convention in `AGENTS.md`.

## Tests

- `test_setup_safe_singleton_addresses_l2_frontier` — synced chain: new L2 row starts at the frontier, `initial_block_number` keeps the deploy block, `l2()` window Min unchanged, L1 row still at deploy block, existing row untouched.
- `test_setup_safe_singleton_addresses_l2_fresh_db` — fresh DB → new L2 row starts from its deploy block.
- `test_setup_safe_singleton_addresses_l2_below_scan_floor` — L2 singleton deployed below the scan floor → starts from its deploy block, not the frontier.

Closes PLA-1810.