### PR TITLE
feat: Add /health/live and /health/ready endpoints

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,8 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
+from safe_transaction_service.utils.views import health
+
 schema_cache_timeout = 60 * 60 * 24 * 7  # 1 week
 swagger_urlpatterns = [
     path(
@@ -81,6 +83,9 @@ urlpatterns = swagger_urlpatterns + [
     path("api/v1/", include((urlpatterns_v1, "v1"))),
     path("api/v2/", include((urlpatterns_v2, "v2"))),
     path("check/", lambda request: HttpResponse("Ok"), name="check"),
+    # Trailing slash is optional so `APPEND_SLASH` never answers a probe with a redirect
+    re_path(r"^health/live/?$", health.live, name="health-live"),
+    re_path(r"^health/ready/?$", health.ready, name="health-ready"),
 ]
 
 

--- a/safe_transaction_service/loggers/custom_logger.py
+++ b/safe_transaction_service/loggers/custom_logger.py
@@ -194,9 +194,18 @@ class IgnoreSucceededNone(logging.Filter):
 
 
 class IgnoreCheckUrl(logging.Filter):
+    """
+    Drop access logs of successful probe requests, they are just noise.
+    Failing probes (e.g. a `503` from the readiness endpoint) are kept.
+    """
+
+    PROBE_PATHS = ("/check/", "/health/live", "/health/ready")
+
     def filter(self, record: logging.LogRecord) -> bool:
         message = record.getMessage()
-        return not ("GET /check/" in message and "200" in message)
+        if "200" not in message:
+            return True
+        return not any(f"GET {path}" in message for path in self.PROBE_PATHS)
 
 
 class PatchedCeleryFormatterOriginal(TaskFormatter):  # pragma: no cover

--- a/safe_transaction_service/loggers/custom_logger.py
+++ b/safe_transaction_service/loggers/custom_logger.py
@@ -199,13 +199,22 @@ class IgnoreCheckUrl(logging.Filter):
     Failing probes (e.g. a `503` from the readiness endpoint) are kept.
     """
 
-    PROBE_PATHS = ("/check/", "/health/live", "/health/ready")
+    PROBE_PATHS = frozenset(("/check", "/health/live", "/health/ready"))
 
     def filter(self, record: logging.LogRecord) -> bool:
-        message = record.getMessage()
-        if "200" not in message:
+        # Gunicorn passes its access log atoms as the record arguments. The
+        # status and the path are read from there, as the formatted message
+        # also contains the client address, the query string and the user
+        # agent, any of which can hold the value being looked for.
+        atoms = record.args
+        if not isinstance(atoms, dict):
             return True
-        return not any(f"GET {path}" in message for path in self.PROBE_PATHS)
+
+        if str(atoms.get("s")) != "200" or atoms.get("m") != "GET":
+            return True
+
+        path = str(atoms.get("U", "")).rstrip("/")
+        return path not in self.PROBE_PATHS
 
 
 class PatchedCeleryFormatterOriginal(TaskFormatter):  # pragma: no cover

--- a/safe_transaction_service/utils/tests/test_health.py
+++ b/safe_transaction_service/utils/tests/test_health.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+from unittest import mock
+
+from django.db import OperationalError, connections
+from django.test import TestCase
+
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+LIVE_URLS = ("/health/live", "/health/live/")
+READY_URLS = ("/health/ready", "/health/ready/")
+
+
+class TestHealthViews(TestCase):
+    def test_live(self):
+        for url in LIVE_URLS:
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 200)
+
+    def test_ready(self):
+        for url in READY_URLS:
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response.json(), {"ready": True, "db": True, "redis": True}
+                )
+
+    def test_ready_database_down(self):
+        with mock.patch.object(
+            connections["default"], "cursor", side_effect=OperationalError
+        ):
+            response = self.client.get("/health/ready")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json(), {"ready": False, "db": False, "redis": True})
+
+    def test_ready_redis_down(self):
+        with mock.patch(
+            "safe_transaction_service.utils.views.health.get_redis"
+        ) as get_redis_mock:
+            get_redis_mock.return_value.ping.side_effect = RedisConnectionError
+            response = self.client.get("/health/ready")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json(), {"ready": False, "db": True, "redis": False})
+
+    def test_urls_are_not_redirected(self):
+        for url in LIVE_URLS + READY_URLS:
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertNotIn(response.status_code, (301, 302))
+
+    def test_check_url_still_works(self):
+        response = self.client.get("/check/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"Ok")

--- a/safe_transaction_service/utils/tests/test_loggers.py
+++ b/safe_transaction_service/utils/tests/test_loggers.py
@@ -14,28 +14,79 @@ class TestLoggers(TestCase):
         lineno = 2
         ignore_check_url = IgnoreCheckUrl(name)
 
-        def build_log(message: str) -> LogRecord:
+        def build_log(
+            status: str,
+            path: str,
+            method: str = "GET",
+            remote_address: str = "127.0.0.1",
+        ) -> LogRecord:
+            """
+            Build a record the way Gunicorn does, passing the access log atoms
+            as the record arguments.
+            """
+            atoms = {
+                "h": remote_address,
+                "m": method,
+                "U": path,
+                "q": "",
+                "s": status,
+                "a": "python-requests/2.32.3",
+            }
             return LogRecord(
-                name, level, pathname, lineno, message, args=(), exc_info=()
+                name,
+                level,
+                pathname,
+                lineno,
+                "%(h)s %(m)s %(U)s %(s)s %(a)s",
+                args=(atoms,),
+                exc_info=(),
             )
 
-        for message in (
-            "200 GET /check/",
-            "200 GET /health/live",
-            "200 GET /health/live/",
-            "200 GET /health/ready",
-            "200 GET /health/ready/",
+        for status, path in (
+            ("200", "/check/"),
+            ("200", "/health/live"),
+            ("200", "/health/live/"),
+            ("200", "/health/ready"),
+            ("200", "/health/ready/"),
         ):
-            with self.subTest(message=message):
-                self.assertFalse(ignore_check_url.filter(build_log(message)))
+            with self.subTest(status=status, path=path):
+                self.assertFalse(ignore_check_url.filter(build_log(status, path)))
 
-        for message in (
-            "200 GET /not-check/",
-            "200 GET /api/v1/about/",
-            "503 GET /health/ready",
+        for status, path in (
+            ("200", "/not-check/"),
+            ("200", "/api/v1/about/"),
+            ("503", "/health/ready"),
+            ("503", "/check/"),
         ):
-            with self.subTest(message=message):
-                self.assertTrue(ignore_check_url.filter(build_log(message)))
+            with self.subTest(status=status, path=path):
+                self.assertTrue(ignore_check_url.filter(build_log(status, path)))
+
+        with self.subTest("Only GET is a probe"):
+            self.assertTrue(
+                ignore_check_url.filter(build_log("200", "/check/", method="POST"))
+            )
+
+        with self.subTest("A 200 elsewhere in the line does not drop a failing probe"):
+            self.assertTrue(
+                ignore_check_url.filter(
+                    build_log("503", "/health/ready", remote_address="2001:db8::1")
+                )
+            )
+
+        with self.subTest("Records without atoms are kept"):
+            self.assertTrue(
+                ignore_check_url.filter(
+                    LogRecord(
+                        name,
+                        level,
+                        pathname,
+                        lineno,
+                        "200 GET /check/",
+                        args=(),
+                        exc_info=(),
+                    )
+                )
+            )
 
     def test_ignore_succeeded_none(self):
         name = "name"

--- a/safe_transaction_service/utils/tests/test_loggers.py
+++ b/safe_transaction_service/utils/tests/test_loggers.py
@@ -13,14 +13,29 @@ class TestLoggers(TestCase):
         pathname = "/"
         lineno = 2
         ignore_check_url = IgnoreCheckUrl(name)
-        check_log = LogRecord(
-            name, level, pathname, lineno, "200 GET /check/", args=(), exc_info=()
-        )
-        other_log = LogRecord(
-            name, level, pathname, lineno, "200 GET /not-check/", args=(), exc_info=()
-        )
-        self.assertFalse(ignore_check_url.filter(check_log))
-        self.assertTrue(ignore_check_url.filter(other_log))
+
+        def build_log(message: str) -> LogRecord:
+            return LogRecord(
+                name, level, pathname, lineno, message, args=(), exc_info=()
+            )
+
+        for message in (
+            "200 GET /check/",
+            "200 GET /health/live",
+            "200 GET /health/live/",
+            "200 GET /health/ready",
+            "200 GET /health/ready/",
+        ):
+            with self.subTest(message=message):
+                self.assertFalse(ignore_check_url.filter(build_log(message)))
+
+        for message in (
+            "200 GET /not-check/",
+            "200 GET /api/v1/about/",
+            "503 GET /health/ready",
+        ):
+            with self.subTest(message=message):
+                self.assertTrue(ignore_check_url.filter(build_log(message)))
 
     def test_ignore_succeeded_none(self):
         name = "name"

--- a/safe_transaction_service/utils/views/health.py
+++ b/safe_transaction_service/utils/views/health.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+import logging
+
+from django.db import connections
+from django.http import HttpRequest, HttpResponse, JsonResponse
+
+from safe_transaction_service.utils.redis import get_redis
+
+logger = logging.getLogger(__name__)
+
+
+def live(request: HttpRequest) -> HttpResponse:
+    """
+    Liveness probe. Answers as long as the process can serve requests, so no
+    dependency is touched and no I/O is done.
+
+    :param request:
+    :return: ``200`` response
+    """
+    return HttpResponse("OK", content_type="text/plain")
+
+
+def _is_database_healthy() -> bool:
+    try:
+        with connections["default"].cursor() as cursor:
+            cursor.execute("SELECT 1")
+        return True
+    except Exception:
+        logger.warning("Readiness check failed for the database", exc_info=True)
+        return False
+
+
+def _is_redis_healthy() -> bool:
+    try:
+        return bool(get_redis().ping())
+    except Exception:
+        logger.warning("Readiness check failed for Redis", exc_info=True)
+        return False
+
+
+def ready(request: HttpRequest) -> JsonResponse:
+    """
+    Readiness probe. Checks the dependencies needed to serve API requests:
+    the database and Redis (services like ``BalanceService`` or
+    ``TransactionService`` read from it on every request).
+
+    Celery workers and indexing lag are not part of it, as the API keeps
+    serving data while they are down.
+
+    Every dependency is checked on its own, so a broken one is reported as
+    ``false`` instead of raising.
+
+    :param request:
+    :return: ``{"ready": bool, "db": bool, "redis": bool}`` with status ``200``
+        when every dependency is healthy, ``503`` otherwise
+    """
+    database_healthy = _is_database_healthy()
+    redis_healthy = _is_redis_healthy()
+    is_ready = database_healthy and redis_healthy
+    return JsonResponse(
+        {"ready": is_ready, "db": database_healthy, "redis": redis_healthy},
+        status=200 if is_ready else 503,
+    )


### PR DESCRIPTION
## What

- `/health/live`, no I/O, always 200.
- `/health/ready`, checks the database and Redis and returns `{"ready", "db", "redis"}` with 200 when both answer and 503 otherwise.
- The access log filter now suppresses the new probe paths too.

`/check/` is untouched.

## Why

All Safe backend services are moving to `/health/live` (liveness) and `/health/ready` (readiness), 200 when healthy and 503 otherwise.

`/check/` is a lambda returning `Ok` and both probes point at it, so a pod is reported ready with the database down.

The probes still point at `/check/`, so it keeps working. They move in a separate step, and the old path is dropped once nothing references it.

## Notes

- The views are plain Django functions, not DRF, which keeps them out of the drf-spectacular schema without an explicit exclude and avoids content negotiation and versioning on a probe endpoint.
- Both paths are registered with an optional trailing slash. `APPEND_SLASH` would otherwise answer `/health/live` with a 301, and a probe should get 200 or 503, not a redirect.
- Celery workers are not part of readiness. A worker outage must not take the API out of rotation.
- Indexer lag is not part of readiness either. A lagging indexer serves stale but valid data, so gating on it would turn "stale" into "down" and flap every pod at once during a reorg or an RPC outage. It belongs in alerting off `/api/v1/about/indexing/`.
- RabbitMQ is not checked. The web tier only publishes from Celery tasks, not from request handling.
- The filter keeps the existing "only suppress 200" rule, so a readiness probe answering 503 is still logged.

Refs PLA-1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)
