### PR TITLE
chore: fix target folder parameter name

### DIFF
--- a/safe_transaction_service/tokens/clients/coinmarketcap_client.py
+++ b/safe_transaction_service/tokens/clients/coinmarketcap_client.py
@@ -33,16 +33,16 @@ class CoinMarketCapClient(BaseHTTPClient):
             "X-CMC_PRO_API_KEY": api_token,
         }
 
-    def download_file(self, url: str, taget_folder: str, local_filename: str) -> str:
-        if not os.path.exists(taget_folder):
-            os.makedirs(taget_folder)
+    def download_file(self, url: str, target_folder: str, local_filename: str) -> str:
+        if not os.path.exists(target_folder):
+            os.makedirs(target_folder)
         with self.http_session.get(
             url, stream=True, timeout=self.request_timeout
         ) as response:
             if not response.ok:
                 logger.warning("Image not found for url %s", url)
                 return None
-            with open(os.path.join(taget_folder, local_filename), "wb") as f:
+            with open(os.path.join(target_folder, local_filename), "wb") as f:
                 for chunk in response.iter_content(chunk_size=1024):
                     if chunk:
                         f.write(chunk)


### PR DESCRIPTION
### Make sure these boxes are checked! 📦✅

- [x] You ran `./run_tests.sh`
- [x] You ran `pre-commit run -a`
- [x] Network setup changes are not applicable

### What was wrong? 👾

`CoinmarketcapClient.download_file` used the misspelled parameter name `taget_folder`, which made the path-handling code harder to read.

Closes #N/A

### How was it fixed? 🎯

Renamed the private method parameter and all of its local uses to `target_folder`. Behavior and the method's positional call contract are unchanged.